### PR TITLE
Removing unpaginated all endpoints from orders and pickups

### DIFF
--- a/src/main/java/com/easypost/model/Order.java
+++ b/src/main/java/com/easypost/model/Order.java
@@ -151,14 +151,6 @@ public class Order extends EasyPostResource {
     return request(RequestMethod.GET, instanceURL(Order.class, id), null, Order.class, apiKey);
   }
 
-  // all
-  public static OrderCollection all(Map<String, Object> params) throws EasyPostException {
-    return all(params, null);
-  }
-  public static OrderCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
-    return request(RequestMethod.GET, classURL(Order.class), params, OrderCollection.class, apiKey);
-  }
-
   // refresh
   public Order refresh() throws EasyPostException {
     return this.refresh(null, null);

--- a/src/main/java/com/easypost/model/Pickup.java
+++ b/src/main/java/com/easypost/model/Pickup.java
@@ -94,14 +94,6 @@ public class Pickup extends EasyPostResource {
         return request(RequestMethod.GET, instanceURL(Pickup.class, id), null, Pickup.class, apiKey);
     }
 
-    // all
-    public static PickupCollection all(Map<String, Object> params) throws EasyPostException {
-        return all(params, null);
-    }
-    public static PickupCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
-        return request(RequestMethod.GET, classURL(Pickup.class), params, PickupCollection.class, apiKey);
-    }
-
     // refresh
     public Pickup refresh() throws EasyPostException {
         return this.refresh(null, null);


### PR DESCRIPTION
Removed the unpaginated endpoints for orders and pickups for the `all` method.