### PR TITLE
use the new rerate api for rerating

### DIFF
--- a/src/main/java/com/easypost/model/Shipment.java
+++ b/src/main/java/com/easypost/model/Shipment.java
@@ -283,8 +283,8 @@ public class Shipment extends EasyPostResource {
 	}
 	public Shipment newRates(Map<String, Object> params, String apiKey) throws EasyPostException {
 		Shipment response = request(
-			RequestMethod.GET,
-			String.format("%s/rates", instanceURL(Shipment.class, this.getId())), params, Shipment.class, apiKey);
+			RequestMethod.POST,
+			String.format("%s/rerate", instanceURL(Shipment.class, this.getId())), params, Shipment.class, apiKey);
 
 		this.merge(this, response);
 		return this;


### PR DESCRIPTION
Starting soon in the future, getRates() will always be read-only (as you would expect from a GET), and re-rating will be triggered through the newRates() function. This adjusts the newRates function. No change has occurred to getRates() yet.