### PR TITLE
fix: corrects support email in error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+# CHANGELOG
+
+
 ## NEXT RELEASE
 
 * Removes `items` and `containers` which have not been supported for some time
+* Corrects references of `contact@easypost.com` to `support@easypost.com`
 
 
 ## 4.0.4 2020-10-29

--- a/src/main/java/com/easypost/net/EasyPostResource.java
+++ b/src/main/java/com/easypost/net/EasyPostResource.java
@@ -358,7 +358,7 @@ public abstract class EasyPostResource {
 				break;
 			default:
 				throw new EasyPostException(
-					String.format("Unrecognized HTTP method %s. Please contact EasyPost at contact@easypost.com.", method));
+					String.format("Unrecognized HTTP method %s. Please contact EasyPost at support@easypost.com.", method));
 			}
 			int rCode = conn.getResponseCode(); // sends the request
 			String rBody = null;
@@ -375,7 +375,7 @@ public abstract class EasyPostResource {
 				String.format(
 					"Could not connect to EasyPost (%s). "
 						+ "Please check your internet connection and try again. If this problem persists,"
-						+ "please contact us at contact@easypost.com.", EasyPost.API_BASE), e);
+						+ "please contact us at support@easypost.com.", EasyPost.API_BASE), e);
 		} finally {
 			if (conn != null) {
 				conn.disconnect();
@@ -417,7 +417,7 @@ public abstract class EasyPostResource {
 			if (apiKeyRequired) {
 				throw new EasyPostException(
 						"No API key provided. (set your API key using 'EasyPost.apiKey = {KEY}'. "
-								+ "Your API key can be found in your EasyPost dashboard, or you can email us at contact@easypost.com for assistance.");
+								+ "Your API key can be found in your EasyPost dashboard, or you can email us at support@easypost.com for assistance.");
 
 			}
 		}
@@ -432,7 +432,7 @@ public abstract class EasyPostResource {
 		} catch (UnsupportedEncodingException e) {
 			throw new EasyPostException("Unable to encode parameters to "
 				+ CHARSET
-				+ ". Please email contact@easypost.com for assistance.", e);
+				+ ". Please email support@easypost.com for assistance.", e);
 		}
 
         // System.out.println(url);
@@ -475,7 +475,7 @@ public abstract class EasyPostResource {
 
 	private static EasyPostResponse makeAppEngineRequest(RequestMethod method, String url, String query, String apiKey) throws EasyPostException {
 		String unknownErrorMessage = "Sorry, an unknown error occurred while trying to use the "
-			+ "Google App Engine runtime. Please email contact@easypost.com for assistance.";
+			+ "Google App Engine runtime. Please email support@easypost.com for assistance.";
 		try {
 			if (method == RequestMethod.GET || method == RequestMethod.DELETE) {
 				url = String.format("%s?%s", url, query);
@@ -493,7 +493,7 @@ public abstract class EasyPostResource {
 				System.err
 					.println("Warning: this App Engine SDK version does not allow verification of SSL certificates;"
 						+ "this exposes you to a MITM attack. Please upgrade your App Engine SDK to >=1.5.0. "
-						+ "If you have questions, email contact@easypost.com.");
+						+ "If you have questions, email support@easypost.com.");
 				fetchOptions = fetchOptionsBuilderClass.getDeclaredMethod("withDefaults").invoke(null);
 			}
 


### PR DESCRIPTION
We haven't used the `contact@easypost.com` email for some time for support inquiries, correct it to `support@easypost.com`.