### PR TITLE
style: format all files for better readability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: java
-install: mvn install --quiet -DskipTests=true -Dgpg.skip=true

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import com.easypost.model.Shipment;
 public class Readme {
 
     public static void main(String[] args) {
-        EasyPost.apiKey = "cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi";
+        EasyPost.apiKey = "API_KEY";
 
         Map<String, Object> fromAddressMap = new HashMap<String, Object>();
         fromAddressMap.put("name", "Simpler Postage Inc");

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.easypost</groupId>
@@ -139,15 +140,15 @@
                 </configuration>
             </plugin>
             <plugin>
-              <groupId>org.sonatype.plugins</groupId>
-              <artifactId>nexus-staging-maven-plugin</artifactId>
-              <version>1.6.7</version>
-              <extensions>true</extensions>
-              <configuration>
-                <serverId>ossrh</serverId>
-                <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                <autoReleaseAfterClose>true</autoReleaseAfterClose>
-              </configuration>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/src/main/java/com/easypost/app/BatchExample.java
+++ b/src/main/java/com/easypost/app/BatchExample.java
@@ -1,3 +1,7 @@
+package com.easypost.app;
+
+// Usage: java -cp "target/easypost-java-2.0.4.jar:target/gson-2.2.4.jar" BatchExample
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
@@ -16,145 +20,148 @@ import com.easypost.model.Batch;
 
 public class BatchExample {
 
-    public static void main(String[] args) throws InterruptedException {
-        EasyPost.apiKey = "cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi";
+  public static void main(String[] args) throws InterruptedException {
+    EasyPost.apiKey = "API_KEY";
 
-        try {
-            Map<String, Object> fromAddressMap = new HashMap<String, Object>();
-            fromAddressMap.put("name", "Simpler Postage Inc");
-            fromAddressMap.put("street1", "388 Townsend St");
-            fromAddressMap.put("street2", "Apt 20");
-            fromAddressMap.put("city", "San Francisco");
-            fromAddressMap.put("state", "CA");
-            fromAddressMap.put("zip", "94107");
-            fromAddressMap.put("phone", "415-456-7890");
-            Address fromAddress = Address.create(fromAddressMap);
+    try {
+      Map<String, Object> fromAddressMap = new HashMap<String, Object>();
+      fromAddressMap.put("name", "Simpler Postage Inc");
+      fromAddressMap.put("street1", "388 Townsend St");
+      fromAddressMap.put("street2", "Apt 20");
+      fromAddressMap.put("city", "San Francisco");
+      fromAddressMap.put("state", "CA");
+      fromAddressMap.put("zip", "94107");
+      fromAddressMap.put("phone", "415-456-7890");
+      Address fromAddress = Address.create(fromAddressMap);
 
-            Map<String, Object> parcelMap = new HashMap<String, Object>();
-            parcelMap.put("weight", 22.9);
-            parcelMap.put("height", 12.1);
-            parcelMap.put("width", 8);
-            parcelMap.put("length", 19.8);
-            Parcel parcel = Parcel.create(parcelMap);
+      Map<String, Object> parcelMap = new HashMap<String, Object>();
+      parcelMap.put("weight", 22.9);
+      parcelMap.put("height", 12.1);
+      parcelMap.put("width", 8);
+      parcelMap.put("length", 19.8);
+      Parcel parcel = Parcel.create(parcelMap);
 
-            // Customs info - this is required for international destinations
-            Map<String, Object> customsItem1Map = new HashMap<String, Object>();
-            customsItem1Map.put("description", "EasyPost T-shirts");
-            customsItem1Map.put("quantity", 2);
-            customsItem1Map.put("value", 23.56);
-            customsItem1Map.put("weight", 18.8);
-            customsItem1Map.put("origin_country", "us");
-            customsItem1Map.put("hs_tariff_number", "610910");
+      // Customs info - this is required for international destinations
+      Map<String, Object> customsItem1Map = new HashMap<String, Object>();
+      customsItem1Map.put("description", "EasyPost T-shirts");
+      customsItem1Map.put("quantity", 2);
+      customsItem1Map.put("value", 23.56);
+      customsItem1Map.put("weight", 18.8);
+      customsItem1Map.put("origin_country", "us");
+      customsItem1Map.put("hs_tariff_number", "610910");
 
-            Map<String, Object> customsItem2Map = new HashMap<String, Object>();
-            customsItem2Map.put("description", "EasyPost Stickers");
-            customsItem2Map.put("quantity", 11);
-            customsItem2Map.put("value", 8.98);
-            customsItem2Map.put("weight", 3.2);
-            customsItem2Map.put("origin_country", "us");
-            customsItem2Map.put("hs_tariff_number", "654321");
+      Map<String, Object> customsItem2Map = new HashMap<String, Object>();
+      customsItem2Map.put("description", "EasyPost Stickers");
+      customsItem2Map.put("quantity", 11);
+      customsItem2Map.put("value", 8.98);
+      customsItem2Map.put("weight", 3.2);
+      customsItem2Map.put("origin_country", "us");
+      customsItem2Map.put("hs_tariff_number", "654321");
 
-            Map<String, Object> customsInfoMap = new HashMap<String, Object>();
-            customsInfoMap.put("customs_certify", true);
-            customsInfoMap.put("customs_signer", "Dr. Pepper");
-            customsInfoMap.put("contents_type", "gift");
-            customsInfoMap.put("eel_pfc", "NOEEI 30.37(a)");
-            customsInfoMap.put("non_delivery_option", "return");
-            customsInfoMap.put("restriction_type", "none");
-            CustomsItem customsItem1 = CustomsItem.create(customsItem1Map);
-            CustomsItem customsItem2 = CustomsItem.create(customsItem2Map);
-            List<CustomsItem> customsItemsList = new ArrayList<CustomsItem>();
-            customsItemsList.add(customsItem1);
-            customsItemsList.add(customsItem2);
-            customsInfoMap.put("customs_items", customsItemsList);
-            CustomsInfo customsInfo = CustomsInfo.create(customsInfoMap);
+      Map<String, Object> customsInfoMap = new HashMap<String, Object>();
+      customsInfoMap.put("customs_certify", true);
+      customsInfoMap.put("customs_signer", "Dr. Pepper");
+      customsInfoMap.put("contents_type", "gift");
+      customsInfoMap.put("eel_pfc", "NOEEI 30.37(a)");
+      customsInfoMap.put("non_delivery_option", "return");
+      customsInfoMap.put("restriction_type", "none");
+      CustomsItem customsItem1 = CustomsItem.create(customsItem1Map);
+      CustomsItem customsItem2 = CustomsItem.create(customsItem2Map);
+      List<CustomsItem> customsItemsList = new ArrayList<CustomsItem>();
+      customsItemsList.add(customsItem1);
+      customsItemsList.add(customsItem2);
+      customsInfoMap.put("customs_items", customsItemsList);
+      CustomsInfo customsInfo = CustomsInfo.create(customsInfoMap);
 
-            // this will be coming from your database or other input source
-            // hard coding it here for demonstration purposes only
-            List<Map<String, Object>> orders = new ArrayList<Map<String, Object>>();
-            Map<String, Object> sampleOrder = new HashMap<String, Object>();
-            sampleOrder.put("name", "Sawyer Bateman");
-            sampleOrder.put("street1", "1A Larkspur Cres");
-            sampleOrder.put("street2", "");
-            sampleOrder.put("city", "St. Albert");
-            sampleOrder.put("state", "AB");
-            sampleOrder.put("zip", "T8N2M4");
-            sampleOrder.put("phone", "780-483-2746");
-            sampleOrder.put("country", "CA");
-            sampleOrder.put("reference", "reference_number_123456");
-            orders.add(sampleOrder);
+      // this will be coming from your database or other input source
+      // hard coding it here for demonstration purposes only
+      List<Map<String, Object>> orders = new ArrayList<Map<String, Object>>();
+      Map<String, Object> sampleOrder = new HashMap<String, Object>();
+      sampleOrder.put("name", "Sawyer Bateman");
+      sampleOrder.put("street1", "1A Larkspur Cres");
+      sampleOrder.put("street2", "");
+      sampleOrder.put("city", "St. Albert");
+      sampleOrder.put("state", "AB");
+      sampleOrder.put("zip", "T8N2M4");
+      sampleOrder.put("phone", "780-483-2746");
+      sampleOrder.put("country", "CA");
+      sampleOrder.put("reference", "reference_number_123456");
+      orders.add(sampleOrder);
 
-            // loop over your orders and add a shipment for each
-            List<Map<String, Object>> shipments = new ArrayList<Map<String, Object>>();
-            Map<String, Object> shipment = new HashMap<String, Object>();
-            Map<String, Object> toAddressMap = new HashMap<String, Object>();
-            for(Map<String, Object> order : orders) {
-                toAddressMap.put("name", order.get("name"));
-                toAddressMap.put("street1", order.get("street1"));
-                toAddressMap.put("street2", order.get("street2"));
-                toAddressMap.put("city", order.get("city"));
-                toAddressMap.put("state", order.get("state"));
-                toAddressMap.put("zip", order.get("zip"));
-                toAddressMap.put("phone", order.get("phone"));
-                toAddressMap.put("country", order.get("country"));
+      // loop over your orders and add a shipment for each
+      List<Map<String, Object>> shipments = new ArrayList<Map<String, Object>>();
+      Map<String, Object> shipment = new HashMap<String, Object>();
+      Map<String, Object> toAddressMap = new HashMap<String, Object>();
+      for (Map<String, Object> order : orders) {
+        toAddressMap.put("name", order.get("name"));
+        toAddressMap.put("street1", order.get("street1"));
+        toAddressMap.put("street2", order.get("street2"));
+        toAddressMap.put("city", order.get("city"));
+        toAddressMap.put("state", order.get("state"));
+        toAddressMap.put("zip", order.get("zip"));
+        toAddressMap.put("phone", order.get("phone"));
+        toAddressMap.put("country", order.get("country"));
 
-                shipment.put("to_address", toAddressMap);
-                shipment.put("from_address", fromAddress);
-                shipment.put("parcel", parcel);
-                shipment.put("customs_info", customsInfo);
-                shipment.put("reference", order.get("reference"));
+        shipment.put("to_address", toAddressMap);
+        shipment.put("from_address", fromAddress);
+        shipment.put("parcel", parcel);
+        shipment.put("customs_info", customsInfo);
+        shipment.put("reference", order.get("reference"));
 
-                shipments.add(shipment);
-            }
+        shipments.add(shipment);
+      }
 
-            // create batch
-            Map<String, Object> batchMap = new HashMap<String, Object>();
-            batchMap.put("shipment", shipments);
-            Batch batch = Batch.create(batchMap);
+      // create batch
+      Map<String, Object> batchMap = new HashMap<String, Object>();
+      batchMap.put("shipment", shipments);
+      Batch batch = Batch.create(batchMap);
 
-            // ** below this point should be a seperate script so that batch creation isn't duplicated
-            // ** store batch.id and use it in a new script with Batch.retrieve("{BATCH_ID}");
+      // ** below this point should be a seperate script so that batch creation isn't
+      // duplicated
+      // ** store batch.id and use it in a new script with
+      // Batch.retrieve("{BATCH_ID}");
 
-            // loop through each shipment in the batch, purchasing the lowest rate for each
-            for (Shipment createdShipment : batch.getShipments()) {
-                // shipments in a new batch do not yet have rates, fetch them before purchasing
-                createdShipment = createdShipment.newRates();
+      // loop through each shipment in the batch, purchasing the lowest rate for each
+      for (Shipment createdShipment : batch.getShipments()) {
+        // shipments in a new batch do not yet have rates, fetch them before purchasing
+        createdShipment = createdShipment.newRates();
 
-                List<String> buyCarriers = new ArrayList<String>();
-                buyCarriers.add("USPS");
-                // List<String> buyServices = new ArrayList<String>();
-                // buyServices.add("FirstClassPackageServiceInternational");
-                createdShipment.buy(createdShipment.lowestRate(buyCarriers));
-            }
+        List<String> buyCarriers = new ArrayList<String>();
+        buyCarriers.add("USPS");
+        // List<String> buyServices = new ArrayList<String>();
+        // buyServices.add("FirstClassPackageServiceInternational");
+        createdShipment.buy(createdShipment.lowestRate(buyCarriers));
+      }
 
-            // request a batch label of type pdf (other options are epl2 or zpl)
-            batch = batch.refresh();
-            if (batch.status.getPostagePurchased() == batch.getShipments().size()) {
-                Map<String, Object> labelMap = new HashMap<String, Object>();
-                labelMap.put("file_format", "pdf");
+      // request a batch label of type pdf (other options are epl2 or zpl)
+      batch = batch.refresh();
+      if (batch.status.getPostagePurchased() == batch.getShipments().size()) {
+        Map<String, Object> labelMap = new HashMap<String, Object>();
+        labelMap.put("file_format", "pdf");
 
-                batch.label(labelMap);
-            } else {
-                // something went wrong, one of the shipments wasn't purchased successfully in the above loop
-                // probably wouldn't ever happen, shipment.buy above would throw an error
-                System.out.println("Uh oh");
-            }
+        batch.label(labelMap);
+      } else {
+        // something went wrong, one of the shipments wasn't purchased successfully in
+        // the above loop
+        // probably wouldn't ever happen, shipment.buy above would throw an error
+        System.out.println("Uh oh");
+      }
 
-            // batch label creation is asyncronous; wait for it to be done before continuing
-            while(true) {
-                batch = batch.refresh();
+      // batch label creation is asyncronous; wait for it to be done before continuing
+      while (true) {
+        batch = batch.refresh();
 
-                if (batch.getLabelUrl() != null) {
-                    break;
-                }
-
-                Thread.sleep(8000);
-            }
-
-            System.out.println(batch.prettyPrint());
-
-        } catch (EasyPostException e) {
-            e.printStackTrace();
+        if (batch.getLabelUrl() != null) {
+          break;
         }
+
+        Thread.sleep(8000);
+      }
+
+      System.out.println(batch.prettyPrint());
+
+    } catch (EasyPostException e) {
+      e.printStackTrace();
     }
+  }
 }

--- a/src/main/java/com/easypost/app/BatchManifestExample.java
+++ b/src/main/java/com/easypost/app/BatchManifestExample.java
@@ -1,3 +1,7 @@
+package com.easypost.app;
+
+// Usage: java -cp "target/easypost-java-2.0.4.jar:target/gson-2.2.4.jar" BatchManifestExample
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
@@ -7,78 +11,76 @@ import java.lang.InterruptedException;
 
 import com.easypost.EasyPost;
 import com.easypost.exception.EasyPostException;
-import com.easypost.model.Address;
-import com.easypost.model.Parcel;
 import com.easypost.model.Shipment;
 import com.easypost.model.Batch;
 
 public class BatchManifestExample {
 
-    public static void main(String[] args) throws InterruptedException {
-        EasyPost.apiKey = "cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi";
+  public static void main(String[] args) throws InterruptedException {
+    EasyPost.apiKey = "API_KEY";
 
-        try {
-            Map<String, Object> addressMap = new HashMap<String, Object>();
-            addressMap.put("name", "Simpler Postage Inc");
-            addressMap.put("street1", "164 Townsend St");
-            addressMap.put("street2", "Unit 1");
-            addressMap.put("city", "San Francisco");
-            addressMap.put("state", "CA");
-            addressMap.put("zip", "94107");
-            addressMap.put("phone", "415-456-7890");
+    try {
+      Map<String, Object> addressMap = new HashMap<String, Object>();
+      addressMap.put("name", "Simpler Postage Inc");
+      addressMap.put("street1", "164 Townsend St");
+      addressMap.put("street2", "Unit 1");
+      addressMap.put("city", "San Francisco");
+      addressMap.put("state", "CA");
+      addressMap.put("zip", "94107");
+      addressMap.put("phone", "415-456-7890");
 
-            Map<String, Object> parcelMap = new HashMap<String, Object>();
-            parcelMap.put("weight", 22.9);
-            parcelMap.put("height", 12.1);
-            parcelMap.put("width", 8);
-            parcelMap.put("length", 19.8);
+      Map<String, Object> parcelMap = new HashMap<String, Object>();
+      parcelMap.put("weight", 22.9);
+      parcelMap.put("height", 12.1);
+      parcelMap.put("width", 8);
+      parcelMap.put("length", 19.8);
 
-            // create two shipments
-            Map<String, Object> shipmentMap = new HashMap<String, Object>();
-            shipmentMap.put("to_address", addressMap);
-            shipmentMap.put("from_address", addressMap);
-            shipmentMap.put("parcel", parcelMap);
-            Shipment shipment1 = Shipment.create(shipmentMap);
-            Shipment shipment2 = Shipment.create(shipmentMap);
+      // create two shipments
+      Map<String, Object> shipmentMap = new HashMap<String, Object>();
+      shipmentMap.put("to_address", addressMap);
+      shipmentMap.put("from_address", addressMap);
+      shipmentMap.put("parcel", parcelMap);
+      Shipment shipment1 = Shipment.create(shipmentMap);
+      Shipment shipment2 = Shipment.create(shipmentMap);
 
-            // create batch
-            Batch batch = Batch.create();
+      // create batch
+      Batch batch = Batch.create();
 
-            // wait until batch is created asynchronously
-            while(true) {
-                batch = batch.refresh();
+      // wait until batch is created asynchronously
+      while (true) {
+        batch = batch.refresh();
 
-                if (batch.getState() == "created") {
-                    break;
-                }
-
-                Thread.sleep(3000);
-            }
-
-            // add shipments to batch
-            List<Shipment> shipments = new ArrayList<Shipment>();
-            shipments.add(shipment1);
-            shipments.add(shipment2);
-            batch.addShipments(shipments);
-
-            // create manifest
-            batch.createScanForm();
-
-            // batch label creation is asyncronou
-            while(true) {
-                batch = batch.refresh();
-
-                if (batch.getScanForm() != null) {
-                    break;
-                }
-
-                Thread.sleep(8000);
-            }
-
-            System.out.println(batch.prettyPrint());
-
-        } catch (EasyPostException e) {
-            e.printStackTrace();
+        if (batch.getState() == "created") {
+          break;
         }
+
+        Thread.sleep(3000);
+      }
+
+      // add shipments to batch
+      List<Shipment> shipments = new ArrayList<Shipment>();
+      shipments.add(shipment1);
+      shipments.add(shipment2);
+      batch.addShipments(shipments);
+
+      // create manifest
+      batch.createScanForm();
+
+      // batch label creation is asyncronou
+      while (true) {
+        batch = batch.refresh();
+
+        if (batch.getScanForm() != null) {
+          break;
+        }
+
+        Thread.sleep(8000);
+      }
+
+      System.out.println(batch.prettyPrint());
+
+    } catch (EasyPostException e) {
+      e.printStackTrace();
     }
+  }
 }

--- a/src/main/java/com/easypost/app/Readme.java
+++ b/src/main/java/com/easypost/app/Readme.java
@@ -1,4 +1,6 @@
-// java -cp "target/easypost-java-2.0.4.jar:target/gson-2.2.4.jar" Readme
+package com.easypost.app;
+
+// Usage: java -cp "target/easypost-java-2.0.4.jar:target/gson-2.2.4.jar" Readme
 
 import java.util.HashMap;
 import java.util.Map;
@@ -15,107 +17,106 @@ import com.easypost.model.Shipment;
 
 public class Readme {
 
-    public static void main(String[] args) {
-        EasyPost.apiKey = "cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi";
+  public static void main(String[] args) {
+    EasyPost.apiKey = "API_KEY";
 
-        Map<String, Object> fromAddressMap = new HashMap<String, Object>();
-        fromAddressMap.put("name", "Simpler Postage Inc");
-        fromAddressMap.put("street1", "388 Townsend St");
-        fromAddressMap.put("street2", "Apt 20");
-        fromAddressMap.put("city", "San Francisco");
-        fromAddressMap.put("state", "CA");
-        fromAddressMap.put("zip", "94107");
-        fromAddressMap.put("phone", "415-456-7890");
+    Map<String, Object> fromAddressMap = new HashMap<String, Object>();
+    fromAddressMap.put("name", "Simpler Postage Inc");
+    fromAddressMap.put("street1", "388 Townsend St");
+    fromAddressMap.put("street2", "Apt 20");
+    fromAddressMap.put("city", "San Francisco");
+    fromAddressMap.put("state", "CA");
+    fromAddressMap.put("zip", "94107");
+    fromAddressMap.put("phone", "415-456-7890");
 
-        Map<String, Object> toAddressMap = new HashMap<String, Object>();
-        toAddressMap.put("name", "Sawyer Bateman");
-        toAddressMap.put("street1", "1A Larkspur Cres");
-        toAddressMap.put("street2", "");
-        toAddressMap.put("city", "St. Albert");
-        toAddressMap.put("state", "AB");
-        toAddressMap.put("zip", "T8N2M4");
-        toAddressMap.put("phone", "780-483-2746");
-        toAddressMap.put("country", "CA");
+    Map<String, Object> toAddressMap = new HashMap<String, Object>();
+    toAddressMap.put("name", "Sawyer Bateman");
+    toAddressMap.put("street1", "1A Larkspur Cres");
+    toAddressMap.put("street2", "");
+    toAddressMap.put("city", "St. Albert");
+    toAddressMap.put("state", "AB");
+    toAddressMap.put("zip", "T8N2M4");
+    toAddressMap.put("phone", "780-483-2746");
+    toAddressMap.put("country", "CA");
 
-        Map<String, Object> parcelMap = new HashMap<String, Object>();
-        parcelMap.put("weight", 22.9);
-        parcelMap.put("height", 12.1);
-        parcelMap.put("width", 8);
-        parcelMap.put("length", 19.8);
+    Map<String, Object> parcelMap = new HashMap<String, Object>();
+    parcelMap.put("weight", 22.9);
+    parcelMap.put("height", 12.1);
+    parcelMap.put("width", 8);
+    parcelMap.put("length", 19.8);
 
-        Map<String, Object> customsItem1Map = new HashMap<String, Object>();
-        customsItem1Map.put("description", "EasyPost T-shirts");
-        customsItem1Map.put("quantity", 2);
-        customsItem1Map.put("value", 23.56);
-        customsItem1Map.put("weight", 18.8);
-        customsItem1Map.put("origin_country", "us");
-        customsItem1Map.put("hs_tariff_number", "123456");
+    Map<String, Object> customsItem1Map = new HashMap<String, Object>();
+    customsItem1Map.put("description", "EasyPost T-shirts");
+    customsItem1Map.put("quantity", 2);
+    customsItem1Map.put("value", 23.56);
+    customsItem1Map.put("weight", 18.8);
+    customsItem1Map.put("origin_country", "us");
+    customsItem1Map.put("hs_tariff_number", "123456");
 
-        Map<String, Object> customsItem2Map = new HashMap<String, Object>();
-        customsItem2Map.put("description", "EasyPost Stickers");
-        customsItem2Map.put("quantity", 11);
-        customsItem2Map.put("value", 8.98);
-        customsItem2Map.put("weight", 3.2);
-        customsItem2Map.put("origin_country", "us");
-        customsItem2Map.put("hs_tariff_number", "654321");
+    Map<String, Object> customsItem2Map = new HashMap<String, Object>();
+    customsItem2Map.put("description", "EasyPost Stickers");
+    customsItem2Map.put("quantity", 11);
+    customsItem2Map.put("value", 8.98);
+    customsItem2Map.put("weight", 3.2);
+    customsItem2Map.put("origin_country", "us");
+    customsItem2Map.put("hs_tariff_number", "654321");
 
-        try {
-            Address fromAddress = Address.create(fromAddressMap);
-            Address toAddress = Address.create(toAddressMap);
-            Parcel parcel = Parcel.create(parcelMap);
+    try {
+      Address fromAddress = Address.create(fromAddressMap);
+      Address toAddress = Address.create(toAddressMap);
+      Parcel parcel = Parcel.create(parcelMap);
 
+      try {
+        toAddress.verify();
+      } catch (EasyPostException e) {
+        System.out.println(e.getMessage());
+      }
 
-            try {
-                Address verified = toAddress.verify();
-            } catch (EasyPostException e) {
-                System.out.println(e.getMessage());
-            }
+      // customs
+      Map<String, Object> customsInfoMap = new HashMap<String, Object>();
+      customsInfoMap.put("integrated_form_type", "form_2976");
+      customsInfoMap.put("customs_certify", true);
+      customsInfoMap.put("customs_signer", "Dr. Pepper");
+      customsInfoMap.put("contents_type", "gift");
+      customsInfoMap.put("eel_pfc", "NOEEI 30.37(a)");
+      customsInfoMap.put("non_delivery_option", "return");
+      customsInfoMap.put("restriction_type", "none");
+      CustomsItem customsItem1 = CustomsItem.create(customsItem1Map);
+      CustomsItem customsItem2 = CustomsItem.create(customsItem2Map);
+      List<CustomsItem> customsItemsList = new ArrayList<CustomsItem>();
+      customsItemsList.add(customsItem1);
+      customsItemsList.add(customsItem2);
+      customsInfoMap.put("customs_items", customsItemsList);
+      CustomsInfo customsInfo = CustomsInfo.create(customsInfoMap);
 
-            // customs
-            Map<String, Object> customsInfoMap = new HashMap<String, Object>();
-            customsInfoMap.put("integrated_form_type", "form_2976");
-            customsInfoMap.put("customs_certify", true);
-            customsInfoMap.put("customs_signer", "Dr. Pepper");
-            customsInfoMap.put("contents_type", "gift");
-            customsInfoMap.put("eel_pfc", "NOEEI 30.37(a)");
-            customsInfoMap.put("non_delivery_option", "return");
-            customsInfoMap.put("restriction_type", "none");
-            CustomsItem customsItem1 = CustomsItem.create(customsItem1Map);
-            CustomsItem customsItem2 = CustomsItem.create(customsItem2Map);
-            List<CustomsItem> customsItemsList = new ArrayList<CustomsItem>();
-            customsItemsList.add(customsItem1);
-            customsItemsList.add(customsItem2);
-            customsInfoMap.put("customs_items", customsItemsList);
-            CustomsInfo customsInfo = CustomsInfo.create(customsInfoMap);
+      // create shipment
+      Map<String, Object> shipmentMap = new HashMap<String, Object>();
+      shipmentMap.put("to_address", toAddress);
+      shipmentMap.put("from_address", fromAddress);
+      shipmentMap.put("parcel", parcel);
+      shipmentMap.put("customs_info", customsInfo);
 
-            // create shipment
-            Map<String, Object> shipmentMap = new HashMap<String, Object>();
-            shipmentMap.put("to_address", toAddress);
-            shipmentMap.put("from_address", fromAddress);
-            shipmentMap.put("parcel", parcel);
-            shipmentMap.put("customs_info", customsInfo);
+      Shipment shipment = Shipment.create(shipmentMap);
 
-            Shipment shipment = Shipment.create(shipmentMap);
+      // buy postage
+      List<String> buyCarriers = new ArrayList<String>();
+      buyCarriers.add("USPS");
+      List<String> buyServices = new ArrayList<String>();
+      buyServices.add("Priority");
+      // List<String> buyServiceCodes = new ArrayList<String>();
+      // buyServiceCodes.add("fedex.fedex_ground");
 
-            // buy postage
-            List<String> buyCarriers = new ArrayList<String>();
-            buyCarriers.add("USPS");
-            List<String> buyServices = new ArrayList<String>();
-            buyServices.add("Priority");
-            // List<String> buyServiceCodes = new ArrayList<String>();
-            // buyServiceCodes.add("fedex.fedex_ground");
+      Map<String, Object> buyMap = new HashMap<String, Object>();
+      buyMap.put("rate", shipment.lowestRate(buyCarriers, buyServices));
+      buyMap.put("insurance", 249.99);
 
-            Map<String, Object> buyMap = new HashMap<String, Object>();
-            buyMap.put("rate", shipment.lowestRate(buyCarriers, buyServices));
-            buyMap.put("insurance", 249.99);
+      // shipment = shipment.buy(shipment.lowestRate(buyCarriers, buyServices));
+      shipment = shipment.buy(buyMap);
 
-            // shipment = shipment.buy(shipment.lowestRate(buyCarriers, buyServices));
-            shipment = shipment.buy(buyMap);
+      System.out.println(shipment.prettyPrint());
 
-            System.out.println(shipment.prettyPrint());
-
-        } catch (EasyPostException e) {
-            e.printStackTrace();
-        }
+    } catch (EasyPostException e) {
+      e.printStackTrace();
     }
+  }
 }

--- a/src/main/java/com/easypost/app/SmartPostExample.java
+++ b/src/main/java/com/easypost/app/SmartPostExample.java
@@ -1,4 +1,6 @@
-// java -cp "target/easypost-java-2.0.2.jar:target/gson-2.2.2.jar" SmartPostExample
+package com.easypost.app;
+
+// Usage: java -cp "target/easypost-java-2.0.2.jar:target/gson-2.2.2.jar" SmartPostExample
 
 import java.util.HashMap;
 import java.util.Map;
@@ -13,73 +15,73 @@ import com.easypost.model.Shipment;
 
 public class SmartPostExample {
 
-    public static void main(String[] args) {
-        EasyPost.apiKey = "cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi";
-        
-        Map<String, Object> fromAddressMap = new HashMap<String, Object>();
-        fromAddressMap.put("name", "Simpler Postage Inc");
-        fromAddressMap.put("street1", "388 Townsend St");
-        fromAddressMap.put("street2", "Apt 20");
-        fromAddressMap.put("city", "San Francisco");
-        fromAddressMap.put("state", "CA");
-        fromAddressMap.put("zip", "94107");
-        fromAddressMap.put("phone", "415-456-7890");
+  public static void main(String[] args) {
+    EasyPost.apiKey = "API_KEY";
 
-        Map<String, Object> toAddressMap = new HashMap<String, Object>();
-        toAddressMap.put("name", "Sawyer Bateman");
-        toAddressMap.put("street1", "63 Ellis Street");
-        toAddressMap.put("street2", "");
-        toAddressMap.put("city", "San Francisco");
-        toAddressMap.put("state", "CA");
-        toAddressMap.put("zip", "94102");
-        toAddressMap.put("phone", "415-482-2937");
-        toAddressMap.put("country", "US");
+    Map<String, Object> fromAddressMap = new HashMap<String, Object>();
+    fromAddressMap.put("name", "Simpler Postage Inc");
+    fromAddressMap.put("street1", "388 Townsend St");
+    fromAddressMap.put("street2", "Apt 20");
+    fromAddressMap.put("city", "San Francisco");
+    fromAddressMap.put("state", "CA");
+    fromAddressMap.put("zip", "94107");
+    fromAddressMap.put("phone", "415-456-7890");
 
-        Map<String, Object> parcelMap = new HashMap<String, Object>();
-        parcelMap.put("weight", 20);
-        parcelMap.put("length", 6);
-        parcelMap.put("width", 8);
-        parcelMap.put("height", 1);
+    Map<String, Object> toAddressMap = new HashMap<String, Object>();
+    toAddressMap.put("name", "Sawyer Bateman");
+    toAddressMap.put("street1", "63 Ellis Street");
+    toAddressMap.put("street2", "");
+    toAddressMap.put("city", "San Francisco");
+    toAddressMap.put("state", "CA");
+    toAddressMap.put("zip", "94102");
+    toAddressMap.put("phone", "415-482-2937");
+    toAddressMap.put("country", "US");
 
-        try {
-            Address fromAddress = Address.create(fromAddressMap);
-            Address toAddress = Address.create(toAddressMap);
-            Parcel parcel = Parcel.create(parcelMap);
+    Map<String, Object> parcelMap = new HashMap<String, Object>();
+    parcelMap.put("weight", 20);
+    parcelMap.put("length", 6);
+    parcelMap.put("width", 8);
+    parcelMap.put("height", 1);
 
-            // Address verified = to_address.verify();
+    try {
+      Address fromAddress = Address.create(fromAddressMap);
+      Address toAddress = Address.create(toAddressMap);
+      Parcel parcel = Parcel.create(parcelMap);
 
-            // create shipment
-            Map<String, Object> shipmentMap = new HashMap<String, Object>();
-            shipmentMap.put("to_address", toAddress);
-            shipmentMap.put("from_address", fromAddress);
-            shipmentMap.put("parcel", parcel);
+      // Address verified = to_address.verify();
 
-            Map<String, Object> shipmentOptions = new HashMap<String, Object>();
-            shipmentOptions.put("smartpost_hub", 5552);
-            shipmentOptions.put("smartpost_manifest", "123456789");
-            shipmentMap.put("options", shipmentOptions);
-            
-            Shipment shipment = Shipment.create(shipmentMap);
+      // create shipment
+      Map<String, Object> shipmentMap = new HashMap<String, Object>();
+      shipmentMap.put("to_address", toAddress);
+      shipmentMap.put("from_address", fromAddress);
+      shipmentMap.put("parcel", parcel);
 
-            // buy postage
-            List<String> buyServiceCodes = new ArrayList<String>();
-            buyServiceCodes.add("fedex.smart_post");
+      Map<String, Object> shipmentOptions = new HashMap<String, Object>();
+      shipmentOptions.put("smartpost_hub", 5552);
+      shipmentOptions.put("smartpost_manifest", "123456789");
+      shipmentMap.put("options", shipmentOptions);
 
-            Map<String, Object> buyMap = new HashMap<String, Object>();
-            buyMap.put("rate", shipment.lowestRate(buyServiceCodes));
-            buyMap.put("insurance", 249.99);
+      Shipment shipment = Shipment.create(shipmentMap);
 
-            // shipment = shipment.buy(shipment.lowestRate(buyCarriers, buyServices));
-            shipment = shipment.buy(buyMap);
+      // buy postage
+      List<String> buyServiceCodes = new ArrayList<String>();
+      buyServiceCodes.add("fedex.smart_post");
 
-            Map<String, Object> labelMap = new HashMap<String, Object>();
-            labelMap.put("file_format", "pdf");
-            shipment = shipment.label(labelMap);
+      Map<String, Object> buyMap = new HashMap<String, Object>();
+      buyMap.put("rate", shipment.lowestRate(buyServiceCodes));
+      buyMap.put("insurance", 249.99);
 
-            System.out.println(shipment.prettyPrint());
-            
-        } catch (EasyPostException e) {
-            e.printStackTrace();
-        }
+      // shipment = shipment.buy(shipment.lowestRate(buyCarriers, buyServices));
+      shipment = shipment.buy(buyMap);
+
+      Map<String, Object> labelMap = new HashMap<String, Object>();
+      labelMap.put("file_format", "pdf");
+      shipment = shipment.label(labelMap);
+
+      System.out.println(shipment.prettyPrint());
+
+    } catch (EasyPostException e) {
+      e.printStackTrace();
     }
+  }
 }

--- a/src/main/java/com/easypost/app/Webhook.java
+++ b/src/main/java/com/easypost/app/Webhook.java
@@ -1,36 +1,27 @@
-// java -cp "target/easypost-java-2.0.4.jar:target/gson-2.2.2.jar" Webhook
+package com.easypost.app;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.List;
-import java.util.ArrayList;
+// Usage: java -cp "target/easypost-java-2.0.4.jar:target/gson-2.2.2.jar" Webhook
 
 import com.easypost.EasyPost;
 import com.easypost.exception.EasyPostException;
-import com.easypost.model.Address;
-import com.easypost.model.Parcel;
-import com.easypost.model.CustomsItem;
-import com.easypost.model.CustomsInfo;
-import com.easypost.model.Shipment;
 import com.easypost.model.Event;
-import com.easypost.model.Tracker;
 import com.easypost.net.EasyPostResource;
 
 public class Webhook {
 
-    public static void main(String[] args) {
-        EasyPost.apiKey = "cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi";
+  public static void main(String[] args) {
+    EasyPost.apiKey = "API_KEY";
 
-        try {
-            Event event = Event.retrieve("evt_ZzMEqURE");
-            EasyPostResource tracker = event.getResult();
+    try {
+      Event event = Event.retrieve("evt_ZzMEqURE");
+      EasyPostResource tracker = event.getResult();
 
-            System.out.println(event.getDescription());
-            System.out.println(tracker.getStatus());
-            System.out.println(tracker.prettyPrint());
+      System.out.println(event.getDescription());
+      System.out.println(tracker.getStatus());
+      System.out.println(tracker.prettyPrint());
 
-        } catch (EasyPostException e) {
-            e.printStackTrace();
-        }
+    } catch (EasyPostException e) {
+      e.printStackTrace();
     }
+  }
 }

--- a/src/main/java/com/easypost/exception/EasyPostException.java
+++ b/src/main/java/com/easypost/exception/EasyPostException.java
@@ -2,25 +2,25 @@ package com.easypost.exception;
 
 public class EasyPostException extends Exception {
 
-	private static final long serialVersionUID = 1L;
-	private final String param;
+  private static final long serialVersionUID = 1L;
+  private final String param;
 
-	public EasyPostException(String message) {
-		super(message, null);
-		this.param = null;
-	}
+  public EasyPostException(String message) {
+    super(message, null);
+    this.param = null;
+  }
 
-	public EasyPostException(String message, Throwable e) {
-		super(message, e);
-		this.param = null;
-	}
+  public EasyPostException(String message, Throwable e) {
+    super(message, e);
+    this.param = null;
+  }
 
-	public EasyPostException(String message, String param, Throwable e) {
-		super(message, e);
-		this.param = param;
-	}
+  public EasyPostException(String message, String param, Throwable e) {
+    super(message, e);
+    this.param = param;
+  }
 
-	public String getParam() {
-		return param;
-	}
+  public String getParam() {
+    return param;
+  }
 }

--- a/src/main/java/com/easypost/model/Address.java
+++ b/src/main/java/com/easypost/model/Address.java
@@ -24,11 +24,12 @@ public class Address extends EasyPostResource {
   String carrierFacility;
   String federalTaxId;
   Boolean residential;
-  Map<String,AddressVerification> verifications;
+  Map<String, AddressVerification> verifications;
 
   public String getId() {
     return id;
   }
+
   public void setId(String id) {
     this.id = id;
   }
@@ -36,6 +37,7 @@ public class Address extends EasyPostResource {
   public String getMode() {
     return mode;
   }
+
   public void setMode(String mode) {
     this.mode = mode;
   }
@@ -43,6 +45,7 @@ public class Address extends EasyPostResource {
   public String getName() {
     return name;
   }
+
   public void setName(String name) {
     this.name = name;
   }
@@ -50,6 +53,7 @@ public class Address extends EasyPostResource {
   public String getCompany() {
     return company;
   }
+
   public void setCompany(String company) {
     this.company = company;
   }
@@ -57,6 +61,7 @@ public class Address extends EasyPostResource {
   public String getStreet1() {
     return street1;
   }
+
   public void setStreet1(String street1) {
     this.street1 = street1;
   }
@@ -64,6 +69,7 @@ public class Address extends EasyPostResource {
   public String getStreet2() {
     return street2;
   }
+
   public void setStreet2(String street2) {
     this.street2 = street2;
   }
@@ -71,6 +77,7 @@ public class Address extends EasyPostResource {
   public String getZip() {
     return zip;
   }
+
   public void setZip(String zip) {
     this.zip = zip;
   }
@@ -78,6 +85,7 @@ public class Address extends EasyPostResource {
   public String getCity() {
     return city;
   }
+
   public void setCity(String city) {
     this.city = city;
   }
@@ -85,6 +93,7 @@ public class Address extends EasyPostResource {
   public String getState() {
     return state;
   }
+
   public void setState(String state) {
     this.state = state;
   }
@@ -92,6 +101,7 @@ public class Address extends EasyPostResource {
   public String getCountry() {
     return country;
   }
+
   public void setCountry(String country) {
     this.country = country;
   }
@@ -99,6 +109,7 @@ public class Address extends EasyPostResource {
   public String getPhone() {
     return phone;
   }
+
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -106,6 +117,7 @@ public class Address extends EasyPostResource {
   public String getEmail() {
     return email;
   }
+
   public void setEmail(String email) {
     this.email = email;
   }
@@ -113,6 +125,7 @@ public class Address extends EasyPostResource {
   public String getMessage() {
     return message;
   }
+
   public void setMessage(String message) {
     this.message = message;
   }
@@ -120,6 +133,7 @@ public class Address extends EasyPostResource {
   public String getCarrierFacility() {
     return carrierFacility;
   }
+
   public void setCarrierFacility(String carrierFacility) {
     this.carrierFacility = carrierFacility;
   }
@@ -127,6 +141,7 @@ public class Address extends EasyPostResource {
   public String getFederalTaxId() {
     return federalTaxId;
   }
+
   public void setFederalTaxId(String federalTaxId) {
     this.federalTaxId = federalTaxId;
   }
@@ -134,17 +149,24 @@ public class Address extends EasyPostResource {
   public Boolean getResidential() {
     return residential;
   }
+
   public void setResidential(Boolean residential) {
     this.residential = residential;
   }
 
-  public Map<String,AddressVerification> getVerifications() { return verifications;  }
-  public void setVerifications(Map<String,AddressVerification> verifications) { this.verifications = verifications; }
+  public Map<String, AddressVerification> getVerifications() {
+    return verifications;
+  }
+
+  public void setVerifications(Map<String, AddressVerification> verifications) {
+    this.verifications = verifications;
+  }
 
   // create
   public static Address create(Map<String, Object> params) throws EasyPostException {
     return create(params, null);
   }
+
   public static Address create(Map<String, Object> params, String apiKey) throws EasyPostException {
     String url = classURL(Address.class);
 
@@ -177,6 +199,7 @@ public class Address extends EasyPostResource {
   public static Address retrieve(String id) throws EasyPostException {
     return retrieve(id, null);
   }
+
   public static Address retrieve(String id, String apiKey) throws EasyPostException {
     return request(RequestMethod.GET, instanceURL(Address.class, id), null, Address.class, apiKey);
   }
@@ -185,6 +208,7 @@ public class Address extends EasyPostResource {
   public static AddressCollection all(Map<String, Object> params) throws EasyPostException {
     return all(params, null);
   }
+
   public static AddressCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
     return request(RequestMethod.GET, classURL(Address.class), params, AddressCollection.class, apiKey);
   }
@@ -193,12 +217,14 @@ public class Address extends EasyPostResource {
   public static Address createAndVerify(Map<String, Object> params) throws EasyPostException {
     return createAndVerify(params, null);
   }
+
   public static Address createAndVerify(Map<String, Object> params, String apiKey) throws EasyPostException {
     Map<String, Object> wrappedParams = new HashMap<String, Object>();
     wrappedParams.put("address", params);
 
     AddressVerifyResponse response;
-    response = request(RequestMethod.POST, String.format("%s/create_and_verify", classURL(Address.class)), wrappedParams, AddressVerifyResponse.class, apiKey);
+    response = request(RequestMethod.POST, String.format("%s/create_and_verify", classURL(Address.class)),
+        wrappedParams, AddressVerifyResponse.class, apiKey);
 
     if (response.message != null) {
       response.address.message = response.message;
@@ -207,16 +233,20 @@ public class Address extends EasyPostResource {
   }
 
   // createAndVerifyWithCarrier
-  public static Address createAndVerifyWithCarrier(Map<String, Object> params, String carrier) throws EasyPostException {
+  public static Address createAndVerifyWithCarrier(Map<String, Object> params, String carrier)
+      throws EasyPostException {
     return createAndVerifyWithCarrier(params, carrier, null);
   }
-  public static Address createAndVerifyWithCarrier(Map<String, Object> params, String carrier, String apiKey) throws EasyPostException {
+
+  public static Address createAndVerifyWithCarrier(Map<String, Object> params, String carrier, String apiKey)
+      throws EasyPostException {
     Map<String, Object> wrappedParams = new HashMap<String, Object>();
     wrappedParams.put("address", params);
     wrappedParams.put("carrier", carrier);
 
     AddressVerifyResponse response;
-    response = request(RequestMethod.POST, String.format("%s/create_and_verify", classURL(Address.class)), wrappedParams, AddressVerifyResponse.class, apiKey);
+    response = request(RequestMethod.POST, String.format("%s/create_and_verify", classURL(Address.class)),
+        wrappedParams, AddressVerifyResponse.class, apiKey);
 
     if (response.message != null) {
       response.address.message = response.message;
@@ -228,9 +258,11 @@ public class Address extends EasyPostResource {
   public Address verify() throws EasyPostException {
     return this.verify(null);
   }
+
   public Address verify(String apiKey) throws EasyPostException {
     AddressVerifyResponse response;
-    response = request(RequestMethod.GET, String.format("%s/verify", instanceURL(Address.class, this.getId())), null, AddressVerifyResponse.class, apiKey);
+    response = request(RequestMethod.GET, String.format("%s/verify", instanceURL(Address.class, this.getId())), null,
+        AddressVerifyResponse.class, apiKey);
 
     if (response.message != null) {
       response.address.message = response.message;
@@ -242,12 +274,14 @@ public class Address extends EasyPostResource {
   public Address verifyWithCarrier(String carrier) throws EasyPostException {
     return this.verifyWithCarrier(carrier, null);
   }
+
   public Address verifyWithCarrier(String carrier, String apiKey) throws EasyPostException {
     Map<String, Object> wrappedParams = new HashMap<String, Object>();
     wrappedParams.put("carrier", carrier);
 
     AddressVerifyResponse response;
-    response = request(RequestMethod.GET, String.format("%s/verify", instanceURL(Address.class, this.getId())), null, AddressVerifyResponse.class, apiKey);
+    response = request(RequestMethod.GET, String.format("%s/verify", instanceURL(Address.class, this.getId())), null,
+        AddressVerifyResponse.class, apiKey);
 
     if (response.message != null) {
       response.address.message = response.message;

--- a/src/main/java/com/easypost/model/AddressCollection.java
+++ b/src/main/java/com/easypost/model/AddressCollection.java
@@ -10,12 +10,15 @@ public class AddressCollection extends EasyPostResource {
   public List<Batch> getAddresses() {
     return addresses;
   }
+
   public void setAddresses(List<Batch> addresses) {
     this.addresses = addresses;
   }
+
   public Boolean getHasMore() {
     return hasMore;
   }
+
   public void setHasMore(Boolean hasMore) {
     this.hasMore = hasMore;
   }

--- a/src/main/java/com/easypost/model/AddressVerifyResponse.java
+++ b/src/main/java/com/easypost/model/AddressVerifyResponse.java
@@ -1,20 +1,22 @@
 package com.easypost.model;
 
 public class AddressVerifyResponse {
-	Address address;
-	String message;
-	
-	public Address getAddress() {
-		return address;
-	}
-	public void setAddress(Address address) {
-		this.address = address;
-	}
+  Address address;
+  String message;
 
-	public String getMessage() {
-		return message;
-	}
-	public void setMessage(String message) {
-		this.message = message;
-	}
+  public Address getAddress() {
+    return address;
+  }
+
+  public void setAddress(Address address) {
+    this.address = address;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
 }

--- a/src/main/java/com/easypost/model/ApiKey.java
+++ b/src/main/java/com/easypost/model/ApiKey.java
@@ -3,13 +3,22 @@ package com.easypost.model;
 import com.easypost.net.EasyPostResource;
 
 public class ApiKey extends EasyPostResource {
-    String mode;
-    String key;
+  String mode;
+  String key;
 
-    public String getMode() { return mode; }
-    public void setMode(String mode) { this.mode = mode; }
+  public String getMode() {
+    return mode;
+  }
 
-    public String getKey() { return key; }
-    public void setKey(String key) { this.key = key; }
+  public void setMode(String mode) {
+    this.mode = mode;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
 }
-

--- a/src/main/java/com/easypost/model/ApiKeys.java
+++ b/src/main/java/com/easypost/model/ApiKeys.java
@@ -1,34 +1,46 @@
 package com.easypost.model;
 
 import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
 public class ApiKeys extends EasyPostResource {
-    public String id;
-    List<ApiKey> keys;
-    List<ApiKeys> children;
+  public String id;
+  List<ApiKey> keys;
+  List<ApiKeys> children;
 
-    public String getId() { return id; }
-    public void setId(String id) { this.id = id; }
+  public String getId() {
+    return id;
+  }
 
-    public List<ApiKey> getKeys() { return keys; }
-    public void setKeys(List<ApiKey> keys) { this.keys = keys; }
+  public void setId(String id) {
+    this.id = id;
+  }
 
-    public List<ApiKeys> getChildren() { return children; }
-    public void setChildren(List<ApiKeys> children) { this.children = children; }
+  public List<ApiKey> getKeys() {
+    return keys;
+  }
 
-    // all
-    public static ApiKeys all() throws EasyPostException {
-      return all(null);
-    }
-    public static ApiKeys all(String apiKey) throws EasyPostException {
-      return request(RequestMethod.GET, classURL(ApiKey.class), null, ApiKeys.class, apiKey);
-    }
+  public void setKeys(List<ApiKey> keys) {
+    this.keys = keys;
+  }
+
+  public List<ApiKeys> getChildren() {
+    return children;
+  }
+
+  public void setChildren(List<ApiKeys> children) {
+    this.children = children;
+  }
+
+  // all
+  public static ApiKeys all() throws EasyPostException {
+    return all(null);
+  }
+
+  public static ApiKeys all(String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, classURL(ApiKey.class), null, ApiKeys.class, apiKey);
+  }
 
 }
-
-

--- a/src/main/java/com/easypost/model/Batch.java
+++ b/src/main/java/com/easypost/model/Batch.java
@@ -8,207 +8,228 @@ import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
 public class Batch extends EasyPostResource {
-	public String id;
-	String mode;
-	String state;
-	public BatchStatus status;
+  public String id;
+  String mode;
+  String state;
+  public BatchStatus status;
   Number numShipments;
-	List<Shipment> shipments;
-	String labelUrl;
-	ScanForm scanForm;
+  List<Shipment> shipments;
+  String labelUrl;
+  ScanForm scanForm;
   String reference;
 
-	public String getId() {
-		return id;
-	}
-	public void setId(String id) {
-		this.id = id;
-	}
+  public String getId() {
+    return id;
+  }
 
-	public String getMode() {
-		return mode;
-	}
-	public void setMode(String mode) {
-		this.mode = mode;
-	}
+  public void setId(String id) {
+    this.id = id;
+  }
 
-	public String getState() {
-		return state;
-	}
-	public void setState(String state) {
-		this.state = state;
-	}
+  public String getMode() {
+    return mode;
+  }
+
+  public void setMode(String mode) {
+    this.mode = mode;
+  }
+
+  public String getState() {
+    return state;
+  }
+
+  public void setState(String state) {
+    this.state = state;
+  }
 
   public Number getNumShipments() {
     return numShipments;
   }
+
   public void setNumShipments(Number numShipments) {
     this.numShipments = numShipments;
   }
 
-	public List<Shipment> getShipments() {
-		return shipments;
-	}
-	public void setShipments(List<Shipment> shipments) {
-		this.shipments = shipments;
-	}
+  public List<Shipment> getShipments() {
+    return shipments;
+  }
 
-	public String getLabelUrl() {
-		return labelUrl;
-	}
-	public void setLabelUrl(String labelUrl) {
-		this.labelUrl = labelUrl;
-	}
+  public void setShipments(List<Shipment> shipments) {
+    this.shipments = shipments;
+  }
 
-	public ScanForm getScanForm() {
-		return scanForm;
-	}
-	public void setScanForm(ScanForm scanForm) {
-		this.scanForm = scanForm;
-	}
+  public String getLabelUrl() {
+    return labelUrl;
+  }
+
+  public void setLabelUrl(String labelUrl) {
+    this.labelUrl = labelUrl;
+  }
+
+  public ScanForm getScanForm() {
+    return scanForm;
+  }
+
+  public void setScanForm(ScanForm scanForm) {
+    this.scanForm = scanForm;
+  }
 
   public String getReference() {
     return reference;
   }
+
   public void setReference(String reference) {
     this.reference = reference;
   }
 
+  // create
+  public static Batch create() throws EasyPostException {
+    return create(null, null);
+  }
 
-	// create
-	public static Batch create() throws EasyPostException {
-		return create(null, null);
-	}
-	public static Batch create(Map<String, Object> params) throws EasyPostException {
-		return create(params, null);
-	}
-	public static Batch create(Map<String, Object> params, String apiKey) throws EasyPostException {
-		Map<String, Object> wrappedParams = new HashMap<String, Object>();
-		wrappedParams.put("batch", params);
+  public static Batch create(Map<String, Object> params) throws EasyPostException {
+    return create(params, null);
+  }
 
-		return request(RequestMethod.POST, classURL(Batch.class), wrappedParams, Batch.class, apiKey);
-	}
+  public static Batch create(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("batch", params);
 
-	// retrieve
-	public static Batch retrieve(String id) throws EasyPostException {
-		return retrieve(id, null);
-	}
-	public static Batch retrieve(String id, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, instanceURL(Batch.class, id), null, Batch.class, apiKey);
-	}
+    return request(RequestMethod.POST, classURL(Batch.class), wrappedParams, Batch.class, apiKey);
+  }
 
-	// all
-	public static BatchCollection all(Map<String, Object> params) throws EasyPostException {
-		return all(params, null);
-	}
-	public static BatchCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, classURL(Batch.class), params, BatchCollection.class, apiKey);
-	}
+  // retrieve
+  public static Batch retrieve(String id) throws EasyPostException {
+    return retrieve(id, null);
+  }
 
-	// create_and_buy
-	public static Batch create_and_buy(Map<String, Object> params) throws EasyPostException {
-		return create_and_buy(params, null);
-	}
-	public static Batch create_and_buy(Map<String, Object> params, String apiKey) throws EasyPostException {
-		Map<String, Object> wrappedParams = new HashMap<String, Object>();
-		wrappedParams.put("batch", params);
+  public static Batch retrieve(String id, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, instanceURL(Batch.class, id), null, Batch.class, apiKey);
+  }
 
-		return request(RequestMethod.POST, classURL(Batch.class), wrappedParams, Batch.class, apiKey);
-	}
+  // all
+  public static BatchCollection all(Map<String, Object> params) throws EasyPostException {
+    return all(params, null);
+  }
 
-	// refresh
-	public Batch refresh() throws EasyPostException {
-		return this.refresh(null, null);
-	}
-	public Batch refresh(Map<String, Object> params) throws EasyPostException {
-		return this.refresh(params, null);
-	}
-	public Batch refresh(String apiKey) throws EasyPostException {
-		return this.refresh((Map<String, Object>) null, apiKey);
-	}
-	public Batch refresh(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(
-			RequestMethod.GET,
-			String.format("%s", instanceURL(Batch.class, this.getId())), params, Batch.class, apiKey);
-	}
+  public static BatchCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, classURL(Batch.class), params, BatchCollection.class, apiKey);
+  }
 
-	// label
-	public Batch label() throws EasyPostException {
-		return this.label(null, null);
-	}
-	public Batch label(Map<String, Object> params) throws EasyPostException {
-		return this.label(params, null);
-	}
-	public Batch label(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(
-			RequestMethod.POST,
-			String.format("%s/label", instanceURL(Batch.class, this.getId())), params, Batch.class, apiKey);
-	}
+  // create_and_buy
+  public static Batch create_and_buy(Map<String, Object> params) throws EasyPostException {
+    return create_and_buy(params, null);
+  }
 
-	// add_shipments
-	public Batch addShipments(List<Shipment> shipments) throws EasyPostException {
-		Map<String, Object> params = new HashMap<String, Object>();
-   	params.put("shipments", shipments);
-		return this.addShipments(params, null);
-	}
-	public Batch addShipments(List<Shipment> shipments, String apiKey) throws EasyPostException {
-		Map<String, Object> params = new HashMap<String, Object>();
-   	params.put("shipments", shipments);
-		return this.addShipments(params, apiKey);
-	}
-	public Batch addShipments(Map<String, Object> params) throws EasyPostException {
-		return this.addShipments(params, null);
-	}
-	public Batch addShipments(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(
-			RequestMethod.POST,
-			String.format("%s/add_shipments", instanceURL(Batch.class, this.getId())), params, Batch.class, apiKey);
-	}
+  public static Batch create_and_buy(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("batch", params);
 
-	// remove_shipments
-	public Batch removeShipments(List<Shipment> shipments) throws EasyPostException {
-		Map<String, Object> params = new HashMap<String, Object>();
-   	params.put("shipments", shipments);
-		return this.removeShipments(params, null);
-	}
-	public Batch removeShipments(List<Shipment> shipments, String apiKey) throws EasyPostException {
-		Map<String, Object> params = new HashMap<String, Object>();
-   	params.put("shipments", shipments);
-		return this.removeShipments(params, apiKey);
-	}
-	public Batch removeShipments(Map<String, Object> params) throws EasyPostException {
-		return this.removeShipments(params, null);
-	}
-	public Batch removeShipments(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(
-			RequestMethod.POST,
-			String.format("%s/remove_shipments", instanceURL(Batch.class, this.getId())), params, Batch.class, apiKey);
-	}
+    return request(RequestMethod.POST, classURL(Batch.class), wrappedParams, Batch.class, apiKey);
+  }
+
+  // refresh
+  public Batch refresh() throws EasyPostException {
+    return this.refresh(null, null);
+  }
+
+  public Batch refresh(Map<String, Object> params) throws EasyPostException {
+    return this.refresh(params, null);
+  }
+
+  public Batch refresh(String apiKey) throws EasyPostException {
+    return this.refresh((Map<String, Object>) null, apiKey);
+  }
+
+  public Batch refresh(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, String.format("%s", instanceURL(Batch.class, this.getId())), params, Batch.class,
+        apiKey);
+  }
+
+  // label
+  public Batch label() throws EasyPostException {
+    return this.label(null, null);
+  }
+
+  public Batch label(Map<String, Object> params) throws EasyPostException {
+    return this.label(params, null);
+  }
+
+  public Batch label(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.POST, String.format("%s/label", instanceURL(Batch.class, this.getId())), params,
+        Batch.class, apiKey);
+  }
+
+  // add_shipments
+  public Batch addShipments(List<Shipment> shipments) throws EasyPostException {
+    Map<String, Object> params = new HashMap<String, Object>();
+    params.put("shipments", shipments);
+    return this.addShipments(params, null);
+  }
+
+  public Batch addShipments(List<Shipment> shipments, String apiKey) throws EasyPostException {
+    Map<String, Object> params = new HashMap<String, Object>();
+    params.put("shipments", shipments);
+    return this.addShipments(params, apiKey);
+  }
+
+  public Batch addShipments(Map<String, Object> params) throws EasyPostException {
+    return this.addShipments(params, null);
+  }
+
+  public Batch addShipments(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.POST, String.format("%s/add_shipments", instanceURL(Batch.class, this.getId())),
+        params, Batch.class, apiKey);
+  }
+
+  // remove_shipments
+  public Batch removeShipments(List<Shipment> shipments) throws EasyPostException {
+    Map<String, Object> params = new HashMap<String, Object>();
+    params.put("shipments", shipments);
+    return this.removeShipments(params, null);
+  }
+
+  public Batch removeShipments(List<Shipment> shipments, String apiKey) throws EasyPostException {
+    Map<String, Object> params = new HashMap<String, Object>();
+    params.put("shipments", shipments);
+    return this.removeShipments(params, apiKey);
+  }
+
+  public Batch removeShipments(Map<String, Object> params) throws EasyPostException {
+    return this.removeShipments(params, null);
+  }
+
+  public Batch removeShipments(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.POST, String.format("%s/remove_shipments", instanceURL(Batch.class, this.getId())),
+        params, Batch.class, apiKey);
+  }
 
   // buy
   public Batch buy() throws EasyPostException {
     return this.buy(null, null);
   }
+
   public Batch buy(Map<String, Object> params) throws EasyPostException {
     return this.buy(params, null);
   }
+
   public Batch buy(Map<String, Object> params, String apiKey) throws EasyPostException {
-    return request(
-      RequestMethod.POST,
-      String.format("%s/buy", instanceURL(Batch.class, this.getId())), params, Batch.class, apiKey);
+    return request(RequestMethod.POST, String.format("%s/buy", instanceURL(Batch.class, this.getId())), params,
+        Batch.class, apiKey);
   }
 
-	// create_scan_form
-	public Batch createScanForm() throws EasyPostException {
-		return this.createScanForm(null, null);
-	}
-	public Batch createScanForm(Map<String, Object> params) throws EasyPostException {
-		return this.createScanForm(params, null);
-	}
-	public Batch createScanForm(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(
-			RequestMethod.POST,
-			String.format("%s/scan_form", instanceURL(Batch.class, this.getId())), params, Batch.class, apiKey);
-	}
+  // create_scan_form
+  public Batch createScanForm() throws EasyPostException {
+    return this.createScanForm(null, null);
+  }
+
+  public Batch createScanForm(Map<String, Object> params) throws EasyPostException {
+    return this.createScanForm(params, null);
+  }
+
+  public Batch createScanForm(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.POST, String.format("%s/scan_form", instanceURL(Batch.class, this.getId())), params,
+        Batch.class, apiKey);
+  }
 
 }

--- a/src/main/java/com/easypost/model/BatchCollection.java
+++ b/src/main/java/com/easypost/model/BatchCollection.java
@@ -10,12 +10,15 @@ public class BatchCollection extends EasyPostResource {
   public List<Batch> getBatches() {
     return batches;
   }
+
   public void setBatches(List<Batch> batches) {
     this.batches = batches;
   }
+
   public Boolean getHasMore() {
     return hasMore;
   }
+
   public void setHasMore(Boolean hasMore) {
     this.hasMore = hasMore;
   }

--- a/src/main/java/com/easypost/model/BatchStatus.java
+++ b/src/main/java/com/easypost/model/BatchStatus.java
@@ -1,36 +1,40 @@
 package com.easypost.model;
 
 public class BatchStatus {
-	int created;
-	int creationFailed;
-	int postagePurchased;
-	int postagePurchaseFailed;
-	
-	public int getCreated() {
-		return created;
-	}
-	public void setCreated(int created) {
-		this.created = created;
-	}
+  int created;
+  int creationFailed;
+  int postagePurchased;
+  int postagePurchaseFailed;
 
-	public int getCreationFailed() {
-		return creationFailed;
-	}
-	public void setCreationFailed(int creationFailed) {
-		this.creationFailed = creationFailed;
-	}
+  public int getCreated() {
+    return created;
+  }
 
-	public int getPostagePurchased() {
-		return postagePurchased;
-	}
-	public void setPostagePurchased(int postagePurchased) {
-		this.postagePurchased = postagePurchased;
-	}
+  public void setCreated(int created) {
+    this.created = created;
+  }
 
-	public int getPostagePurchaseFailed() {
-		return postagePurchaseFailed;
-	}
-	public void setPostagePurchaseFailed(int postagePurchaseFailed) {
-		this.postagePurchaseFailed = postagePurchaseFailed;
-	}
+  public int getCreationFailed() {
+    return creationFailed;
+  }
+
+  public void setCreationFailed(int creationFailed) {
+    this.creationFailed = creationFailed;
+  }
+
+  public int getPostagePurchased() {
+    return postagePurchased;
+  }
+
+  public void setPostagePurchased(int postagePurchased) {
+    this.postagePurchased = postagePurchased;
+  }
+
+  public int getPostagePurchaseFailed() {
+    return postagePurchaseFailed;
+  }
+
+  public void setPostagePurchaseFailed(int postagePurchaseFailed) {
+    this.postagePurchaseFailed = postagePurchaseFailed;
+  }
 }

--- a/src/main/java/com/easypost/model/CarrierAccount.java
+++ b/src/main/java/com/easypost/model/CarrierAccount.java
@@ -9,89 +9,107 @@ import java.util.Map;
 import java.util.List;
 
 public class CarrierAccount extends EasyPostResource {
-    public String id;
-    String readable;
-    String description;
-		String reference;
-		Map<String, Object> credentials;
+  public String id;
+  String readable;
+  String description;
+  String reference;
+  Map<String, Object> credentials;
 
-    public String getId() {
-        return id;
-    }
-    public void setId(String id) {
-        this.id = id;
-    }
+  public String getId() {
+    return id;
+  }
 
-    public String getReadable() { return readable; }
-    public void setReadable(String readable) { this.readable = readable; }
+  public void setId(String id) {
+    this.id = id;
+  }
 
-    public String getDescription() { return description; }
-    public void setDescription(String description) { this.description = description; }
+  public String getReadable() {
+    return readable;
+  }
 
-		public String getReference() {
-		return reference;
-	}
-		public void setReference(String reference) {
-		this.reference = reference;
-	}
+  public void setReadable(String readable) {
+    this.readable = readable;
+  }
 
-		public Map<String, Object> getCredentials() {
-		return credentials;
-	}
-		public void setCredentials(Map<String, Object> credentials) {
-		this.credentials = credentials;
-	}
+  public String getDescription() {
+    return description;
+  }
 
-		// update
-		public CarrierAccount update(Map<String, Object> params) throws EasyPostException {
-			return this.update(params, null);
-		}
-		public CarrierAccount update(Map<String, Object> params, String apiKey) throws EasyPostException {
-			Map<String, Object> wrappedParams = new HashMap<String, Object>();
-			wrappedParams.put("carrier_account", params);
+  public void setDescription(String description) {
+    this.description = description;
+  }
 
-			CarrierAccount response = request(RequestMethod.PUT, instanceURL(CarrierAccount.class, this.getId()), wrappedParams, CarrierAccount.class, apiKey);
+  public String getReference() {
+    return reference;
+  }
 
-			this.merge(this, response);
-			return this;
-		}
+  public void setReference(String reference) {
+    this.reference = reference;
+  }
 
-		// delete
-		public void delete() throws EasyPostException {
-			this.delete(null);
-		}
-		public void delete(String apiKey) throws EasyPostException {
-			request(RequestMethod.DELETE, instanceURL(CarrierAccount.class, this.getId()), null, CarrierAccount.class, apiKey);
-		}
+  public Map<String, Object> getCredentials() {
+    return credentials;
+  }
 
-		// create
-		public static CarrierAccount create(Map<String, Object> params) throws EasyPostException {
-			return create(params, null);
-		}
-		public static CarrierAccount create(Map<String, Object> params, String apiKey) throws EasyPostException {
-			Map<String, Object> wrappedParams = new HashMap<String, Object>();
-			wrappedParams.put("carrier_account", params);
+  public void setCredentials(Map<String, Object> credentials) {
+    this.credentials = credentials;
+  }
 
-			return request(RequestMethod.POST, classURL(CarrierAccount.class), wrappedParams, CarrierAccount.class, apiKey);
-		}
+  // update
+  public CarrierAccount update(Map<String, Object> params) throws EasyPostException {
+    return this.update(params, null);
+  }
 
-		// retrieve
-		public static CarrierAccount retrieve(String id) throws EasyPostException {
-			return retrieve(id, null);
-		}
-		public static CarrierAccount retrieve(String id, String apiKey) throws EasyPostException {
-			return request(RequestMethod.GET, instanceURL(CarrierAccount.class, id), null, CarrierAccount.class, apiKey);
-		}
+  public CarrierAccount update(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("carrier_account", params);
 
-		// all
-		public static List<CarrierAccount> all(Map<String, Object> params) throws EasyPostException {
-			return all(params, null);
-		}
-		public static List<CarrierAccount> all(Map<String, Object> params, String apiKey) throws EasyPostException {
-			CarrierAccount[] response = request(RequestMethod.GET, classURL(CarrierAccount.class), params, CarrierAccount[].class, apiKey);
-			return Arrays.asList(response);
-		}
+    CarrierAccount response = request(RequestMethod.PUT, instanceURL(CarrierAccount.class, this.getId()), wrappedParams,
+        CarrierAccount.class, apiKey);
 
+    this.merge(this, response);
+    return this;
+  }
 
+  // delete
+  public void delete() throws EasyPostException {
+    this.delete(null);
+  }
 
-	}
+  public void delete(String apiKey) throws EasyPostException {
+    request(RequestMethod.DELETE, instanceURL(CarrierAccount.class, this.getId()), null, CarrierAccount.class, apiKey);
+  }
+
+  // create
+  public static CarrierAccount create(Map<String, Object> params) throws EasyPostException {
+    return create(params, null);
+  }
+
+  public static CarrierAccount create(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("carrier_account", params);
+
+    return request(RequestMethod.POST, classURL(CarrierAccount.class), wrappedParams, CarrierAccount.class, apiKey);
+  }
+
+  // retrieve
+  public static CarrierAccount retrieve(String id) throws EasyPostException {
+    return retrieve(id, null);
+  }
+
+  public static CarrierAccount retrieve(String id, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, instanceURL(CarrierAccount.class, id), null, CarrierAccount.class, apiKey);
+  }
+
+  // all
+  public static List<CarrierAccount> all(Map<String, Object> params) throws EasyPostException {
+    return all(params, null);
+  }
+
+  public static List<CarrierAccount> all(Map<String, Object> params, String apiKey) throws EasyPostException {
+    CarrierAccount[] response = request(RequestMethod.GET, classURL(CarrierAccount.class), params,
+        CarrierAccount[].class, apiKey);
+    return Arrays.asList(response);
+  }
+
+}

--- a/src/main/java/com/easypost/model/CarrierDetail.java
+++ b/src/main/java/com/easypost/model/CarrierDetail.java
@@ -1,60 +1,85 @@
 package com.easypost.model;
 
 public class CarrierDetail {
-	String service;
-	String containerType;
-	String estDeliveryDateLocal;
-	String estDeliveryTimeLocal;
-	String originLocation;
-	String destinationLocation;
-	String guaranteedDeliveryDate;
-	String alternateIdentifier;
-	String initialDeliveryAttempt;
+  String service;
+  String containerType;
+  String estDeliveryDateLocal;
+  String estDeliveryTimeLocal;
+  String originLocation;
+  String destinationLocation;
+  String guaranteedDeliveryDate;
+  String alternateIdentifier;
+  String initialDeliveryAttempt;
 
-	public String getService() { return service; }
-	public void setService(String service) { this.service = service; }
+  public String getService() {
+    return service;
+  }
 
-	public String getContainerType() { return containerType; }
-	public void setContainerType(String containerType) { this.containerType = containerType; }
+  public void setService(String service) {
+    this.service = service;
+  }
 
-	public String getEstDeliveryDateLocal() { return estDeliveryDateLocal; }
-	public void setEstDeliveryDateLocal(String estDeliveryDateLocal) { this.estDeliveryDateLocal = estDeliveryDateLocal; }
+  public String getContainerType() {
+    return containerType;
+  }
 
-	public String getEstDeliveryTimeLocal() { return estDeliveryTimeLocal; }
-	public void setEstDeliveryTimeLocal(String estDeliveryTimeLocal) { this.estDeliveryTimeLocal = estDeliveryTimeLocal; }
+  public void setContainerType(String containerType) {
+    this.containerType = containerType;
+  }
 
-	public String getOriginLocation() {
-		return originLocation;
-	}
-	public void setOriginLocation(String originLocation) {
-		this.originLocation = originLocation;
-	}
+  public String getEstDeliveryDateLocal() {
+    return estDeliveryDateLocal;
+  }
 
-	public String getDestinationLocation() {
-		return destinationLocation;
-	}
-	public void setDestinationLocation(String destinationLocation) {
-		this.destinationLocation = destinationLocation;
-	}
+  public void setEstDeliveryDateLocal(String estDeliveryDateLocal) {
+    this.estDeliveryDateLocal = estDeliveryDateLocal;
+  }
 
-	public String getGuaranteedDeliveryDate() {
-		return guaranteedDeliveryDate;
-	}
-	public void setGuaranteedDeliveryDate(String guaranteedDeliveryDate) {
-		this.guaranteedDeliveryDate = guaranteedDeliveryDate;
-	}
+  public String getEstDeliveryTimeLocal() {
+    return estDeliveryTimeLocal;
+  }
 
-	public String getAlternateIdentifier() {
-		return alternateIdentifier;
-	}
-	public void setAlternateIdentifier(String alternateIdentifier) {
-		this.alternateIdentifier = alternateIdentifier;
-	}
+  public void setEstDeliveryTimeLocal(String estDeliveryTimeLocal) {
+    this.estDeliveryTimeLocal = estDeliveryTimeLocal;
+  }
 
-	public String getInitialDeliveryAttempt() {
-		return initialDeliveryAttempt;
-	}
-	public void setInitialDeliveryAttempt(String initialDeliveryAttempt) {
-		this.initialDeliveryAttempt = initialDeliveryAttempt;
-	}
+  public String getOriginLocation() {
+    return originLocation;
+  }
+
+  public void setOriginLocation(String originLocation) {
+    this.originLocation = originLocation;
+  }
+
+  public String getDestinationLocation() {
+    return destinationLocation;
+  }
+
+  public void setDestinationLocation(String destinationLocation) {
+    this.destinationLocation = destinationLocation;
+  }
+
+  public String getGuaranteedDeliveryDate() {
+    return guaranteedDeliveryDate;
+  }
+
+  public void setGuaranteedDeliveryDate(String guaranteedDeliveryDate) {
+    this.guaranteedDeliveryDate = guaranteedDeliveryDate;
+  }
+
+  public String getAlternateIdentifier() {
+    return alternateIdentifier;
+  }
+
+  public void setAlternateIdentifier(String alternateIdentifier) {
+    this.alternateIdentifier = alternateIdentifier;
+  }
+
+  public String getInitialDeliveryAttempt() {
+    return initialDeliveryAttempt;
+  }
+
+  public void setInitialDeliveryAttempt(String initialDeliveryAttempt) {
+    this.initialDeliveryAttempt = initialDeliveryAttempt;
+  }
 }

--- a/src/main/java/com/easypost/model/CustomsInfo.java
+++ b/src/main/java/com/easypost/model/CustomsInfo.java
@@ -8,97 +8,107 @@ import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
 public class CustomsInfo extends EasyPostResource {
-	public String id;
-	String contentsType;
-	String contentsExplanation;
-	boolean customsCertify;
-	String customsSigner;
-	String nonDeliveryOption;
-	String restrictionType;
-	String restrictionComments;
-	List<CustomsItem> customsItems;
+  public String id;
+  String contentsType;
+  String contentsExplanation;
+  boolean customsCertify;
+  String customsSigner;
+  String nonDeliveryOption;
+  String restrictionType;
+  String restrictionComments;
+  List<CustomsItem> customsItems;
 
-	public String getId() {
-		return id;
-	}
-	public void setId(String id) {
-		this.id = id;
-	}
+  public String getId() {
+    return id;
+  }
 
-	public String getContentsType() {
-		return contentsType;
-	}
-	public void setContentsType(String contentsType) {
-		this.contentsType = contentsType;
-	}
+  public void setId(String id) {
+    this.id = id;
+  }
 
-	public String getContentsExplanation() {
-		return contentsExplanation;
-	}
-	public void setContentsExplanation(String contentsExplanation) {
-		this.contentsExplanation = contentsExplanation;
-	}
+  public String getContentsType() {
+    return contentsType;
+  }
 
-	public boolean getCustomsCertify() {
-		return customsCertify;
-	}
-	public void setCustomsCertify(boolean customsCertify) {
-		this.customsCertify = customsCertify;
-	}
+  public void setContentsType(String contentsType) {
+    this.contentsType = contentsType;
+  }
 
-	public String getCustomsSigner() {
-		return customsSigner;
-	}
-	public void setCustomsSigner(String customsSigner) {
-		this.customsSigner = customsSigner;
-	}
+  public String getContentsExplanation() {
+    return contentsExplanation;
+  }
 
-	public String getNonDeliveryOption() {
-		return nonDeliveryOption;
-	}
-	public void setNonDeliveryOption(String nonDeliveryOption) {
-		this.nonDeliveryOption = nonDeliveryOption;
-	}
+  public void setContentsExplanation(String contentsExplanation) {
+    this.contentsExplanation = contentsExplanation;
+  }
 
-	public String getRestrictionType() {
-		return restrictionType;
-	}
-	public void setRestrictionType(String restrictionType) {
-		this.restrictionType = restrictionType;
-	}
+  public boolean getCustomsCertify() {
+    return customsCertify;
+  }
 
-	public String getRestrictionComments() {
-		return restrictionComments;
-	}
-	public void setRestrictionComments(String restrictionComments) {
-		this.restrictionComments = restrictionComments;
-	}
+  public void setCustomsCertify(boolean customsCertify) {
+    this.customsCertify = customsCertify;
+  }
 
-	public List<CustomsItem> getCustomsItems() {
-		return customsItems;
-	}
-	public void setCustomsItems(List<CustomsItem> customsItems) {
-		this.customsItems = customsItems;
-	}
+  public String getCustomsSigner() {
+    return customsSigner;
+  }
 
+  public void setCustomsSigner(String customsSigner) {
+    this.customsSigner = customsSigner;
+  }
 
-	// create
-	public static CustomsInfo create(Map<String, Object> params) throws EasyPostException {
-		return create(params, null);
-	}
-	public static CustomsInfo create(Map<String, Object> params, String apiKey) throws EasyPostException {
-		Map<String, Object> wrappedParams = new HashMap<String, Object>();
-		wrappedParams.put("customs_info", params);
+  public String getNonDeliveryOption() {
+    return nonDeliveryOption;
+  }
 
-		return request(RequestMethod.POST, classURL(CustomsInfo.class), wrappedParams, CustomsInfo.class, apiKey);
-	}
+  public void setNonDeliveryOption(String nonDeliveryOption) {
+    this.nonDeliveryOption = nonDeliveryOption;
+  }
 
-	// retrieve
-	public static CustomsInfo retrieve(String id) throws EasyPostException {
-		return retrieve(id, null);
-	}
-	public static CustomsInfo retrieve(String id, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, instanceURL(CustomsInfo.class, id), null, CustomsInfo.class, apiKey);
-	}
+  public String getRestrictionType() {
+    return restrictionType;
+  }
+
+  public void setRestrictionType(String restrictionType) {
+    this.restrictionType = restrictionType;
+  }
+
+  public String getRestrictionComments() {
+    return restrictionComments;
+  }
+
+  public void setRestrictionComments(String restrictionComments) {
+    this.restrictionComments = restrictionComments;
+  }
+
+  public List<CustomsItem> getCustomsItems() {
+    return customsItems;
+  }
+
+  public void setCustomsItems(List<CustomsItem> customsItems) {
+    this.customsItems = customsItems;
+  }
+
+  // create
+  public static CustomsInfo create(Map<String, Object> params) throws EasyPostException {
+    return create(params, null);
+  }
+
+  public static CustomsInfo create(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("customs_info", params);
+
+    return request(RequestMethod.POST, classURL(CustomsInfo.class), wrappedParams, CustomsInfo.class, apiKey);
+  }
+
+  // retrieve
+  public static CustomsInfo retrieve(String id) throws EasyPostException {
+    return retrieve(id, null);
+  }
+
+  public static CustomsInfo retrieve(String id, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, instanceURL(CustomsInfo.class, id), null, CustomsInfo.class, apiKey);
+  }
 
 }

--- a/src/main/java/com/easypost/model/CustomsItem.java
+++ b/src/main/java/com/easypost/model/CustomsItem.java
@@ -1,6 +1,5 @@
 package com.easypost.model;
 
-import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -8,97 +7,107 @@ import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
 public class CustomsItem extends EasyPostResource {
-	public String id;
-	String description;
-	String hsTariffNumber;
-	String originCountry;
-	int quantity;
-	Float value;
-	Float weight;
-	String code;
-	String currency;
+  public String id;
+  String description;
+  String hsTariffNumber;
+  String originCountry;
+  int quantity;
+  Float value;
+  Float weight;
+  String code;
+  String currency;
 
-	public String getId() {
-		return id;
-	}
-	public void setId(String id) {
-		this.id = id;
-	}
+  public String getId() {
+    return id;
+  }
 
-	public String getDescription() {
-		return description;
-	}
-	public void setDescription(String description) {
-		this.description = description;
-	}
+  public void setId(String id) {
+    this.id = id;
+  }
 
-	public String getHsTariffNumber() {
-		return hsTariffNumber;
-	}
-	public void setHsTariffNumber(String hsTariffNumber) {
-		this.hsTariffNumber = hsTariffNumber;
-	}
+  public String getDescription() {
+    return description;
+  }
 
-	public String getOriginCountry() {
-		return originCountry;
-	}
-	public void setOriginCountry(String originCountry) {
-		this.originCountry = originCountry;
-	}
+  public void setDescription(String description) {
+    this.description = description;
+  }
 
-	public int getQuantity() {
-		return quantity;
-	}
-	public void setQuantity(int quantity) {
-		this.quantity = quantity;
-	}
+  public String getHsTariffNumber() {
+    return hsTariffNumber;
+  }
 
-	public Float getValue() {
-		return value;
-	}
-	public void setValue(Float value) {
-		this.value = value;
-	}
+  public void setHsTariffNumber(String hsTariffNumber) {
+    this.hsTariffNumber = hsTariffNumber;
+  }
 
-	public Float getWeight() {
-		return weight;
-	}
-	public void setWeight(Float weight) {
-		this.weight = weight;
-	}
+  public String getOriginCountry() {
+    return originCountry;
+  }
 
-	public String getCode() {
-		return code;
-	}
-	public void setCode(String code) {
-		this.code = code;
-	}
+  public void setOriginCountry(String originCountry) {
+    this.originCountry = originCountry;
+  }
 
-	public String getCurrency() {
-		return currency;
-	}
-	public void setCurrency(String currency) {
-		this.currency = currency;
-	}
+  public int getQuantity() {
+    return quantity;
+  }
 
+  public void setQuantity(int quantity) {
+    this.quantity = quantity;
+  }
 
-	// create
-	public static CustomsItem create(Map<String, Object> params) throws EasyPostException {
-		return create(params, null);
-	}
-	public static CustomsItem create(Map<String, Object> params, String apiKey) throws EasyPostException {
-		Map<String, Object> wrappedParams = new HashMap<String, Object>();
-		wrappedParams.put("customs_item", params);
+  public Float getValue() {
+    return value;
+  }
 
-		return request(RequestMethod.POST, classURL(CustomsItem.class), wrappedParams, CustomsItem.class, apiKey);
-	}
+  public void setValue(Float value) {
+    this.value = value;
+  }
 
-	// retrieve
-	public static CustomsItem retrieve(String id) throws EasyPostException {
-		return retrieve(id, null);
-	}
-	public static CustomsItem retrieve(String id, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, instanceURL(CustomsItem.class, id), null, CustomsItem.class, apiKey);
-	}
+  public Float getWeight() {
+    return weight;
+  }
+
+  public void setWeight(Float weight) {
+    this.weight = weight;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public void setCode(String code) {
+    this.code = code;
+  }
+
+  public String getCurrency() {
+    return currency;
+  }
+
+  public void setCurrency(String currency) {
+    this.currency = currency;
+  }
+
+  // create
+  public static CustomsItem create(Map<String, Object> params) throws EasyPostException {
+    return create(params, null);
+  }
+
+  public static CustomsItem create(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("customs_item", params);
+
+    return request(RequestMethod.POST, classURL(CustomsItem.class), wrappedParams, CustomsItem.class, apiKey);
+  }
+
+  // retrieve
+  public static CustomsItem retrieve(String id) throws EasyPostException {
+    return retrieve(id, null);
+  }
+
+  public static CustomsItem retrieve(String id, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, instanceURL(CustomsItem.class, id), null, CustomsItem.class, apiKey);
+  }
 
 }

--- a/src/main/java/com/easypost/model/Event.java
+++ b/src/main/java/com/easypost/model/Event.java
@@ -6,62 +6,65 @@ import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
 public class Event extends EasyPostResource {
-	public String id;
-	String description;
-	String mode;
-	EasyPostResource result;
-	Map<String, Object> previousAttributes;
+  public String id;
+  String description;
+  String mode;
+  EasyPostResource result;
+  Map<String, Object> previousAttributes;
 
+  public String getId() {
+    return id;
+  }
 
-	public String getId() {
-		return id;
-	}
-	public void setId(String id) {
-		this.id = id;
-	}
+  public void setId(String id) {
+    this.id = id;
+  }
 
-	public String getDescription() {
-		return description;
-	}
-	public void setDescription(String description) {
-		this.description = description;
-	}
+  public String getDescription() {
+    return description;
+  }
 
-	public String getMode() {
-		return mode;
-	}
-	public void setMode(String mode) {
-		this.mode = mode;
-	}
+  public void setDescription(String description) {
+    this.description = description;
+  }
 
-	public EasyPostResource getResult() {
-		return result;
-	}
-	public void setResult(EasyPostResource result) {
-		this.result = result;
-	}
+  public String getMode() {
+    return mode;
+  }
 
-	public Map<String, Object> getPreviousAttributes() {
-		return previousAttributes;
-	}
-	public void setPreviousAttributes(Map<String, Object> previousAttributes) {
-		this.previousAttributes = previousAttributes;
-	}
+  public void setMode(String mode) {
+    this.mode = mode;
+  }
 
+  public EasyPostResource getResult() {
+    return result;
+  }
 
-	public static Event retrieve(String id) throws EasyPostException {
-		return retrieve(id, null);
-	}
+  public void setResult(EasyPostResource result) {
+    this.result = result;
+  }
 
-	public static EventCollection all(Map<String, Object> params) throws EasyPostException {
-		return all(params, null);
-	}
+  public Map<String, Object> getPreviousAttributes() {
+    return previousAttributes;
+  }
 
-	public static Event retrieve(String id, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, instanceURL(Event.class, id), null, Event.class, apiKey);
-	}
+  public void setPreviousAttributes(Map<String, Object> previousAttributes) {
+    this.previousAttributes = previousAttributes;
+  }
 
-	public static EventCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, classURL(Event.class), params, EventCollection.class, apiKey);
-	}
+  public static Event retrieve(String id) throws EasyPostException {
+    return retrieve(id, null);
+  }
+
+  public static EventCollection all(Map<String, Object> params) throws EasyPostException {
+    return all(params, null);
+  }
+
+  public static Event retrieve(String id, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, instanceURL(Event.class, id), null, Event.class, apiKey);
+  }
+
+  public static EventCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, classURL(Event.class), params, EventCollection.class, apiKey);
+  }
 }

--- a/src/main/java/com/easypost/model/EventCollection.java
+++ b/src/main/java/com/easypost/model/EventCollection.java
@@ -10,12 +10,15 @@ public class EventCollection extends EasyPostResource {
   public List<Event> getEvents() {
     return events;
   }
+
   public void setEvents(List<Event> events) {
     this.events = events;
   }
+
   public Boolean getHasMore() {
     return hasMore;
   }
+
   public void setHasMore(Boolean hasMore) {
     this.hasMore = hasMore;
   }

--- a/src/main/java/com/easypost/model/EventData.java
+++ b/src/main/java/com/easypost/model/EventData.java
@@ -4,20 +4,22 @@ import java.util.Map;
 import com.easypost.net.EasyPostResource;
 
 public class EventData extends EasyPostResource {
-	Map<String, Object> previousAttributes;
-	EasyPostResource object;
-	
-	public Map<String, Object> getPreviousAttributes() {
-		return previousAttributes;
-	}
-	public void setPreviousAttributes(Map<String, Object> previousAttributes) {
-		this.previousAttributes = previousAttributes;
-	}
+  Map<String, Object> previousAttributes;
+  EasyPostResource object;
 
-	public EasyPostResource getObject() {
-		return object;
-	}
-	public void setObject(EasyPostResource object) {
-		this.object = object;
-	}
+  public Map<String, Object> getPreviousAttributes() {
+    return previousAttributes;
+  }
+
+  public void setPreviousAttributes(Map<String, Object> previousAttributes) {
+    this.previousAttributes = previousAttributes;
+  }
+
+  public EasyPostResource getObject() {
+    return object;
+  }
+
+  public void setObject(EasyPostResource object) {
+    this.object = object;
+  }
 }

--- a/src/main/java/com/easypost/model/EventDeserializer.java
+++ b/src/main/java/com/easypost/model/EventDeserializer.java
@@ -13,100 +13,100 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.easypost.net.EasyPostResource;
-import com.easypost.model.Event;
 
 public class EventDeserializer implements JsonDeserializer<Event> {
 
-	@SuppressWarnings("rawtypes")
-	static Map<String, Class> objectMap = new HashMap<String, Class>();
-    static {
-        objectMap.put("Address", Address.class);
-        objectMap.put("Batch", Batch.class);
-        objectMap.put("CustomsInfo", CustomsInfo.class);
-        objectMap.put("CustomsItem", CustomsItem.class);
-        objectMap.put("Event", Event.class);
-        objectMap.put("Fee", Fee.class);
-        objectMap.put("Parcel", Parcel.class);
-        objectMap.put("PostageLabel", PostageLabel.class);
-        objectMap.put("Rate", Rate.class);
-        objectMap.put("Refund", Refund.class);
-        objectMap.put("ScanForm", ScanForm.class);
-        objectMap.put("Shipment", Shipment.class);
-        objectMap.put("Tracker", Tracker.class);
-        objectMap.put("TrackingDetail", TrackingDetail.class);
-		objectMap.put("Webhook", Webhook.class);
+  @SuppressWarnings("rawtypes")
+  static Map<String, Class> objectMap = new HashMap<String, Class>();
+  static {
+    objectMap.put("Address", Address.class);
+    objectMap.put("Batch", Batch.class);
+    objectMap.put("CustomsInfo", CustomsInfo.class);
+    objectMap.put("CustomsItem", CustomsItem.class);
+    objectMap.put("Event", Event.class);
+    objectMap.put("Fee", Fee.class);
+    objectMap.put("Parcel", Parcel.class);
+    objectMap.put("PostageLabel", PostageLabel.class);
+    objectMap.put("Rate", Rate.class);
+    objectMap.put("Refund", Refund.class);
+    objectMap.put("ScanForm", ScanForm.class);
+    objectMap.put("Shipment", Shipment.class);
+    objectMap.put("Tracker", Tracker.class);
+    objectMap.put("TrackingDetail", TrackingDetail.class);
+    objectMap.put("Webhook", Webhook.class);
+  }
+
+  private Object deserializeJsonPrimitive(JsonPrimitive element) {
+    if (element.isBoolean()) {
+      return element.getAsBoolean();
+    } else if (element.isNumber()) {
+      return element.getAsNumber();
+    } else {
+      return element.getAsString();
     }
+  }
 
-    private Object deserializeJsonPrimitive(JsonPrimitive element) {
-    	if (element.isBoolean()) {
-    		return element.getAsBoolean();
-    	} else if (element.isNumber()) {
-    		return element.getAsNumber();
-    	} else {
-    		return element.getAsString();
-    	}
+  private Object[] deserializeJsonArray(JsonArray arr) {
+    Object[] elems = new Object[arr.size()];
+    Iterator<JsonElement> elemIter = arr.iterator();
+    int i = 0;
+    while (elemIter.hasNext()) {
+      JsonElement elem = elemIter.next();
+      elems[i++] = deserializeJsonElement(elem);
     }
+    return elems;
+  }
 
-    private Object[] deserializeJsonArray(JsonArray arr) {
-    	Object[] elems = new Object[arr.size()];
-    	Iterator<JsonElement> elemIter = arr.iterator();
-    	int i = 0;
-    	while (elemIter.hasNext()) {
-    		JsonElement elem = elemIter.next();
-    		elems[i++] = deserializeJsonElement(elem);
-    	}
-    	return elems;
+  private Object deserializeJsonElement(JsonElement element) {
+    if (element.isJsonNull()) {
+      return null;
+    } else if (element.isJsonObject()) {
+      Map<String, Object> valueMap = new HashMap<String, Object>();
+      populateMapFromJSONObject(valueMap, element.getAsJsonObject());
+      return valueMap;
+    } else if (element.isJsonPrimitive()) {
+      return deserializeJsonPrimitive(element.getAsJsonPrimitive());
+    } else if (element.isJsonArray()) {
+      return deserializeJsonArray(element.getAsJsonArray());
+    } else {
+      System.err.println(
+          "Unknown JSON element type for element " + element + ". " + "Please email us at support@easypost.com.");
+      return null;
     }
+  }
 
-    private Object deserializeJsonElement(JsonElement element) {
-    	if (element.isJsonNull()) {
-    		return null;
-    	} else if (element.isJsonObject()) {
-			Map<String, Object> valueMap = new HashMap<String, Object>();
-			populateMapFromJSONObject(valueMap, element.getAsJsonObject());
-			return valueMap;
-		} else if (element.isJsonPrimitive()) {
-			return deserializeJsonPrimitive(element.getAsJsonPrimitive());
-		} else if (element.isJsonArray()) {
-			return deserializeJsonArray(element.getAsJsonArray());
-		} else {
-			System.err.println("Unknown JSON element type for element " + element + ". " +
-					"Please email us at support@easypost.com.");
-			return null;
-		}
-	}
-
-    private void populateMapFromJSONObject(Map<String, Object> objMap, JsonObject jsonObject) {
-		for(Map.Entry<String, JsonElement> entry: jsonObject.entrySet()) {
-			String key = entry.getKey();
-			JsonElement element = entry.getValue();
-			objMap.put(key, deserializeJsonElement(element));
-		}
+  private void populateMapFromJSONObject(Map<String, Object> objMap, JsonObject jsonObject) {
+    for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
+      String key = entry.getKey();
+      JsonElement element = entry.getValue();
+      objMap.put(key, deserializeJsonElement(element));
     }
+  }
 
-    @SuppressWarnings("unchecked")
-	public Event deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-		Event event = new Event();
+  @SuppressWarnings("unchecked")
+  public Event deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    Event event = new Event();
 
-		JsonObject jsonObject = json.getAsJsonObject();
-		for(Map.Entry<String, JsonElement> entry: jsonObject.entrySet()) {
-			String key = entry.getKey();
-			JsonElement element = entry.getValue();
-			if("previous_attributes".equals(key) && !element.isJsonNull()) {
-				Map<String, Object> previousAttributes = new HashMap<String, Object>();
-				populateMapFromJSONObject(previousAttributes, element.getAsJsonObject());
-				event.setPreviousAttributes(previousAttributes);
-        	} else if ("result".equals(key)) {
-				String type = element.getAsJsonObject().get("object").getAsString();
-				Class<EasyPostResource> cl = objectMap.get(type);
-				EasyPostResource result = EasyPostResource.gson.fromJson(entry.getValue(), cl);
-				event.setResult(result);
-			}
-		}
-        event.setId(jsonObject.get("id").getAsString());
-        event.setDescription(jsonObject.get("description").getAsString());
-        event.setMode(jsonObject.get("mode").getAsString());
+    JsonObject jsonObject = json.getAsJsonObject();
+    for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
+      String key = entry.getKey();
+      JsonElement element = entry.getValue();
+      if ("previous_attributes".equals(key) && !element.isJsonNull()) {
+        Map<String, Object> previousAttributes = new HashMap<String, Object>();
+        populateMapFromJSONObject(previousAttributes, element.getAsJsonObject());
+        event.setPreviousAttributes(previousAttributes);
+      } else if ("result".equals(key)) {
+        String type = element.getAsJsonObject().get("object").getAsString();
+        Class<EasyPostResource> cl = objectMap.get(type);
+        EasyPostResource result = EasyPostResource.gson.fromJson(entry.getValue(), cl);
+        event.setResult(result);
+      }
+    }
+    event.setId(jsonObject.get("id").getAsString());
+    event.setDescription(jsonObject.get("description").getAsString());
+    event.setMode(jsonObject.get("mode").getAsString());
 
-		return event;
-	}
+    return event;
+  }
 }

--- a/src/main/java/com/easypost/model/Fee.java
+++ b/src/main/java/com/easypost/model/Fee.java
@@ -1,36 +1,40 @@
 package com.easypost.model;
 
-public class Fee{
-    String type;
-    float amount;
-    Boolean charged;
-    Boolean refunded;
+public class Fee {
+  String type;
+  float amount;
+  Boolean charged;
+  Boolean refunded;
 
-    public String getType() {
-        return type;
-    }
-    public void setType(String type) {
-        this.type = type;
-    }
+  public String getType() {
+    return type;
+  }
 
-    public float getAmount() {
-        return amount;
-    }
-    public void setAmount(float amount) {
-        this.amount = amount;
-    }
+  public void setType(String type) {
+    this.type = type;
+  }
 
-    public Boolean getCharged() {
-        return charged;
-    }
-    public void setCharged(Boolean charged) {
-        this.charged = charged;
-    }
+  public float getAmount() {
+    return amount;
+  }
 
-    public Boolean getRefunded() {
-        return refunded;
-    }
-    public void setRefunded(Boolean refunded) {
-        this.refunded = refunded;
-    }
+  public void setAmount(float amount) {
+    this.amount = amount;
+  }
+
+  public Boolean getCharged() {
+    return charged;
+  }
+
+  public void setCharged(Boolean charged) {
+    this.charged = charged;
+  }
+
+  public Boolean getRefunded() {
+    return refunded;
+  }
+
+  public void setRefunded(Boolean refunded) {
+    this.refunded = refunded;
+  }
 }

--- a/src/main/java/com/easypost/model/Form.java
+++ b/src/main/java/com/easypost/model/Form.java
@@ -10,6 +10,7 @@ public class Form {
   public String getId() {
     return id;
   }
+
   public void setId(String id) {
     this.id = id;
   }
@@ -17,6 +18,7 @@ public class Form {
   public String getMode() {
     return mode;
   }
+
   public void setMode(String mode) {
     this.mode = mode;
   }
@@ -24,6 +26,7 @@ public class Form {
   public String getFormType() {
     return formType;
   }
+
   public void setFormType(String formType) {
     this.formType = formType;
   }
@@ -31,6 +34,7 @@ public class Form {
   public String getFormUrl() {
     return formUrl;
   }
+
   public void setFormUrl(String formUrl) {
     this.formUrl = formUrl;
   }
@@ -38,6 +42,7 @@ public class Form {
   public Boolean getSubmittedElectronically() {
     return submittedElectronically;
   }
+
   public void setSubmittedElectronically(Boolean submittedElectronically) {
     this.submittedElectronically = submittedElectronically;
   }

--- a/src/main/java/com/easypost/model/Insurance.java
+++ b/src/main/java/com/easypost/model/Insurance.java
@@ -4,105 +4,173 @@ import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 
-import com.google.gson.reflect.TypeToken;
-
 import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
 public class Insurance extends EasyPostResource {
-	public String id;
-	String mode;
-	String reference;
-	Address toAddress;
-	Address fromAddress;
-	Tracker tracker;
-	String provider;
-	String providerId;
-	String trackingCode;
-	String status;
-	String shipmentId;
-	Float amount;
-	List<String> messages;
+  public String id;
+  String mode;
+  String reference;
+  Address toAddress;
+  Address fromAddress;
+  Tracker tracker;
+  String provider;
+  String providerId;
+  String trackingCode;
+  String status;
+  String shipmentId;
+  Float amount;
+  List<String> messages;
 
-	public String getId() { return id; }
-	public void setId(String id) { this.id = id; }
+  public String getId() {
+    return id;
+  }
 
-	public String getMode() { return mode; }
-	public void setMode(String mode) { this.mode = mode; }
+  public void setId(String id) {
+    this.id = id;
+  }
 
-	public String getReference() { return reference; }
-	public void setReference(String reference) { this.reference = reference; }
+  public String getMode() {
+    return mode;
+  }
 
-	public Address getToAddress() { return toAddress; }
-	public void setToAddress(Address toAddress) { this.toAddress = toAddress; }
+  public void setMode(String mode) {
+    this.mode = mode;
+  }
 
-	public Address getFromAddress() { return fromAddress; }
-	public void setFromAddress(Address fromAddress) { this.fromAddress = fromAddress; }
+  public String getReference() {
+    return reference;
+  }
 
-	public Tracker getTracker() { return tracker; }
-	public void setTracker(Tracker tracker) { this.tracker = tracker; }
+  public void setReference(String reference) {
+    this.reference = reference;
+  }
 
-	public String getProvider() { return provider; }
-	public void setProvider(String provider) { this.provider = provider; }
+  public Address getToAddress() {
+    return toAddress;
+  }
 
-	public String getProviderId() { return providerId; }
-	public void setProviderId(String providerId) { this.providerId = providerId; }
+  public void setToAddress(Address toAddress) {
+    this.toAddress = toAddress;
+  }
 
-	public String getTrackingCode() { return trackingCode; }
-	public void setTrackingCode(String trackingCode) { this.trackingCode = trackingCode; }
+  public Address getFromAddress() {
+    return fromAddress;
+  }
 
-	public String getStatus() { return status; }
-	public void setStatus(String status) { this.status = status; }
+  public void setFromAddress(Address fromAddress) {
+    this.fromAddress = fromAddress;
+  }
 
-	public String getShipmentId() { return shipmentId; }
-	public void setShipmentId(String shipmentId) { this.shipmentId = shipmentId; }
+  public Tracker getTracker() {
+    return tracker;
+  }
 
-	public Float getAmount() { return amount; }
-	public void setAmount(Float amount) { this.amount = amount; }
+  public void setTracker(Tracker tracker) {
+    this.tracker = tracker;
+  }
 
-	public List<String> getMessages() { return messages; }
-	public void setMessages(List<String> messages) { this.messages = messages; }
+  public String getProvider() {
+    return provider;
+  }
 
-	// create
-	public static Insurance create(Map<String, Object> params) throws EasyPostException {
-		return create(params, null);
-	}
-	public static Insurance create(Map<String, Object> params, String apiKey) throws EasyPostException {
-		Map<String, Object> wrappedParams = new HashMap<String, Object>();
-		wrappedParams.put("insurance", params);
+  public void setProvider(String provider) {
+    this.provider = provider;
+  }
 
-		return request(RequestMethod.POST, classURL(Insurance.class), wrappedParams, Insurance.class, apiKey);
-	}
+  public String getProviderId() {
+    return providerId;
+  }
 
-	// retrieve
-	public static Insurance retrieve(String id) throws EasyPostException {
-		return retrieve(id, null);
-	}
-	public static Insurance retrieve(String id, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, instanceURL(Insurance.class, id), null, Insurance.class, apiKey);
-	}
+  public void setProviderId(String providerId) {
+    this.providerId = providerId;
+  }
 
-	// all
-	public static InsuranceCollection all(Map<String, Object> params) throws EasyPostException {
-		return all(params, null);
-	}
-	public static InsuranceCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, classURL(Insurance.class), params, InsuranceCollection.class, apiKey);
-	}
+  public String getTrackingCode() {
+    return trackingCode;
+  }
 
-	// refresh
-	public Insurance refresh() throws EasyPostException {
-		return this.refresh(null, null);
-	}
-	public Insurance refresh(Map<String, Object> params) throws EasyPostException {
-		return this.refresh(params, null);
-	}
-	public Insurance refresh(String apiKey) throws EasyPostException {
-		return this.refresh((Map<String, Object>) null, apiKey);
-	}
-	public Insurance refresh(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(
-			RequestMethod.GET,
-			String.format("%s", instanceURL(Insurance.class, this.getId())), params, Insurance.class, apiKey);
-	}
+  public void setTrackingCode(String trackingCode) {
+    this.trackingCode = trackingCode;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public String getShipmentId() {
+    return shipmentId;
+  }
+
+  public void setShipmentId(String shipmentId) {
+    this.shipmentId = shipmentId;
+  }
+
+  public Float getAmount() {
+    return amount;
+  }
+
+  public void setAmount(Float amount) {
+    this.amount = amount;
+  }
+
+  public List<String> getMessages() {
+    return messages;
+  }
+
+  public void setMessages(List<String> messages) {
+    this.messages = messages;
+  }
+
+  // create
+  public static Insurance create(Map<String, Object> params) throws EasyPostException {
+    return create(params, null);
+  }
+
+  public static Insurance create(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("insurance", params);
+
+    return request(RequestMethod.POST, classURL(Insurance.class), wrappedParams, Insurance.class, apiKey);
+  }
+
+  // retrieve
+  public static Insurance retrieve(String id) throws EasyPostException {
+    return retrieve(id, null);
+  }
+
+  public static Insurance retrieve(String id, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, instanceURL(Insurance.class, id), null, Insurance.class, apiKey);
+  }
+
+  // all
+  public static InsuranceCollection all(Map<String, Object> params) throws EasyPostException {
+    return all(params, null);
+  }
+
+  public static InsuranceCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, classURL(Insurance.class), params, InsuranceCollection.class, apiKey);
+  }
+
+  // refresh
+  public Insurance refresh() throws EasyPostException {
+    return this.refresh(null, null);
+  }
+
+  public Insurance refresh(Map<String, Object> params) throws EasyPostException {
+    return this.refresh(params, null);
+  }
+
+  public Insurance refresh(String apiKey) throws EasyPostException {
+    return this.refresh((Map<String, Object>) null, apiKey);
+  }
+
+  public Insurance refresh(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, String.format("%s", instanceURL(Insurance.class, this.getId())), params,
+        Insurance.class, apiKey);
+  }
 }

--- a/src/main/java/com/easypost/model/InsuranceCollection.java
+++ b/src/main/java/com/easypost/model/InsuranceCollection.java
@@ -10,12 +10,15 @@ public class InsuranceCollection extends EasyPostResource {
   public List<Insurance> getInsurances() {
     return insurances;
   }
+
   public void setInsurances(List<Insurance> insurances) {
     this.insurances = insurances;
   }
+
   public Boolean getHasMore() {
     return hasMore;
   }
+
   public void setHasMore(Boolean hasMore) {
     this.hasMore = hasMore;
   }

--- a/src/main/java/com/easypost/model/Order.java
+++ b/src/main/java/com/easypost/model/Order.java
@@ -4,8 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 
-import com.google.gson.reflect.TypeToken;
-
 import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
@@ -27,6 +25,7 @@ public class Order extends EasyPostResource {
   public String getId() {
     return id;
   }
+
   public void setId(String id) {
     this.id = id;
   }
@@ -34,6 +33,7 @@ public class Order extends EasyPostResource {
   public String getMode() {
     return mode;
   }
+
   public void setMode(String mode) {
     this.mode = mode;
   }
@@ -41,6 +41,7 @@ public class Order extends EasyPostResource {
   public String getReference() {
     return reference;
   }
+
   public void setReference(String reference) {
     this.reference = reference;
   }
@@ -48,6 +49,7 @@ public class Order extends EasyPostResource {
   public Boolean getIsReturn() {
     return isReturn;
   }
+
   public void setIsReturn(Boolean isReturn) {
     this.isReturn = isReturn;
   }
@@ -55,6 +57,7 @@ public class Order extends EasyPostResource {
   public Address getToAddress() {
     return toAddress;
   }
+
   public void setToAddress(Address toAddress) {
     this.toAddress = toAddress;
   }
@@ -62,6 +65,7 @@ public class Order extends EasyPostResource {
   public Address getBuyerAddress() {
     return buyerAddress;
   }
+
   public void setBuyerAddress(Address buyerAddress) {
     this.buyerAddress = buyerAddress;
   }
@@ -69,6 +73,7 @@ public class Order extends EasyPostResource {
   public Address getFromAddress() {
     return fromAddress;
   }
+
   public void setFromAddress(Address fromAddress) {
     this.fromAddress = fromAddress;
   }
@@ -76,6 +81,7 @@ public class Order extends EasyPostResource {
   public Address getReturnAddress() {
     return returnAddress;
   }
+
   public void setReturnAddress(Address returnAddress) {
     this.returnAddress = returnAddress;
   }
@@ -83,6 +89,7 @@ public class Order extends EasyPostResource {
   public CustomsInfo getCustomsInfo() {
     return customsInfo;
   }
+
   public void setCustomsInfo(CustomsInfo customsInfo) {
     this.customsInfo = customsInfo;
   }
@@ -90,6 +97,7 @@ public class Order extends EasyPostResource {
   public List<Shipment> getShipments() {
     return shipments;
   }
+
   public void setShipments(List<Shipment> shipments) {
     this.shipments = shipments;
   }
@@ -97,6 +105,7 @@ public class Order extends EasyPostResource {
   public List<Rate> getRates() {
     return rates;
   }
+
   public void setRates(List<Rate> rates) {
     this.rates = rates;
   }
@@ -104,6 +113,7 @@ public class Order extends EasyPostResource {
   public Map<String, Object> getOptions() {
     return options;
   }
+
   public void setOptions(Map<String, Object> options) {
     this.options = options;
   }
@@ -111,15 +121,16 @@ public class Order extends EasyPostResource {
   public List<ShipmentMessage> getMessages() {
     return messages;
   }
+
   public void setMessages(List<ShipmentMessage> messages) {
     this.messages = messages;
   }
-
 
   // create
   public static Order create(Map<String, Object> params) throws EasyPostException {
     return create(params, null);
   }
+
   public static Order create(Map<String, Object> params, String apiKey) throws EasyPostException {
     Map<String, Object> wrappedParams = new HashMap<String, Object>();
     wrappedParams.put("order", params);
@@ -131,6 +142,7 @@ public class Order extends EasyPostResource {
   public static Order retrieve(String id) throws EasyPostException {
     return retrieve(id, null);
   }
+
   public static Order retrieve(String id, String apiKey) throws EasyPostException {
     return request(RequestMethod.GET, instanceURL(Order.class, id), null, Order.class, apiKey);
   }
@@ -139,32 +151,36 @@ public class Order extends EasyPostResource {
   public Order refresh() throws EasyPostException {
     return this.refresh(null, null);
   }
+
   public Order refresh(Map<String, Object> params) throws EasyPostException {
     return this.refresh(params, null);
   }
+
   public Order refresh(String apiKey) throws EasyPostException {
     return this.refresh((Map<String, Object>) null, apiKey);
   }
+
   public Order refresh(Map<String, Object> params, String apiKey) throws EasyPostException {
-    return request(
-      RequestMethod.GET,
-      String.format("%s", instanceURL(Order.class, this.getId())), params, Order.class, apiKey);
+    return request(RequestMethod.GET, String.format("%s", instanceURL(Order.class, this.getId())), params, Order.class,
+        apiKey);
   }
 
   // get rates
   public Order newRates() throws EasyPostException {
     return this.newRates(null, null);
   }
+
   public Order newRates(Map<String, Object> params) throws EasyPostException {
     return this.newRates(params, null);
   }
+
   public Order newRates(String apiKey) throws EasyPostException {
     return this.newRates((Map<String, Object>) null, apiKey);
   }
+
   public Order newRates(Map<String, Object> params, String apiKey) throws EasyPostException {
-    Order response = request(
-            RequestMethod.GET,
-            String.format("%s/rates", instanceURL(Order.class, this.getId())), params, Order.class, apiKey);
+    Order response = request(RequestMethod.GET, String.format("%s/rates", instanceURL(Order.class, this.getId())),
+        params, Order.class, apiKey);
 
     this.merge(this, response);
     return this;
@@ -174,6 +190,7 @@ public class Order extends EasyPostResource {
   public Order buy(Map<String, Object> params) throws EasyPostException {
     return this.buy(params, null);
   }
+
   public Order buy(Rate rate) throws EasyPostException {
     Map<String, Object> params = new HashMap<String, Object>();
     params.put("carrier", rate.carrier);
@@ -181,13 +198,13 @@ public class Order extends EasyPostResource {
 
     return this.buy(params, null);
   }
+
   public Order buy(Map<String, Object> params, String apiKey) throws EasyPostException {
-    Order response = request(
-      RequestMethod.POST,
-      String.format("%s/buy", instanceURL(Order.class, this.getId())), params, Order.class, apiKey);
+    Order response = request(RequestMethod.POST, String.format("%s/buy", instanceURL(Order.class, this.getId())),
+        params, Order.class, apiKey);
 
     this.merge(this, response);
-      return this;
+    return this;
   }
 
 }

--- a/src/main/java/com/easypost/model/OrderCollection.java
+++ b/src/main/java/com/easypost/model/OrderCollection.java
@@ -10,12 +10,15 @@ public class OrderCollection extends EasyPostResource {
   public List<Order> getOrders() {
     return orders;
   }
+
   public void setOrders(List<Order> orders) {
     this.orders = orders;
   }
+
   public Boolean getHasMore() {
     return hasMore;
   }
+
   public void setHasMore(Boolean hasMore) {
     this.hasMore = hasMore;
   }

--- a/src/main/java/com/easypost/model/Parcel.java
+++ b/src/main/java/com/easypost/model/Parcel.java
@@ -1,6 +1,5 @@
 package com.easypost.model;
 
-import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -8,81 +7,89 @@ import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
 public class Parcel extends EasyPostResource {
-	public String id;
-	String predefinedPackage;
-	Float weight;
-	Float length;
-	Float width;
-	Float height;
-	
-	public String getId() {
-		return id;
-	}
-	public void setId(String id) {
-		this.id = id;
-	}
+  public String id;
+  String predefinedPackage;
+  Float weight;
+  Float length;
+  Float width;
+  Float height;
 
-	public String getPredefinedPackage() {
-		return predefinedPackage;
-	}
-	public void setPredefinedPackage(String predefinedPackage) {
-		this.predefinedPackage = predefinedPackage;
-	}
+  public String getId() {
+    return id;
+  }
 
-	public Float getWeight() {
-		return weight;
-	}
-	public void setWeight(Float weight) {
-		this.weight = weight;
-	}
+  public void setId(String id) {
+    this.id = id;
+  }
 
-	public Float getLength() {
-		return length;
-	}
-	public void setLength(Float length) {
-		this.length = length;
-	}
+  public String getPredefinedPackage() {
+    return predefinedPackage;
+  }
 
-	public Float getWidth() {
-		return width;
-	}
-	public void setWidth(Float width) {
-		this.width = width;
-	}
+  public void setPredefinedPackage(String predefinedPackage) {
+    this.predefinedPackage = predefinedPackage;
+  }
 
-	public Float getHeight() {
-		return height;
-	}
-	public void setHeight(Float height) {
-		this.height = height;
-	}
+  public Float getWeight() {
+    return weight;
+  }
 
+  public void setWeight(Float weight) {
+    this.weight = weight;
+  }
 
-	// create
-	public static Parcel create(Map<String, Object> params) throws EasyPostException {
-		return create(params, null);
-	}
-	public static Parcel create(Map<String, Object> params, String apiKey) throws EasyPostException {
-		Map<String, Object> wrappedParams = new HashMap<String, Object>();
-		wrappedParams.put("parcel", params);
-		
-		return request(RequestMethod.POST, classURL(Parcel.class), wrappedParams, Parcel.class, apiKey);
-	}
+  public Float getLength() {
+    return length;
+  }
 
-	// retrieve
-	public static Parcel retrieve(String id) throws EasyPostException {
-		return retrieve(id, null);
-	}
-	public static Parcel retrieve(String id, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, instanceURL(Parcel.class, id), null, Parcel.class, apiKey);
-	}
+  public void setLength(Float length) {
+    this.length = length;
+  }
 
-	// all
-	public static ParcelCollection all(Map<String, Object> params) throws EasyPostException {
-		return all(params, null);
-	}
-	public static ParcelCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, classURL(Parcel.class), params, ParcelCollection.class, apiKey);
-	}
+  public Float getWidth() {
+    return width;
+  }
+
+  public void setWidth(Float width) {
+    this.width = width;
+  }
+
+  public Float getHeight() {
+    return height;
+  }
+
+  public void setHeight(Float height) {
+    this.height = height;
+  }
+
+  // create
+  public static Parcel create(Map<String, Object> params) throws EasyPostException {
+    return create(params, null);
+  }
+
+  public static Parcel create(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("parcel", params);
+
+    return request(RequestMethod.POST, classURL(Parcel.class), wrappedParams, Parcel.class, apiKey);
+  }
+
+  // retrieve
+  public static Parcel retrieve(String id) throws EasyPostException {
+    return retrieve(id, null);
+  }
+
+  public static Parcel retrieve(String id, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, instanceURL(Parcel.class, id), null, Parcel.class, apiKey);
+  }
+
+  // all
+  public static ParcelCollection all(Map<String, Object> params) throws EasyPostException {
+    return all(params, null);
+  }
+
+  public static ParcelCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, classURL(Parcel.class), params, ParcelCollection.class, apiKey);
+  }
 
 }

--- a/src/main/java/com/easypost/model/ParcelCollection.java
+++ b/src/main/java/com/easypost/model/ParcelCollection.java
@@ -10,12 +10,15 @@ public class ParcelCollection extends EasyPostResource {
   public List<Parcel> getParcels() {
     return parcels;
   }
+
   public void setParcels(List<Parcel> parcels) {
     this.parcels = parcels;
   }
+
   public Boolean getHasMore() {
     return hasMore;
   }
+
   public void setHasMore(Boolean hasMore) {
     this.hasMore = hasMore;
   }

--- a/src/main/java/com/easypost/model/Pickup.java
+++ b/src/main/java/com/easypost/model/Pickup.java
@@ -9,145 +9,206 @@ import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
 public class Pickup extends EasyPostResource {
-    public String id;
-    String mode;
-    String status;
-    String reference;
-    Date minDatetime;
-    Date maxDatetime;
-    Boolean isAccountAddress;
-    String instructions;
-    List<ShipmentMessage> messages;
-    String confirmation;
-    Address address;
-    List<CarrierAccount> carrierAccounts;
-    List<PickupRate> pickupRates;
+  public String id;
+  String mode;
+  String status;
+  String reference;
+  Date minDatetime;
+  Date maxDatetime;
+  Boolean isAccountAddress;
+  String instructions;
+  List<ShipmentMessage> messages;
+  String confirmation;
+  Address address;
+  List<CarrierAccount> carrierAccounts;
+  List<PickupRate> pickupRates;
 
-    public String getId() {
-        return id;
-    }
-    public void setId(String id) {
-        this.id = id;
-    }
+  public String getId() {
+    return id;
+  }
 
-    public String getMode() {
-        return mode;
-    }
-    public void setMode(String mode) {
-        this.mode = mode;
-    }
+  public void setId(String id) {
+    this.id = id;
+  }
 
-    public String getStatus() {
-        return status;
-    }
-    public void setStatus(String status) {
-        this.status = status;
-    }
+  public String getMode() {
+    return mode;
+  }
 
-    public String getReference() { return reference; }
-    public void setReference(String reference) { this.reference = reference; }
+  public void setMode(String mode) {
+    this.mode = mode;
+  }
 
-    public Date getMinDatetime() { return minDatetime; }
-    public void setMinDatetime(Date minDatetime) { this.minDatetime = minDatetime; }
+  public String getStatus() {
+    return status;
+  }
 
-    public Date getMaxDatetime() { return maxDatetime; }
-    public void setMaxDatetime(Date maxDatetime) { this.maxDatetime = maxDatetime; }
+  public void setStatus(String status) {
+    this.status = status;
+  }
 
-    public Boolean getIsAccountAddress() { return isAccountAddress; }
-    public void setIsAccountAddress(Boolean isAccountAddress) { this.isAccountAddress = isAccountAddress; }
+  public String getReference() {
+    return reference;
+  }
 
-    public String getInstructions() { return instructions; }
-    public void setInstructions(String instructions) { this.instructions = instructions; }
+  public void setReference(String reference) {
+    this.reference = reference;
+  }
 
-    public List<ShipmentMessage> getMessages() { return messages; }
-    public void setMessages(List<ShipmentMessage> messages) { this.messages = messages; }
+  public Date getMinDatetime() {
+    return minDatetime;
+  }
 
-    public String getConfirmation() { return confirmation; }
-    public void setConfirmation(String confirmation) { this.confirmation = confirmation; }
+  public void setMinDatetime(Date minDatetime) {
+    this.minDatetime = minDatetime;
+  }
 
-    public Address getAddress() { return address; }
-    public void setAddress(Address address) { this.address = address; }
+  public Date getMaxDatetime() {
+    return maxDatetime;
+  }
 
-    public List<CarrierAccount> getCarrierAccounts() { return carrierAccounts; }
-    public void setCarrierAccounts(List<CarrierAccount> carrierAccounts) { this.carrierAccounts = carrierAccounts; }
+  public void setMaxDatetime(Date maxDatetime) {
+    this.maxDatetime = maxDatetime;
+  }
 
-    public List<PickupRate> getPickupRates() { return pickupRates; }
-    public void setPickupRates(List<PickupRate> pickupRates) { this.pickupRates = pickupRates; }
+  public Boolean getIsAccountAddress() {
+    return isAccountAddress;
+  }
 
+  public void setIsAccountAddress(Boolean isAccountAddress) {
+    this.isAccountAddress = isAccountAddress;
+  }
 
-    // create
-    public static Pickup create(Map<String, Object> params) throws EasyPostException {
-        return create(params, null);
-    }
-    public static Pickup create(Map<String, Object> params, String apiKey) throws EasyPostException {
-        Map<String, Object> wrappedParams = new HashMap<String, Object>();
-        wrappedParams.put("pickup", params);
+  public String getInstructions() {
+    return instructions;
+  }
 
-        return request(RequestMethod.POST, classURL(Pickup.class), wrappedParams, Pickup.class, apiKey);
-    }
+  public void setInstructions(String instructions) {
+    this.instructions = instructions;
+  }
 
-    // retrieve
-    public static Pickup retrieve(String id) throws EasyPostException {
-        return retrieve(id, null);
-    }
-    public static Pickup retrieve(String id, String apiKey) throws EasyPostException {
-        return request(RequestMethod.GET, instanceURL(Pickup.class, id), null, Pickup.class, apiKey);
-    }
+  public List<ShipmentMessage> getMessages() {
+    return messages;
+  }
 
-    // refresh
-    public Pickup refresh() throws EasyPostException {
-        return this.refresh(null, null);
-    }
-    public Pickup refresh(Map<String, Object> params) throws EasyPostException {
-        return this.refresh(params, null);
-    }
-    public Pickup refresh(String apiKey) throws EasyPostException {
-        return this.refresh((Map<String, Object>) null, apiKey);
-    }
-    public Pickup refresh(Map<String, Object> params, String apiKey) throws EasyPostException {
-        return request(
-                RequestMethod.GET,
-                String.format("%s", instanceURL(Pickup.class, this.getId())), params, Pickup.class, apiKey);
-    }
+  public void setMessages(List<ShipmentMessage> messages) {
+    this.messages = messages;
+  }
 
-    // buy
-    public Pickup buy() throws EasyPostException {
-        return this.buy(null, null);
-    }
-    public Pickup buy(Map<String, Object> params) throws EasyPostException {
-        return this.buy(params, null);
-    }
-    public Pickup buy(String apiKey) throws EasyPostException {
-        return this.buy((Map<String, Object>) null, apiKey);
-    }
-    public Pickup buy(PickupRate pickupRate) throws EasyPostException {
-        Map<String, Object> params = new HashMap<String, Object>();
-        params.put("rate", pickupRate);
+  public String getConfirmation() {
+    return confirmation;
+  }
 
-        return this.buy(params, null);
-    }
-    public Pickup buy(Map<String, Object> params, String apiKey) throws EasyPostException {
-        Pickup response = request(
-                RequestMethod.POST,
-                String.format("%s/buy", instanceURL(Pickup.class, this.getId())), params, Pickup.class, apiKey);
+  public void setConfirmation(String confirmation) {
+    this.confirmation = confirmation;
+  }
 
-        this.merge(this, response);
-        return this;
-    }
+  public Address getAddress() {
+    return address;
+  }
 
-    // cancel
-    public Pickup cancel() throws EasyPostException {
-        return this.cancel(null, null);
-    }
-    public Pickup cancel(Map<String, Object> params) throws EasyPostException {
-        return this.cancel(params, null);
-    }
-    public Pickup cancel(String apiKey) throws EasyPostException {
-        return this.cancel((Map<String, Object>) null, apiKey);
-    }
-    public Pickup cancel(Map<String, Object> params, String apiKey) throws EasyPostException {
-        return request(
-                RequestMethod.POST,
-                String.format("%s/cancel", instanceURL(Pickup.class, this.getId())), params, Pickup.class, apiKey);
-    }
+  public void setAddress(Address address) {
+    this.address = address;
+  }
+
+  public List<CarrierAccount> getCarrierAccounts() {
+    return carrierAccounts;
+  }
+
+  public void setCarrierAccounts(List<CarrierAccount> carrierAccounts) {
+    this.carrierAccounts = carrierAccounts;
+  }
+
+  public List<PickupRate> getPickupRates() {
+    return pickupRates;
+  }
+
+  public void setPickupRates(List<PickupRate> pickupRates) {
+    this.pickupRates = pickupRates;
+  }
+
+  // create
+  public static Pickup create(Map<String, Object> params) throws EasyPostException {
+    return create(params, null);
+  }
+
+  public static Pickup create(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("pickup", params);
+
+    return request(RequestMethod.POST, classURL(Pickup.class), wrappedParams, Pickup.class, apiKey);
+  }
+
+  // retrieve
+  public static Pickup retrieve(String id) throws EasyPostException {
+    return retrieve(id, null);
+  }
+
+  public static Pickup retrieve(String id, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, instanceURL(Pickup.class, id), null, Pickup.class, apiKey);
+  }
+
+  // refresh
+  public Pickup refresh() throws EasyPostException {
+    return this.refresh(null, null);
+  }
+
+  public Pickup refresh(Map<String, Object> params) throws EasyPostException {
+    return this.refresh(params, null);
+  }
+
+  public Pickup refresh(String apiKey) throws EasyPostException {
+    return this.refresh((Map<String, Object>) null, apiKey);
+  }
+
+  public Pickup refresh(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, String.format("%s", instanceURL(Pickup.class, this.getId())), params,
+        Pickup.class, apiKey);
+  }
+
+  // buy
+  public Pickup buy() throws EasyPostException {
+    return this.buy(null, null);
+  }
+
+  public Pickup buy(Map<String, Object> params) throws EasyPostException {
+    return this.buy(params, null);
+  }
+
+  public Pickup buy(String apiKey) throws EasyPostException {
+    return this.buy((Map<String, Object>) null, apiKey);
+  }
+
+  public Pickup buy(PickupRate pickupRate) throws EasyPostException {
+    Map<String, Object> params = new HashMap<String, Object>();
+    params.put("rate", pickupRate);
+
+    return this.buy(params, null);
+  }
+
+  public Pickup buy(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Pickup response = request(RequestMethod.POST, String.format("%s/buy", instanceURL(Pickup.class, this.getId())),
+        params, Pickup.class, apiKey);
+
+    this.merge(this, response);
+    return this;
+  }
+
+  // cancel
+  public Pickup cancel() throws EasyPostException {
+    return this.cancel(null, null);
+  }
+
+  public Pickup cancel(Map<String, Object> params) throws EasyPostException {
+    return this.cancel(params, null);
+  }
+
+  public Pickup cancel(String apiKey) throws EasyPostException {
+    return this.cancel((Map<String, Object>) null, apiKey);
+  }
+
+  public Pickup cancel(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.POST, String.format("%s/cancel", instanceURL(Pickup.class, this.getId())), params,
+        Pickup.class, apiKey);
+  }
 }

--- a/src/main/java/com/easypost/model/PickupCollection.java
+++ b/src/main/java/com/easypost/model/PickupCollection.java
@@ -4,19 +4,22 @@ import java.util.List;
 import com.easypost.net.EasyPostResource;
 
 public class PickupCollection extends EasyPostResource {
-    List<Pickup> pickups;
-    Boolean hasMore;
+  List<Pickup> pickups;
+  Boolean hasMore;
 
-    public List<Pickup> getPickups() {
-        return pickups;
-    }
-    public void setPickups(List<Pickup> pickups) {
-        this.pickups = pickups;
-    }
-    public Boolean getHasMore() {
-        return hasMore;
-    }
-    public void setHasMore(Boolean hasMore) {
-        this.hasMore = hasMore;
-    }
+  public List<Pickup> getPickups() {
+    return pickups;
+  }
+
+  public void setPickups(List<Pickup> pickups) {
+    this.pickups = pickups;
+  }
+
+  public Boolean getHasMore() {
+    return hasMore;
+  }
+
+  public void setHasMore(Boolean hasMore) {
+    this.hasMore = hasMore;
+  }
 }

--- a/src/main/java/com/easypost/model/PickupRate.java
+++ b/src/main/java/com/easypost/model/PickupRate.java
@@ -3,32 +3,58 @@ package com.easypost.model;
 import com.easypost.net.EasyPostResource;
 
 public class PickupRate extends EasyPostResource {
-    public String id;
-    String mode;
-    String carrier;
-    String service;
-    Float rate;
-    String currency;
+  public String id;
+  String mode;
+  String carrier;
+  String service;
+  Float rate;
+  String currency;
 
-    public String getId() {
-        return id;
-    }
-    public void setId(String id) {
-        this.id = id;
-    }
+  public String getId() {
+    return id;
+  }
 
-    public String getMode() { return mode; }
-    public void setMode(String mode) { this.mode = mode; }
+  public void setId(String id) {
+    this.id = id;
+  }
 
-    public String getCarrier() { return carrier; }
-    public void setCarrier(String carrier) { this.carrier = carrier; }
+  public String getMode() {
+    return mode;
+  }
 
-    public String getService() { return service; }
-    public void setService(String service) { this.service = service; }
+  public void setMode(String mode) {
+    this.mode = mode;
+  }
 
-    public Float getRate() { return rate; }
-    public void setRate(Float rate) { this.rate = rate; }
+  public String getCarrier() {
+    return carrier;
+  }
 
-    public String getCurrency() { return currency; }
-    public void setCurrency(String currency) { this.currency = currency; }
+  public void setCarrier(String carrier) {
+    this.carrier = carrier;
+  }
+
+  public String getService() {
+    return service;
+  }
+
+  public void setService(String service) {
+    this.service = service;
+  }
+
+  public Float getRate() {
+    return rate;
+  }
+
+  public void setRate(Float rate) {
+    this.rate = rate;
+  }
+
+  public String getCurrency() {
+    return currency;
+  }
+
+  public void setCurrency(String currency) {
+    this.currency = currency;
+  }
 }

--- a/src/main/java/com/easypost/model/PostageLabel.java
+++ b/src/main/java/com/easypost/model/PostageLabel.java
@@ -1,15 +1,10 @@
 package com.easypost.model;
 
-import java.util.List;
-import java.util.HashMap;
-import java.util.Map;
-
-import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
 public class PostageLabel extends EasyPostResource {
-	public String id;
-	int dateAdvance;
+  public String id;
+  int dateAdvance;
   String integratedForm;
   int labelResolution;
   String labelSize;
@@ -30,150 +25,171 @@ public class PostageLabel extends EasyPostResource {
   String labelZplUrl;
   String labelZplFileType;
 
-	public String getId() {
-		return id;
-	}
-	private void setId(String id) {
-		this.id = id;
-	}
+  public String getId() {
+    return id;
+  }
 
-	public int getDateAdvance() {
-		return dateAdvance;
-	}
-	private void setDateAdvance(int dateAdvance) {
-		this.dateAdvance = dateAdvance;
-	}
+  private void setId(String id) {
+    this.id = id;
+  }
 
-	public String getIntegratedForm() {
-		return integratedForm;
-	}
-	private void setIntegratedForm(String integratedForm) {
-		this.integratedForm = integratedForm;
-	}
+  public int getDateAdvance() {
+    return dateAdvance;
+  }
 
-	public int getLabelResolution() {
-		return labelResolution;
-	}
-	private void setLabelResolution(int labelResolution) {
-		this.labelResolution = labelResolution;
-	}
+  private void setDateAdvance(int dateAdvance) {
+    this.dateAdvance = dateAdvance;
+  }
 
-	public String getLabelSize() {
-		return labelSize;
-	}
-	private void setLabelSize(String labelSize) {
-		this.labelSize = labelSize;
-	}
+  public String getIntegratedForm() {
+    return integratedForm;
+  }
 
-	public String getLabelType() {
-		return labelType;
-	}
-	private void setLabelType(String labelType) {
-		this.labelType = labelType;
-	}
+  private void setIntegratedForm(String integratedForm) {
+    this.integratedForm = integratedForm;
+  }
 
-	public String getLabelUrl() {
-		return labelUrl;
-	}
-	private void setLabelUrl(String labelUrl) {
-		this.labelUrl = labelUrl;
-	}
+  public int getLabelResolution() {
+    return labelResolution;
+  }
 
-	public String getLabelFile() {
-		return labelFile;
-	}
-	private void setLabelFile(String labelFile) {
-		this.labelFile = labelFile;
-	}
+  private void setLabelResolution(int labelResolution) {
+    this.labelResolution = labelResolution;
+  }
 
-	public String getLabelFileType() {
-		return labelFileType;
-	}
-	private void setLabelFileType(String labelFileType) {
-		this.labelFileType = labelFileType;
-	}
+  public String getLabelSize() {
+    return labelSize;
+  }
 
-	public String getLabelPdfSize() {
-		return labelPdfSize;
-	}
-	private void setLabelPdfSize(String labelPdfSize) {
-		this.labelPdfSize = labelPdfSize;
-	}
+  private void setLabelSize(String labelSize) {
+    this.labelSize = labelSize;
+  }
 
-	public String getPdfLabelType() {
-		return labelPdfType;
-	}
-	private void setLabelPdfType(String labelPdfType) {
-		this.labelPdfType = labelPdfType;
-	}
+  public String getLabelType() {
+    return labelType;
+  }
 
-	public String getLabelPdfUrl() {
-		return labelPdfUrl;
-	}
-	private void setLabelPdfUrl(String labelPdfUrl) {
-		this.labelPdfUrl = labelPdfUrl;
-	}
+  private void setLabelType(String labelType) {
+    this.labelType = labelType;
+  }
 
-	public String getLabelPdfFileType() {
-		return labelPdfFileType;
-	}
-	private void setLabelPdfFileType(String labelPdfFileType) {
-		this.labelPdfFileType = labelPdfFileType;
-	}
+  public String getLabelUrl() {
+    return labelUrl;
+  }
 
-	public String getLabelEpl2Size() {
-		return labelEpl2Size;
-	}
-	private void setLabelEpl2Size(String labelEpl2Size) {
-		this.labelEpl2Size = labelEpl2Size;
-	}
+  private void setLabelUrl(String labelUrl) {
+    this.labelUrl = labelUrl;
+  }
 
-	public String getEpl2LabelType() {
-		return labelEpl2Type;
-	}
-	private void setLabelEpl2Type(String labelEpl2Type) {
-		this.labelEpl2Type = labelEpl2Type;
-	}
+  public String getLabelFile() {
+    return labelFile;
+  }
 
-	public String getLabelEpl2Url() {
-		return labelEpl2Url;
-	}
-	private void setLabelEpl2Url(String labelEpl2Url) {
-		this.labelEpl2Url = labelEpl2Url;
-	}
+  private void setLabelFile(String labelFile) {
+    this.labelFile = labelFile;
+  }
 
-	public String getLabelEpl2FileType() {
-		return labelEpl2FileType;
-	}
-	private void setLabelEpl2FileType(String labelEpl2FileType) {
-		this.labelEpl2FileType = labelEpl2FileType;
-	}
+  public String getLabelFileType() {
+    return labelFileType;
+  }
 
-	public String getLabelZplSize() {
-		return labelZplSize;
-	}
-	private void setLabelZplSize(String labelZplSize) {
-		this.labelZplSize = labelZplSize;
-	}
+  private void setLabelFileType(String labelFileType) {
+    this.labelFileType = labelFileType;
+  }
 
-	public String getZplLabelType() {
-		return labelZplType;
-	}
-	private void setLabelZplType(String labelZplType) {
-		this.labelZplType = labelZplType;
-	}
+  public String getLabelPdfSize() {
+    return labelPdfSize;
+  }
 
-	public String getLabelZplUrl() {
-		return labelZplUrl;
-	}
-	private void setLabelZplUrl(String labelZplUrl) {
-		this.labelZplUrl = labelZplUrl;
-	}
+  private void setLabelPdfSize(String labelPdfSize) {
+    this.labelPdfSize = labelPdfSize;
+  }
 
-	public String getLabelZplFileType() {
-		return labelZplFileType;
-	}
-	private void setLabelZplFileType(String labelZplFileType) {
-		this.labelZplFileType = labelZplFileType;
-	}
+  public String getPdfLabelType() {
+    return labelPdfType;
+  }
+
+  private void setLabelPdfType(String labelPdfType) {
+    this.labelPdfType = labelPdfType;
+  }
+
+  public String getLabelPdfUrl() {
+    return labelPdfUrl;
+  }
+
+  private void setLabelPdfUrl(String labelPdfUrl) {
+    this.labelPdfUrl = labelPdfUrl;
+  }
+
+  public String getLabelPdfFileType() {
+    return labelPdfFileType;
+  }
+
+  private void setLabelPdfFileType(String labelPdfFileType) {
+    this.labelPdfFileType = labelPdfFileType;
+  }
+
+  public String getLabelEpl2Size() {
+    return labelEpl2Size;
+  }
+
+  private void setLabelEpl2Size(String labelEpl2Size) {
+    this.labelEpl2Size = labelEpl2Size;
+  }
+
+  public String getEpl2LabelType() {
+    return labelEpl2Type;
+  }
+
+  private void setLabelEpl2Type(String labelEpl2Type) {
+    this.labelEpl2Type = labelEpl2Type;
+  }
+
+  public String getLabelEpl2Url() {
+    return labelEpl2Url;
+  }
+
+  private void setLabelEpl2Url(String labelEpl2Url) {
+    this.labelEpl2Url = labelEpl2Url;
+  }
+
+  public String getLabelEpl2FileType() {
+    return labelEpl2FileType;
+  }
+
+  private void setLabelEpl2FileType(String labelEpl2FileType) {
+    this.labelEpl2FileType = labelEpl2FileType;
+  }
+
+  public String getLabelZplSize() {
+    return labelZplSize;
+  }
+
+  private void setLabelZplSize(String labelZplSize) {
+    this.labelZplSize = labelZplSize;
+  }
+
+  public String getZplLabelType() {
+    return labelZplType;
+  }
+
+  private void setLabelZplType(String labelZplType) {
+    this.labelZplType = labelZplType;
+  }
+
+  public String getLabelZplUrl() {
+    return labelZplUrl;
+  }
+
+  private void setLabelZplUrl(String labelZplUrl) {
+    this.labelZplUrl = labelZplUrl;
+  }
+
+  public String getLabelZplFileType() {
+    return labelZplFileType;
+  }
+
+  private void setLabelZplFileType(String labelZplFileType) {
+    this.labelZplFileType = labelZplFileType;
+  }
 }

--- a/src/main/java/com/easypost/model/Rate.java
+++ b/src/main/java/com/easypost/model/Rate.java
@@ -1,9 +1,5 @@
 package com.easypost.model;
 
-import java.util.List;
-import java.util.HashMap;
-import java.util.Map;
-
 import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
@@ -28,6 +24,7 @@ public class Rate extends EasyPostResource {
   public String getId() {
     return id;
   }
+
   public void setId(String id) {
     this.id = id;
   }
@@ -35,20 +32,23 @@ public class Rate extends EasyPostResource {
   public String getCarrier() {
     return carrier;
   }
+
   public void setCarrier(String carrier) {
     this.carrier = carrier;
   }
 
   public String getService() {
-          return service;
+    return service;
   }
+
   public void setService(String service) {
-          this.service = service;
+    this.service = service;
   }
 
   public String getServiceCode() {
     return serviceCode;
   }
+
   public void setServiceCode(String serviceCode) {
     this.serviceCode = serviceCode;
   }
@@ -56,6 +56,7 @@ public class Rate extends EasyPostResource {
   public Float getRate() {
     return rate;
   }
+
   public void setRate(Float rate) {
     this.rate = rate;
   }
@@ -63,6 +64,7 @@ public class Rate extends EasyPostResource {
   public Float getListRate() {
     return listRate;
   }
+
   public void setListRate(Float listRate) {
     this.listRate = listRate;
   }
@@ -70,6 +72,7 @@ public class Rate extends EasyPostResource {
   public Float getRetailRate() {
     return retailRate;
   }
+
   public void setRetailRate(Float retailRate) {
     this.retailRate = retailRate;
   }
@@ -77,6 +80,7 @@ public class Rate extends EasyPostResource {
   public String getCurrency() {
     return currency;
   }
+
   public void setCurrency(String currency) {
     this.currency = currency;
   }
@@ -84,6 +88,7 @@ public class Rate extends EasyPostResource {
   public String getListCurrency() {
     return listCurrency;
   }
+
   public void setListCurrency(String listCurrency) {
     this.listCurrency = listCurrency;
   }
@@ -91,6 +96,7 @@ public class Rate extends EasyPostResource {
   public String getRetailCurrency() {
     return retailCurrency;
   }
+
   public void setRetailCurrency(String retailCurrency) {
     this.retailCurrency = retailCurrency;
   }
@@ -98,6 +104,7 @@ public class Rate extends EasyPostResource {
   public Number getDeliveryDays() {
     return deliveryDays;
   }
+
   public void setDeliveryDays(Number deliveryDays) {
     this.deliveryDays = deliveryDays;
   }
@@ -105,6 +112,7 @@ public class Rate extends EasyPostResource {
   public String getDeliveryDate() {
     return deliveryDate;
   }
+
   public void setDeliveryDate(String deliveryDate) {
     this.deliveryDate = deliveryDate;
   }
@@ -112,6 +120,7 @@ public class Rate extends EasyPostResource {
   public Boolean getDeliveryDateGuaranteed() {
     return deliveryDateGuaranteed;
   }
+
   public void setDeliveryDateGuaranteed(Boolean deliveryDateGuaranteed) {
     this.deliveryDateGuaranteed = deliveryDateGuaranteed;
   }
@@ -119,6 +128,7 @@ public class Rate extends EasyPostResource {
   public Number getEstDeliveryDays() {
     return estDeliveryDays;
   }
+
   public void setEstDeliveryDays(Number estDeliveryDays) {
     this.estDeliveryDays = estDeliveryDays;
   }
@@ -126,6 +136,7 @@ public class Rate extends EasyPostResource {
   public String getShipmentId() {
     return shipmentId;
   }
+
   public void setShipmentId(String shipmentId) {
     this.shipmentId = shipmentId;
   }
@@ -133,12 +144,14 @@ public class Rate extends EasyPostResource {
   public String getCarrierAccountId() {
     return carrierAccountId;
   }
+
   public void setCarrierAccountId(String carrierAccountId) {
     this.carrierAccountId = carrierAccountId;
   }
 
-
-  public Rate(String id, String carrier, String service, Float rate, String currency, Float listRate, String listCurrency, Float retailRate, String retailCurrency, Number deliveryDays, String deliveryDate, Boolean deliveryDateGuaranteed, Number estDeliveryDays, String shipmentId, String carrierAccountId) {
+  public Rate(String id, String carrier, String service, Float rate, String currency, Float listRate,
+      String listCurrency, Float retailRate, String retailCurrency, Number deliveryDays, String deliveryDate,
+      Boolean deliveryDateGuaranteed, Number estDeliveryDays, String shipmentId, String carrierAccountId) {
     this.id = id;
     this.carrier = carrier;
     this.service = service;
@@ -161,6 +174,7 @@ public class Rate extends EasyPostResource {
   public static Rate retrieve(String id) throws EasyPostException {
     return retrieve(id, null);
   }
+
   public static Rate retrieve(String id, String apiKey) throws EasyPostException {
     Rate response;
     response = request(RequestMethod.GET, instanceURL(Rate.class, id), null, Rate.class, apiKey);

--- a/src/main/java/com/easypost/model/RateDeserializer.java
+++ b/src/main/java/com/easypost/model/RateDeserializer.java
@@ -66,7 +66,7 @@ public class RateDeserializer implements JsonDeserializer<Rate> {
     if (jo.get("delivery_date_guaranteed").isJsonNull()) {
       deliveryDateGuaranteed = false;
     } else {
-      deliveryDateGuaranteed = new Boolean(jo.get("delivery_date_guaranteed").getAsString());
+      deliveryDateGuaranteed = Boolean.parseBoolean(jo.get("delivery_date_guaranteed").getAsString());
     }
 
     Number estDeliveryDays;
@@ -83,21 +83,11 @@ public class RateDeserializer implements JsonDeserializer<Rate> {
       shipmentID = jo.get("shipment_id").getAsString();
     }
 
-    return new Rate(
-        jo.get("id").getAsString(),
-        jo.get("carrier").getAsString(),
-        jo.get("service").getAsString(),
-        jo.get("rate").getAsFloat(),
-        currency,
-        listRate,
-        listCurrency,
-        retailRate,
-        retailCurrency,
-        deliveryDays,
-        deliveryDate,
-        deliveryDateGuaranteed,
-        estDeliveryDays,
-        shipmentID,
-        jo.get("carrier_account_id").getAsString());
+    // TODO: Unpack this list so each item is on its own line even with formatting
+    Rate rate = new Rate(jo.get("id").getAsString(), jo.get("carrier").getAsString(), jo.get("service").getAsString(),
+        jo.get("rate").getAsFloat(), currency, listRate, listCurrency, retailRate, retailCurrency, deliveryDays,
+        deliveryDate, deliveryDateGuaranteed, estDeliveryDays, shipmentID, jo.get("carrier_account_id").getAsString());
+
+    return rate;
   }
 }

--- a/src/main/java/com/easypost/model/Refund.java
+++ b/src/main/java/com/easypost/model/Refund.java
@@ -8,81 +8,89 @@ import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
 public class Refund extends EasyPostResource {
-	public String id;
-	String trackingCode;
-	String confirmationNumber;
-	String status;
-	String carrier;
-	String shipmentId;
-	
-	public String getId() {
-		return id;
-	}
-	public void setId(String id) {
-		this.id = id;
-	}
+  public String id;
+  String trackingCode;
+  String confirmationNumber;
+  String status;
+  String carrier;
+  String shipmentId;
 
-	public String getTrackingCode() {
-		return trackingCode;
-	}
-	public void setTrackingCode(String trackingCode) {
-		this.trackingCode = trackingCode;
-	}
+  public String getId() {
+    return id;
+  }
 
-	public String getConfirmationNumber() {
-		return confirmationNumber;
-	}
-	public void setConfirmationNumber(String confirmationNumber) {
-		this.confirmationNumber = confirmationNumber;
-	}
+  public void setId(String id) {
+    this.id = id;
+  }
 
-	public String getStatus() {
-		return status;
-	}
-	public void setStatus(String status) {
-		this.status = status;
-	}
+  public String getTrackingCode() {
+    return trackingCode;
+  }
 
-	public String getCarrier() {
-		return carrier;
-	}
-	public void setCarrier(String carrier) {
-		this.carrier = carrier;
-	}
+  public void setTrackingCode(String trackingCode) {
+    this.trackingCode = trackingCode;
+  }
 
-	public String getShipmentId() {
-		return shipmentId;
-	}
-	public void setShipmentId(String shipmentId) {
-		this.shipmentId = shipmentId;
-	}
+  public String getConfirmationNumber() {
+    return confirmationNumber;
+  }
 
+  public void setConfirmationNumber(String confirmationNumber) {
+    this.confirmationNumber = confirmationNumber;
+  }
 
-	// create
-	public static List<Refund> create(Map<String, Object> params) throws EasyPostException {
-		return create(params, null);
-	}
-	public static List<Refund> create(Map<String, Object> params, String apiKey) throws EasyPostException {
-		Map<String, Object> wrappedParams = new HashMap<String, Object>();
-		wrappedParams.put("refund", params);
-		
-		return request(RequestMethod.POST, classURL(Refund.class), wrappedParams, List.class, apiKey);
-	}
+  public String getStatus() {
+    return status;
+  }
 
-	// retrieve
-	public static Refund retrieve(String id) throws EasyPostException {
-		return retrieve(id, null);
-	}
-	public static Refund retrieve(String id, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, instanceURL(Refund.class, id), null, Refund.class, apiKey);
-	}
+  public void setStatus(String status) {
+    this.status = status;
+  }
 
-	// all
-	public static RefundCollection all(Map<String, Object> params) throws EasyPostException {
-		return all(params, null);
-	}
-	public static RefundCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, classURL(Refund.class), params, RefundCollection.class, apiKey);
-	}
+  public String getCarrier() {
+    return carrier;
+  }
+
+  public void setCarrier(String carrier) {
+    this.carrier = carrier;
+  }
+
+  public String getShipmentId() {
+    return shipmentId;
+  }
+
+  public void setShipmentId(String shipmentId) {
+    this.shipmentId = shipmentId;
+  }
+
+  // create
+  public static List<Refund> create(Map<String, Object> params) throws EasyPostException {
+    return create(params, null);
+  }
+
+  public static List<Refund> create(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("refund", params);
+
+    return request(RequestMethod.POST, classURL(Refund.class), wrappedParams, List.class, apiKey);
+  }
+
+  // retrieve
+  public static Refund retrieve(String id) throws EasyPostException {
+    return retrieve(id, null);
+  }
+
+  public static Refund retrieve(String id, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, instanceURL(Refund.class, id), null, Refund.class, apiKey);
+  }
+
+  // all
+  public static RefundCollection all(Map<String, Object> params) throws EasyPostException {
+    return all(params, null);
+  }
+
+  public static RefundCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, classURL(Refund.class), params, RefundCollection.class, apiKey);
+  }
 
 }

--- a/src/main/java/com/easypost/model/RefundCollection.java
+++ b/src/main/java/com/easypost/model/RefundCollection.java
@@ -10,12 +10,15 @@ public class RefundCollection extends EasyPostResource {
   public List<Refund> getRefunds() {
     return refunds;
   }
+
   public void setRefunds(List<Refund> refunds) {
     this.refunds = refunds;
   }
+
   public Boolean getHasMore() {
     return hasMore;
   }
+
   public void setHasMore(Boolean hasMore) {
     this.hasMore = hasMore;
   }

--- a/src/main/java/com/easypost/model/Report.java
+++ b/src/main/java/com/easypost/model/Report.java
@@ -111,8 +111,7 @@ public class Report extends EasyPostResource {
     return all(params, null);
   }
 
-  public static ReportCollection all(Map<String, Object> params, String apiKey)
-      throws EasyPostException {
+  public static ReportCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
     String type = (String) params.get("type");
     return request(RequestMethod.GET, reportURL(type), params, ReportCollection.class, apiKey);
   }

--- a/src/main/java/com/easypost/model/ReportCollection.java
+++ b/src/main/java/com/easypost/model/ReportCollection.java
@@ -4,20 +4,22 @@ import java.util.List;
 import com.easypost.net.EasyPostResource;
 
 public class ReportCollection extends EasyPostResource {
-    List<Report> reports;
-    Boolean hasMore;
+  List<Report> reports;
+  Boolean hasMore;
 
-    public List<Report> getReports() {
-        return reports;
-    }
-    public void setReports(List<Report> reports) {
-        this.reports = reports;
-    }
+  public List<Report> getReports() {
+    return reports;
+  }
 
-    public Boolean getHasMore() {
-        return hasMore;
-    }
-    public void setHasMore(Boolean hasMore) {
-        this.hasMore = hasMore;
-    }
+  public void setReports(List<Report> reports) {
+    this.reports = reports;
+  }
+
+  public Boolean getHasMore() {
+    return hasMore;
+  }
+
+  public void setHasMore(Boolean hasMore) {
+    this.hasMore = hasMore;
+  }
 }

--- a/src/main/java/com/easypost/model/ScanForm.java
+++ b/src/main/java/com/easypost/model/ScanForm.java
@@ -1,108 +1,127 @@
 package com.easypost.model;
 
 import java.util.List;
-import java.util.HashMap;
 import java.util.Map;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
 public class ScanForm extends EasyPostResource {
-	public String id;
-	String status;
-	String message;
-	Address fromAddress;
-	List<String> trackingCodes;
-	String formUrl;
-	String formFileType;
-	String confirmation;
-	String batchId;
+  public String id;
+  String status;
+  String message;
+  Address fromAddress;
+  List<String> trackingCodes;
+  String formUrl;
+  String formFileType;
+  String confirmation;
+  String batchId;
 
-	public String getId() {
-		return id;
-	}
-	public void setId(String id) {
-		this.id = id;
-	}
+  public String getId() {
+    return id;
+  }
 
-	public String getStatus() {
-	return status;
-	}
-	public void setStatus(String status) {
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
     this.status = status;
   }
 
-	public String getMessage() {
-		return message;
-	}
-	public void setMessage(String message) {
-		this.message = message;
-	}
+  public String getMessage() {
+    return message;
+  }
 
-	public Address getFromAddress() {
-		return fromAddress;
-	}
-	public void setFromAddress(Address fromAddress) {
-		this.fromAddress = fromAddress;
-	}
+  public void setMessage(String message) {
+    this.message = message;
+  }
 
-	public List<String> getTrackingCodes() {
-		return trackingCodes;
-	}
-	public void setTrackingCodes(List<String> trackingCodes) {
-		this.trackingCodes = trackingCodes;
-	}
+  public Address getFromAddress() {
+    return fromAddress;
+  }
 
-	public String getFormUrl() {
-		return formUrl;
-	}
-	public String getLabelUrl() {
-		return this.getFormUrl();
-	}
-	public void setFormUrl(String formUrl) {
-		this.formUrl = formUrl;
-	}
+  public void setFromAddress(Address fromAddress) {
+    this.fromAddress = fromAddress;
+  }
 
-	public String getFormFileType() {
-		return formFileType;
-	}
-	public String getLabelFileType() { return this.getFormFileType(); }
-	public void setFormFileType(String formFileType) {
-		this.formFileType = formFileType;
-	}
+  public List<String> getTrackingCodes() {
+    return trackingCodes;
+  }
 
-	public String getConfirmation() { return confirmation; }
-	public void setConfirmation(String confirmation) { this.confirmation = confirmation; }
+  public void setTrackingCodes(List<String> trackingCodes) {
+    this.trackingCodes = trackingCodes;
+  }
 
-	public String getBatchId() {
-		return batchId;
-	}
-	public void setBatchId(String batchId) {
-		this.batchId = batchId;
-	}
+  public String getFormUrl() {
+    return formUrl;
+  }
 
-	// create
-	public static ScanForm create(Map<String, Object> params) throws EasyPostException {
-		return create(params, null);
-	}
-	public static ScanForm create(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(RequestMethod.POST, classURL(ScanForm.class), params, ScanForm.class, apiKey);
-	}
+  public String getLabelUrl() {
+    return this.getFormUrl();
+  }
 
-	// retrieve
-	public static ScanForm retrieve(String id) throws EasyPostException {
-		return retrieve(id, null);
-	}
-	public static ScanForm retrieve(String id, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, instanceURL(ScanForm.class, id), null, ScanForm.class, apiKey);
-	}
+  public void setFormUrl(String formUrl) {
+    this.formUrl = formUrl;
+  }
 
-	// all
-	public static ScanFormCollection all(Map<String, Object> params) throws EasyPostException {
-		return all(params, null);
-	}
-	public static ScanFormCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, classURL(ScanForm.class), params, ScanFormCollection.class, apiKey);
-	}
+  public String getFormFileType() {
+    return formFileType;
+  }
+
+  public String getLabelFileType() {
+    return this.getFormFileType();
+  }
+
+  public void setFormFileType(String formFileType) {
+    this.formFileType = formFileType;
+  }
+
+  public String getConfirmation() {
+    return confirmation;
+  }
+
+  public void setConfirmation(String confirmation) {
+    this.confirmation = confirmation;
+  }
+
+  public String getBatchId() {
+    return batchId;
+  }
+
+  public void setBatchId(String batchId) {
+    this.batchId = batchId;
+  }
+
+  // create
+  public static ScanForm create(Map<String, Object> params) throws EasyPostException {
+    return create(params, null);
+  }
+
+  public static ScanForm create(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.POST, classURL(ScanForm.class), params, ScanForm.class, apiKey);
+  }
+
+  // retrieve
+  public static ScanForm retrieve(String id) throws EasyPostException {
+    return retrieve(id, null);
+  }
+
+  public static ScanForm retrieve(String id, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, instanceURL(ScanForm.class, id), null, ScanForm.class, apiKey);
+  }
+
+  // all
+  public static ScanFormCollection all(Map<String, Object> params) throws EasyPostException {
+    return all(params, null);
+  }
+
+  public static ScanFormCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, classURL(ScanForm.class), params, ScanFormCollection.class, apiKey);
+  }
 
 }

--- a/src/main/java/com/easypost/model/ScanFormCollection.java
+++ b/src/main/java/com/easypost/model/ScanFormCollection.java
@@ -10,12 +10,15 @@ public class ScanFormCollection extends EasyPostResource {
   public List<ScanForm> getScanForms() {
     return scanForms;
   }
+
   public void setScanForms(List<ScanForm> scanForms) {
     this.scanForms = scanForms;
   }
+
   public Boolean getHasMore() {
     return hasMore;
   }
+
   public void setHasMore(Boolean hasMore) {
     this.hasMore = hasMore;
   }

--- a/src/main/java/com/easypost/model/Shipment.java
+++ b/src/main/java/com/easypost/model/Shipment.java
@@ -4,407 +4,451 @@ import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 
-import com.google.gson.reflect.TypeToken;
-
 import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
 public class Shipment extends EasyPostResource {
-	public String id;
-	String mode;
-	String reference;
-	Boolean isReturn;
-	Address toAddress;
-	Address buyerAddress;
-	Address fromAddress;
-	Address returnAddress;
-	Parcel parcel;
-	CustomsInfo customsInfo;
-	Rate selectedRate;
-	List<Rate> rates;
-	PostageLabel postageLabel;
-	ScanForm scanForm;
-	String orderId;
-	List<Form> forms;
-	Tracker tracker;
-	String insurance;
-	String trackingCode;
-	String status;
-	String refundStatus;
-	String batchId;
-	String batchStatus;
-	String batchMessage;
-	String uspsZone;
-	Map<String, Object> options;
-	List<ShipmentMessage> messages;
+  public String id;
+  String mode;
+  String reference;
+  Boolean isReturn;
+  Address toAddress;
+  Address buyerAddress;
+  Address fromAddress;
+  Address returnAddress;
+  Parcel parcel;
+  CustomsInfo customsInfo;
+  Rate selectedRate;
+  List<Rate> rates;
+  PostageLabel postageLabel;
+  ScanForm scanForm;
+  String orderId;
+  List<Form> forms;
+  Tracker tracker;
+  String insurance;
+  String trackingCode;
+  String status;
+  String refundStatus;
+  String batchId;
+  String batchStatus;
+  String batchMessage;
+  String uspsZone;
+  Map<String, Object> options;
+  List<ShipmentMessage> messages;
 
-	public String getId() {
-		return id;
-	}
-	public void setId(String id) {
-		this.id = id;
-	}
+  public String getId() {
+    return id;
+  }
 
-	public String getMode() {
-		return mode;
-	}
-	public void setMode(String mode) {
-		this.mode = mode;
-	}
+  public void setId(String id) {
+    this.id = id;
+  }
 
-	public String getReference() {
-		return reference;
-	}
-	public void setReference(String reference) {
-		this.reference = reference;
-	}
+  public String getMode() {
+    return mode;
+  }
 
-	public Boolean getIsReturn() {
-		return isReturn;
-	}
-	public void setIsReturn(Boolean isReturn) {
-		this.isReturn = isReturn;
-	}
+  public void setMode(String mode) {
+    this.mode = mode;
+  }
 
-	public Address getToAddress() {
-		return toAddress;
-	}
-	public void setToAddress(Address toAddress) {
-		this.toAddress = toAddress;
-	}
+  public String getReference() {
+    return reference;
+  }
 
-	public Address getBuyerAddress() {
-		return buyerAddress;
-	}
-	public void setBuyerAddress(Address buyerAddress) {
-		this.buyerAddress = buyerAddress;
-	}
+  public void setReference(String reference) {
+    this.reference = reference;
+  }
 
-	public Address getFromAddress() {
-		return fromAddress;
-	}
-	public void setFromAddress(Address fromAddress) {
-		this.fromAddress = fromAddress;
-	}
+  public Boolean getIsReturn() {
+    return isReturn;
+  }
 
-	public Address getReturnAddress() {
-		return returnAddress;
-	}
-	public void setReturnAddress(Address returnAddress) {
-		this.returnAddress = returnAddress;
-	}
+  public void setIsReturn(Boolean isReturn) {
+    this.isReturn = isReturn;
+  }
 
-	public Parcel getParcel() {
-		return parcel;
-	}
-	public void setParcel(Parcel parcel) {
-		this.parcel = parcel;
-	}
+  public Address getToAddress() {
+    return toAddress;
+  }
 
-	public CustomsInfo getCustomsInfo() {
-		return customsInfo;
-	}
-	public void setCustomsInfo(CustomsInfo customsInfo) {
-		this.customsInfo = customsInfo;
-	}
+  public void setToAddress(Address toAddress) {
+    this.toAddress = toAddress;
+  }
 
-	public Rate getSelectedRate() {
-		return selectedRate;
-	}
-	public void setSelectedRate(Rate selectedRate) {
-		this.selectedRate = selectedRate;
-	}
+  public Address getBuyerAddress() {
+    return buyerAddress;
+  }
 
-	public List<Rate> getRates() {
-		return rates;
-	}
-	public void setRates(List<Rate> rates) {
-		this.rates = rates;
-	}
+  public void setBuyerAddress(Address buyerAddress) {
+    this.buyerAddress = buyerAddress;
+  }
 
-	public PostageLabel getPostageLabel() {
-		return postageLabel;
-	}
-	public void setPostageLabel(PostageLabel postageLabel) {
-		this.postageLabel = postageLabel;
-	}
+  public Address getFromAddress() {
+    return fromAddress;
+  }
 
-	public ScanForm getScanForm() {
-		return scanForm;
-	}
-	public void setScanForm(ScanForm scanForm) {
-		this.scanForm = scanForm;
-	}
+  public void setFromAddress(Address fromAddress) {
+    this.fromAddress = fromAddress;
+  }
 
-	public String getOrderId() {
-		return orderId;
-	}
-	public void setOrderId(String orderId) {
-		this.orderId = orderId;
-	}
+  public Address getReturnAddress() {
+    return returnAddress;
+  }
 
-	public Tracker getTracker() {
-		return tracker;
-	}
-	public void setTracker(Tracker tracker) {
-		this.tracker = tracker;
-	}
+  public void setReturnAddress(Address returnAddress) {
+    this.returnAddress = returnAddress;
+  }
 
-	public String getInsurance() {
-		return insurance;
-	}
-	public void setInsurance(String insurance) {
-		this.insurance = insurance;
-	}
+  public Parcel getParcel() {
+    return parcel;
+  }
 
-	public String getTrackingCode() {
-		return trackingCode;
-	}
-	public void setTrackingCode(String trackingCode) {
-		this.trackingCode = trackingCode;
-	}
+  public void setParcel(Parcel parcel) {
+    this.parcel = parcel;
+  }
 
-	public String getStatus() {
-		return status;
-	}
-	public void setStatus(String status) {
-		this.status = status;
-	}
+  public CustomsInfo getCustomsInfo() {
+    return customsInfo;
+  }
 
-	public String getRefundStatus() {
-		return refundStatus;
-	}
-	public void setRefundStatus(String refundStatus) {
-		this.refundStatus = refundStatus;
-	}
+  public void setCustomsInfo(CustomsInfo customsInfo) {
+    this.customsInfo = customsInfo;
+  }
 
-	public String getBatchId() {
-		return batchId;
-	}
-	public void setBatchId(String batchId) {
-		this.batchId = batchId;
-	}
+  public Rate getSelectedRate() {
+    return selectedRate;
+  }
 
-	public String getBatchStatus() {
-		return batchStatus;
-	}
-	public void setBatchStatus(String batchStatus) {
-		this.batchStatus = batchStatus;
-	}
+  public void setSelectedRate(Rate selectedRate) {
+    this.selectedRate = selectedRate;
+  }
 
-	public String getBatchMessage() {
-		return batchMessage;
-	}
-	public void setBatchMessage(String batchMessage) {
-		this.batchMessage = batchMessage;
-	}
+  public List<Rate> getRates() {
+    return rates;
+  }
 
-	public String getUspsZone() {
-		return uspsZone;
-	}
-	public void setUspsZone(String uspsZone) {
-		this.uspsZone = uspsZone;
-	}
+  public void setRates(List<Rate> rates) {
+    this.rates = rates;
+  }
 
-	public Map<String, Object> getOptions() {
-		return options;
-	}
-	public void setOptions(Map<String, Object> options) {
-		this.options = options;
-	}
+  public PostageLabel getPostageLabel() {
+    return postageLabel;
+  }
 
-	public List<ShipmentMessage> getMessages() {
-		return messages;
-	}
-	public void setMessages(List<ShipmentMessage> messages) {
-		this.messages = messages;
-	}
+  public void setPostageLabel(PostageLabel postageLabel) {
+    this.postageLabel = postageLabel;
+  }
 
-	public List<Form> getForms() {
-		return forms;
-	}
-	public void setForms(List<Form> forms) {
-		this.forms = forms;
-	}
+  public ScanForm getScanForm() {
+    return scanForm;
+  }
 
+  public void setScanForm(ScanForm scanForm) {
+    this.scanForm = scanForm;
+  }
 
-	// create
-	public static Shipment create(Map<String, Object> params) throws EasyPostException {
-		return create(params, null);
-	}
-	public static Shipment create(Map<String, Object> params, String apiKey) throws EasyPostException {
-		Map<String, Object> wrappedParams = new HashMap<String, Object>();
-		wrappedParams.put("shipment", params);
+  public String getOrderId() {
+    return orderId;
+  }
 
-		return request(RequestMethod.POST, classURL(Shipment.class), wrappedParams, Shipment.class, apiKey);
-	}
+  public void setOrderId(String orderId) {
+    this.orderId = orderId;
+  }
 
-	// retrieve
-	public static Shipment retrieve(String id) throws EasyPostException {
-		return retrieve(id, null);
-	}
-	public static Shipment retrieve(String id, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, instanceURL(Shipment.class, id), null, Shipment.class, apiKey);
-	}
+  public Tracker getTracker() {
+    return tracker;
+  }
 
-	// all
-	public static ShipmentCollection all(Map<String, Object> params) throws EasyPostException {
-		return all(params, null);
-	}
-	public static ShipmentCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, classURL(Shipment.class), params, ShipmentCollection.class, apiKey);
-	}
+  public void setTracker(Tracker tracker) {
+    this.tracker = tracker;
+  }
 
-	// refresh
-	public Shipment refresh() throws EasyPostException {
-		return this.refresh(null, null);
-	}
-	public Shipment refresh(Map<String, Object> params) throws EasyPostException {
-		return this.refresh(params, null);
-	}
-	public Shipment refresh(String apiKey) throws EasyPostException {
-		return this.refresh((Map<String, Object>) null, apiKey);
-	}
-	public Shipment refresh(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(
-			RequestMethod.GET,
-			String.format("%s", instanceURL(Shipment.class, this.getId())), params, Shipment.class, apiKey);
-	}
+  public String getInsurance() {
+    return insurance;
+  }
 
-	// get rates
-	public Shipment newRates() throws EasyPostException {
-		return this.newRates(null, null);
-	}
-	public Shipment newRates(Map<String, Object> params) throws EasyPostException {
-		return this.newRates(params, null);
-	}
-	public Shipment newRates(String apiKey) throws EasyPostException {
-		return this.newRates((Map<String, Object>) null, apiKey);
-	}
-	public Shipment newRates(Map<String, Object> params, String apiKey) throws EasyPostException {
-		Shipment response = request(
-			RequestMethod.POST,
-			String.format("%s/rerate", instanceURL(Shipment.class, this.getId())), params, Shipment.class, apiKey);
+  public void setInsurance(String insurance) {
+    this.insurance = insurance;
+  }
 
-		this.merge(this, response);
-		return this;
-	}
+  public String getTrackingCode() {
+    return trackingCode;
+  }
 
-	// buy
-	public Shipment buy() throws EasyPostException {
-		return this.buy(null, null);
-	}
-	public Shipment buy(Map<String, Object> params) throws EasyPostException {
-		return this.buy(params, null);
-	}
-	public Shipment buy(String apiKey) throws EasyPostException {
-		return this.buy((Map<String, Object>) null, apiKey);
-	}
-	public Shipment buy(Rate rate) throws EasyPostException {
-		Map<String, Object> params = new HashMap<String, Object>();
-		params.put("rate", rate);
+  public void setTrackingCode(String trackingCode) {
+    this.trackingCode = trackingCode;
+  }
 
-		return this.buy(params, null);
-	}
-	public Shipment buy(Map<String, Object> params, String apiKey) throws EasyPostException {
-		Shipment response = request(
-			RequestMethod.POST,
-			String.format("%s/buy", instanceURL(Shipment.class, this.getId())), params, Shipment.class, apiKey);
+  public String getStatus() {
+    return status;
+  }
 
-		this.merge(this, response);
-		return this;
-	}
+  public void setStatus(String status) {
+    this.status = status;
+  }
 
-	// refund
-	public Shipment refund() throws EasyPostException {
-		return this.refund(null, null);
-	}
-	public Shipment refund(Map<String, Object> params) throws EasyPostException {
-		return this.refund(params, null);
-	}
-	public Shipment refund(String apiKey) throws EasyPostException {
-		return this.refund((Map<String, Object>) null, apiKey);
-	}
-	public Shipment refund(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(
-			RequestMethod.GET,
-			String.format("%s/refund", instanceURL(Shipment.class, this.getId())), params, Shipment.class, apiKey);
-	}
+  public String getRefundStatus() {
+    return refundStatus;
+  }
 
-	// label
-	public Shipment label() throws EasyPostException {
-		return this.label(null, null);
-	}
-	public Shipment label(Map<String, Object> params) throws EasyPostException {
-		return this.label(params, null);
-	}
-	public Shipment label(String apiKey) throws EasyPostException {
-		return this.label((Map<String, Object>) null, apiKey);
-	}
-	public Shipment label(Map<String, Object> params, String apiKey) throws EasyPostException {
-		Shipment response = request(
-			RequestMethod.GET,
-			String.format("%s/label", instanceURL(Shipment.class, this.getId())), params, Shipment.class, apiKey);
+  public void setRefundStatus(String refundStatus) {
+    this.refundStatus = refundStatus;
+  }
 
-		this.merge(this, response);
-		return this;
-	}
+  public String getBatchId() {
+    return batchId;
+  }
 
-	// insure
-	public Shipment insure() throws EasyPostException {
-		return this.insure(null, null);
-	}
-	public Shipment insure(Map<String, Object> params) throws EasyPostException {
-		return this.insure(params, null);
-	}
-	public Shipment insure(String apiKey) throws EasyPostException {
-		return this.insure((Map<String, Object>) null, apiKey);
-	}
-	public Shipment insure(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(
-			RequestMethod.POST,
-			String.format("%s/insure", instanceURL(Shipment.class, this.getId())), params, Shipment.class, apiKey);
-	}
+  public void setBatchId(String batchId) {
+    this.batchId = batchId;
+  }
 
-	// lowest rate
-	public Rate lowestRate() throws EasyPostException {
-		return this.lowestRate(null, null);
-	}
-	public Rate lowestRate(List<String> carriers) throws EasyPostException {
-		return this.lowestRate(carriers, null);
-	}
-	public Rate lowestRate(List<String> carriers, List<String> services) throws EasyPostException {
-		Rate lowestRate = null;
+  public String getBatchStatus() {
+    return batchStatus;
+  }
 
-		if (carriers != null) {
-			for(int i=0; i < carriers.size(); i++) {
-				carriers.set(i, carriers.get(i).toLowerCase());
-			}
-		}
+  public void setBatchStatus(String batchStatus) {
+    this.batchStatus = batchStatus;
+  }
 
-		if (services != null) {
-			for(int i=0; i < services.size(); i++) {
-				services.set(i, services.get(i).toLowerCase());
-			}
-		}
+  public String getBatchMessage() {
+    return batchMessage;
+  }
 
-		for(int i=0; i < this.rates.size(); i++) {
-			if (carriers != null && carriers.size() > 0 && !carriers.contains(this.rates.get(i).carrier.toLowerCase()) && !carriers.contains(this.rates.get(i).serviceCode.toLowerCase())) {
-				continue;
-			}
-			if (services != null && services.size() > 0 && !services.contains(this.rates.get(i).service.toLowerCase()) && !services.contains(this.rates.get(i).serviceCode.toLowerCase())) {
-				continue;
-			}
+  public void setBatchMessage(String batchMessage) {
+    this.batchMessage = batchMessage;
+  }
 
-			if (lowestRate == null || lowestRate.rate > this.rates.get(i).rate) {
-				lowestRate = this.rates.get(i);
-			}
-		}
+  public String getUspsZone() {
+    return uspsZone;
+  }
 
-		if(lowestRate == null) {
-			throw new EasyPostException("Unable to find lowest rate matching required criteria.");
-		}
+  public void setUspsZone(String uspsZone) {
+    this.uspsZone = uspsZone;
+  }
 
-		return lowestRate;
-	}
+  public Map<String, Object> getOptions() {
+    return options;
+  }
+
+  public void setOptions(Map<String, Object> options) {
+    this.options = options;
+  }
+
+  public List<ShipmentMessage> getMessages() {
+    return messages;
+  }
+
+  public void setMessages(List<ShipmentMessage> messages) {
+    this.messages = messages;
+  }
+
+  public List<Form> getForms() {
+    return forms;
+  }
+
+  public void setForms(List<Form> forms) {
+    this.forms = forms;
+  }
+
+  // create
+  public static Shipment create(Map<String, Object> params) throws EasyPostException {
+    return create(params, null);
+  }
+
+  public static Shipment create(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("shipment", params);
+
+    return request(RequestMethod.POST, classURL(Shipment.class), wrappedParams, Shipment.class, apiKey);
+  }
+
+  // retrieve
+  public static Shipment retrieve(String id) throws EasyPostException {
+    return retrieve(id, null);
+  }
+
+  public static Shipment retrieve(String id, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, instanceURL(Shipment.class, id), null, Shipment.class, apiKey);
+  }
+
+  // all
+  public static ShipmentCollection all(Map<String, Object> params) throws EasyPostException {
+    return all(params, null);
+  }
+
+  public static ShipmentCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, classURL(Shipment.class), params, ShipmentCollection.class, apiKey);
+  }
+
+  // refresh
+  public Shipment refresh() throws EasyPostException {
+    return this.refresh(null, null);
+  }
+
+  public Shipment refresh(Map<String, Object> params) throws EasyPostException {
+    return this.refresh(params, null);
+  }
+
+  public Shipment refresh(String apiKey) throws EasyPostException {
+    return this.refresh((Map<String, Object>) null, apiKey);
+  }
+
+  public Shipment refresh(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, String.format("%s", instanceURL(Shipment.class, this.getId())), params,
+        Shipment.class, apiKey);
+  }
+
+  // get rates
+  public Shipment newRates() throws EasyPostException {
+    return this.newRates(null, null);
+  }
+
+  public Shipment newRates(Map<String, Object> params) throws EasyPostException {
+    return this.newRates(params, null);
+  }
+
+  public Shipment newRates(String apiKey) throws EasyPostException {
+    return this.newRates((Map<String, Object>) null, apiKey);
+  }
+
+  public Shipment newRates(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Shipment response = request(RequestMethod.POST,
+        String.format("%s/rerate", instanceURL(Shipment.class, this.getId())), params, Shipment.class, apiKey);
+
+    this.merge(this, response);
+    return this;
+  }
+
+  // buy
+  public Shipment buy() throws EasyPostException {
+    return this.buy(null, null);
+  }
+
+  public Shipment buy(Map<String, Object> params) throws EasyPostException {
+    return this.buy(params, null);
+  }
+
+  public Shipment buy(String apiKey) throws EasyPostException {
+    return this.buy((Map<String, Object>) null, apiKey);
+  }
+
+  public Shipment buy(Rate rate) throws EasyPostException {
+    Map<String, Object> params = new HashMap<String, Object>();
+    params.put("rate", rate);
+
+    return this.buy(params, null);
+  }
+
+  public Shipment buy(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Shipment response = request(RequestMethod.POST, String.format("%s/buy", instanceURL(Shipment.class, this.getId())),
+        params, Shipment.class, apiKey);
+
+    this.merge(this, response);
+    return this;
+  }
+
+  // refund
+  public Shipment refund() throws EasyPostException {
+    return this.refund(null, null);
+  }
+
+  public Shipment refund(Map<String, Object> params) throws EasyPostException {
+    return this.refund(params, null);
+  }
+
+  public Shipment refund(String apiKey) throws EasyPostException {
+    return this.refund((Map<String, Object>) null, apiKey);
+  }
+
+  public Shipment refund(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, String.format("%s/refund", instanceURL(Shipment.class, this.getId())), params,
+        Shipment.class, apiKey);
+  }
+
+  // label
+  public Shipment label() throws EasyPostException {
+    return this.label(null, null);
+  }
+
+  public Shipment label(Map<String, Object> params) throws EasyPostException {
+    return this.label(params, null);
+  }
+
+  public Shipment label(String apiKey) throws EasyPostException {
+    return this.label((Map<String, Object>) null, apiKey);
+  }
+
+  public Shipment label(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Shipment response = request(RequestMethod.GET, String.format("%s/label", instanceURL(Shipment.class, this.getId())),
+        params, Shipment.class, apiKey);
+
+    this.merge(this, response);
+    return this;
+  }
+
+  // insure
+  public Shipment insure() throws EasyPostException {
+    return this.insure(null, null);
+  }
+
+  public Shipment insure(Map<String, Object> params) throws EasyPostException {
+    return this.insure(params, null);
+  }
+
+  public Shipment insure(String apiKey) throws EasyPostException {
+    return this.insure((Map<String, Object>) null, apiKey);
+  }
+
+  public Shipment insure(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.POST, String.format("%s/insure", instanceURL(Shipment.class, this.getId())), params,
+        Shipment.class, apiKey);
+  }
+
+  // lowest rate
+  public Rate lowestRate() throws EasyPostException {
+    return this.lowestRate(null, null);
+  }
+
+  public Rate lowestRate(List<String> carriers) throws EasyPostException {
+    return this.lowestRate(carriers, null);
+  }
+
+  public Rate lowestRate(List<String> carriers, List<String> services) throws EasyPostException {
+    Rate lowestRate = null;
+
+    if (carriers != null) {
+      for (int i = 0; i < carriers.size(); i++) {
+        carriers.set(i, carriers.get(i).toLowerCase());
+      }
+    }
+
+    if (services != null) {
+      for (int i = 0; i < services.size(); i++) {
+        services.set(i, services.get(i).toLowerCase());
+      }
+    }
+
+    for (int i = 0; i < this.rates.size(); i++) {
+      if (carriers != null && carriers.size() > 0 && !carriers.contains(this.rates.get(i).carrier.toLowerCase())
+          && !carriers.contains(this.rates.get(i).serviceCode.toLowerCase())) {
+        continue;
+      }
+      if (services != null && services.size() > 0 && !services.contains(this.rates.get(i).service.toLowerCase())
+          && !services.contains(this.rates.get(i).serviceCode.toLowerCase())) {
+        continue;
+      }
+
+      if (lowestRate == null || lowestRate.rate > this.rates.get(i).rate) {
+        lowestRate = this.rates.get(i);
+      }
+    }
+
+    if (lowestRate == null) {
+      throw new EasyPostException("Unable to find lowest rate matching required criteria.");
+    }
+
+    return lowestRate;
+  }
 }

--- a/src/main/java/com/easypost/model/ShipmentCollection.java
+++ b/src/main/java/com/easypost/model/ShipmentCollection.java
@@ -10,12 +10,15 @@ public class ShipmentCollection extends EasyPostResource {
   public List<Shipment> getShipments() {
     return shipments;
   }
+
   public void setShipments(List<Shipment> shipments) {
     this.shipments = shipments;
   }
+
   public Boolean getHasMore() {
     return hasMore;
   }
+
   public void setHasMore(Boolean hasMore) {
     this.hasMore = hasMore;
   }

--- a/src/main/java/com/easypost/model/ShipmentOptions.java
+++ b/src/main/java/com/easypost/model/ShipmentOptions.java
@@ -1,20 +1,22 @@
 package com.easypost.model;
 
 public class ShipmentOptions {
-	String smartpostHub;
-	String smartpostManifest;
-	
-	public String getSmartpostHub() {
-		return smartpostHub;
-	}
-	public void setSmartpostHub(String smartpostHub) {
-		this.smartpostHub = smartpostHub;
-	}
+  String smartpostHub;
+  String smartpostManifest;
 
-	public String getSmartpostManifest() {
-		return smartpostManifest;
-	}
-	public void setSmartpostManifest(String smartpostManifest) {
-		this.smartpostManifest = smartpostManifest;
-	}
+  public String getSmartpostHub() {
+    return smartpostHub;
+  }
+
+  public void setSmartpostHub(String smartpostHub) {
+    this.smartpostHub = smartpostHub;
+  }
+
+  public String getSmartpostManifest() {
+    return smartpostManifest;
+  }
+
+  public void setSmartpostManifest(String smartpostManifest) {
+    this.smartpostManifest = smartpostManifest;
+  }
 }

--- a/src/main/java/com/easypost/model/Tracker.java
+++ b/src/main/java/com/easypost/model/Tracker.java
@@ -9,147 +9,174 @@ import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
 public class Tracker extends EasyPostResource {
-	public String id;
-	String mode;
-	String trackingCode;
-	String status;
-	String shipmentId;
-	String carrier;
-	List<TrackingDetail> trackingDetails;
-	float weight;
-	Date estDeliveryDate;
-	String signedBy;
-	CarrierDetail carrierDetail;
-	String publicUrl;
-	String statusDetail;
+  public String id;
+  String mode;
+  String trackingCode;
+  String status;
+  String shipmentId;
+  String carrier;
+  List<TrackingDetail> trackingDetails;
+  float weight;
+  Date estDeliveryDate;
+  String signedBy;
+  CarrierDetail carrierDetail;
+  String publicUrl;
+  String statusDetail;
 
-	public String getId() {
-		return id;
-	}
-	public void setId(String id) {
-		this.id = id;
-	}
+  public String getId() {
+    return id;
+  }
 
-	public String getMode() {
-		return mode;
-	}
-	public void setMode(String mode) {
-		this.mode = mode;
-	}
+  public void setId(String id) {
+    this.id = id;
+  }
 
-	public String getShipmentId() {
-		return shipmentId;
-	}
-	public void setShipmentId(String shipmentId) {
-		this.shipmentId = shipmentId;
-	}
+  public String getMode() {
+    return mode;
+  }
 
-	public String getCarrier() {
-		return carrier;
-	}
-	public void setCarrier(String carrier) {
-		this.carrier = carrier;
-	}
+  public void setMode(String mode) {
+    this.mode = mode;
+  }
 
-	public String getTrackingCode() {
-		return trackingCode;
-	}
-	public void setTrackingCode(String trackingCode) {
-		this.trackingCode = trackingCode;
-	}
+  public String getShipmentId() {
+    return shipmentId;
+  }
 
-	public String getStatus() {
-		return status;
-	}
-	public void setStatus(String status) {
-		this.status = status;
-	}
+  public void setShipmentId(String shipmentId) {
+    this.shipmentId = shipmentId;
+  }
 
-	public List<TrackingDetail> getTrackingDetails() {
-		return trackingDetails;
-	}
-	public void setTrackingDetails(List<TrackingDetail> trackingDetails) {
-		this.trackingDetails = trackingDetails;
-	}
+  public String getCarrier() {
+    return carrier;
+  }
 
-	public float getWeight() {
-		return weight;
-	}
-	public void setWeight(float weight) {
-		this.weight = weight;
-	}
+  public void setCarrier(String carrier) {
+    this.carrier = carrier;
+  }
 
-	public Date getEstDeliveryDate() {
-		return estDeliveryDate;
-	}
-	public void setEstDeliveryDate(Date estDeliveryDate) {
-		this.estDeliveryDate = estDeliveryDate;
-	}
+  public String getTrackingCode() {
+    return trackingCode;
+  }
 
-	public String getSignedBy() {
-		return signedBy;
-	}
-	public void setSignedBy(String signedBy) {
-		this.signedBy = signedBy;
-	}
+  public void setTrackingCode(String trackingCode) {
+    this.trackingCode = trackingCode;
+  }
 
-	public CarrierDetail getCarrierDetail() { return carrierDetail; }
-	public void setCarrierDetail(CarrierDetail carrierDetail) { this.carrierDetail = carrierDetail; }
+  public String getStatus() {
+    return status;
+  }
 
-	// This method is a misspelling, but it persists to avoid breaking backwards compatibility
-	public Date getUpdateAt() {
-		return getUpdatedAt();
-	}
-	public void setUpdateAt(Date updatedAt) {
-		setUpdatedAt(updatedAt);
-	}
+  public void setStatus(String status) {
+    this.status = status;
+  }
 
-	public String getPublicUrl() { return publicUrl; }
-	public void setPublicUrl(String publicUrl) { this.publicUrl = publicUrl; }
+  public List<TrackingDetail> getTrackingDetails() {
+    return trackingDetails;
+  }
 
-	public String getStatusDetail() {
-		return statusDetail;
-	}
-	public void setStatusDetail(String statusDetail) {
-		this.statusDetail = statusDetail;
-	}
+  public void setTrackingDetails(List<TrackingDetail> trackingDetails) {
+    this.trackingDetails = trackingDetails;
+  }
 
-	// create
-	public static Tracker create(Map<String, Object> params) throws EasyPostException {
-		return create(params, null);
-	}
-	public static Tracker create(Map<String, Object> params, String apiKey) throws EasyPostException {
-		Map<String, Object> wrappedParams = new HashMap<String, Object>();
-		wrappedParams.put("tracker", params);
+  public float getWeight() {
+    return weight;
+  }
 
-		return request(RequestMethod.POST, classURL(Tracker.class), wrappedParams, Tracker.class, apiKey);
-	}
+  public void setWeight(float weight) {
+    this.weight = weight;
+  }
 
-	// retrieve
-	public static Tracker retrieve(String id) throws EasyPostException {
-		return retrieve(id, null);
-	}
-	public static Tracker retrieve(String id, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, instanceURL(Tracker.class, id), null, Tracker.class, apiKey);
-	}
+  public Date getEstDeliveryDate() {
+    return estDeliveryDate;
+  }
 
-	// all
-	public static TrackerCollection all(Map<String, Object> params) throws EasyPostException {
-		return all(params, null);
-	}
-	public static TrackerCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, classURL(Tracker.class), params, TrackerCollection.class, apiKey);
-	}
+  public void setEstDeliveryDate(Date estDeliveryDate) {
+    this.estDeliveryDate = estDeliveryDate;
+  }
 
-	// createList
-	public static boolean createList(Map<String, Object> params) throws EasyPostException {
-		return createList(params, null);
-	}
-	public static boolean createList(Map<String, Object> params, String apiKey) throws EasyPostException {
-		String createListUrl = String.format("%s/create_list", classURL(Tracker.class));
+  public String getSignedBy() {
+    return signedBy;
+  }
 
-		request(RequestMethod.POST, createListUrl, params, Object.class, apiKey);
-		return true;
-	}
+  public void setSignedBy(String signedBy) {
+    this.signedBy = signedBy;
+  }
+
+  public CarrierDetail getCarrierDetail() {
+    return carrierDetail;
+  }
+
+  public void setCarrierDetail(CarrierDetail carrierDetail) {
+    this.carrierDetail = carrierDetail;
+  }
+
+  // This method is a misspelling, but it persists to avoid breaking backwards
+  // compatibility
+  public Date getUpdateAt() {
+    return getUpdatedAt();
+  }
+
+  public void setUpdateAt(Date updatedAt) {
+    setUpdatedAt(updatedAt);
+  }
+
+  public String getPublicUrl() {
+    return publicUrl;
+  }
+
+  public void setPublicUrl(String publicUrl) {
+    this.publicUrl = publicUrl;
+  }
+
+  public String getStatusDetail() {
+    return statusDetail;
+  }
+
+  public void setStatusDetail(String statusDetail) {
+    this.statusDetail = statusDetail;
+  }
+
+  // create
+  public static Tracker create(Map<String, Object> params) throws EasyPostException {
+    return create(params, null);
+  }
+
+  public static Tracker create(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("tracker", params);
+
+    return request(RequestMethod.POST, classURL(Tracker.class), wrappedParams, Tracker.class, apiKey);
+  }
+
+  // retrieve
+  public static Tracker retrieve(String id) throws EasyPostException {
+    return retrieve(id, null);
+  }
+
+  public static Tracker retrieve(String id, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, instanceURL(Tracker.class, id), null, Tracker.class, apiKey);
+  }
+
+  // all
+  public static TrackerCollection all(Map<String, Object> params) throws EasyPostException {
+    return all(params, null);
+  }
+
+  public static TrackerCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, classURL(Tracker.class), params, TrackerCollection.class, apiKey);
+  }
+
+  // createList
+  public static boolean createList(Map<String, Object> params) throws EasyPostException {
+    return createList(params, null);
+  }
+
+  public static boolean createList(Map<String, Object> params, String apiKey) throws EasyPostException {
+    String createListUrl = String.format("%s/create_list", classURL(Tracker.class));
+
+    request(RequestMethod.POST, createListUrl, params, Object.class, apiKey);
+    return true;
+  }
 
 }

--- a/src/main/java/com/easypost/model/TrackerCollection.java
+++ b/src/main/java/com/easypost/model/TrackerCollection.java
@@ -10,12 +10,15 @@ public class TrackerCollection extends EasyPostResource {
   public List<Tracker> getTrackers() {
     return trackers;
   }
+
   public void setTrackers(List<Tracker> trackers) {
     this.trackers = trackers;
   }
+
   public Boolean getHasMore() {
     return hasMore;
   }
+
   public void setHasMore(Boolean hasMore) {
     this.hasMore = hasMore;
   }

--- a/src/main/java/com/easypost/model/TrackingDetail.java
+++ b/src/main/java/com/easypost/model/TrackingDetail.java
@@ -3,41 +3,50 @@ package com.easypost.model;
 import java.util.Date;
 
 public class TrackingDetail {
-	String status;
-	String message;
-	Date datetime;
-	TrackingLocation trackingLocation;
-	String statusDetail;
+  String status;
+  String message;
+  Date datetime;
+  TrackingLocation trackingLocation;
+  String statusDetail;
 
-	public String getStatus() {
-		return status;
-	}
-	public void setStatus(String status) {
-		this.status = status;
-	}
+  public String getStatus() {
+    return status;
+  }
 
-	public String getMessage() {
-		return message;
-	}
-	public void setMessage(String message) {
-		this.message = message;
-	}
+  public void setStatus(String status) {
+    this.status = status;
+  }
 
-	public Date getDatetime() {
-		return datetime;
-	}
-	public void setDatetime(Date datetime) {
-		this.datetime = datetime;
-	}
+  public String getMessage() {
+    return message;
+  }
 
-	public TrackingLocation getTrackingLocation() { return trackingLocation; }
-	public void setTrackingLocation(TrackingLocation location) { this.trackingLocation = location; }
+  public void setMessage(String message) {
+    this.message = message;
+  }
 
-	public String getStatusDetail() {
-		return statusDetail;
-	}
-	public void setStatusDetail(String statusDetail) {
-		this.statusDetail = statusDetail;
-	}
+  public Date getDatetime() {
+    return datetime;
+  }
+
+  public void setDatetime(Date datetime) {
+    this.datetime = datetime;
+  }
+
+  public TrackingLocation getTrackingLocation() {
+    return trackingLocation;
+  }
+
+  public void setTrackingLocation(TrackingLocation location) {
+    this.trackingLocation = location;
+  }
+
+  public String getStatusDetail() {
+    return statusDetail;
+  }
+
+  public void setStatusDetail(String statusDetail) {
+    this.statusDetail = statusDetail;
+  }
 
 }

--- a/src/main/java/com/easypost/model/TrackingLocation.java
+++ b/src/main/java/com/easypost/model/TrackingLocation.java
@@ -1,21 +1,41 @@
 package com.easypost.model;
 
 public class TrackingLocation {
-    String city;
-    String state;
-    String country;
-    String zip;
+  String city;
+  String state;
+  String country;
+  String zip;
 
-    public String getCity() { return city; }
-    public void setCity(String city) { this.city = city; }
+  public String getCity() {
+    return city;
+  }
 
-    public String getState() { return state; }
-    public void setState(String state) { this.state = state; }
+  public void setCity(String city) {
+    this.city = city;
+  }
 
-    public String getCountry() { return country; }
-    public void setCountry(String country) { this.country = country; }
+  public String getState() {
+    return state;
+  }
 
-    public String getZip() { return zip; }
-    public void setZip(String zip) { this.zip = zip; }
+  public void setState(String state) {
+    this.state = state;
+  }
+
+  public String getCountry() {
+    return country;
+  }
+
+  public void setCountry(String country) {
+    this.country = country;
+  }
+
+  public String getZip() {
+    return zip;
+  }
+
+  public void setZip(String zip) {
+    this.zip = zip;
+  }
 
 }

--- a/src/main/java/com/easypost/model/User.java
+++ b/src/main/java/com/easypost/model/User.java
@@ -6,125 +6,163 @@ import java.util.HashMap;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
-import com.easypost.model.ApiKeys;
 
 public class User extends EasyPostResource {
-    public String id;
-    String name;
-    String email;
-    String phoneNumber;
-    String balance;
-    String rechargeAmount;
-    String secondaryRechargeAmount;
-    String rechargeThreshold;
-    List<User> children;
+  public String id;
+  String name;
+  String email;
+  String phoneNumber;
+  String balance;
+  String rechargeAmount;
+  String secondaryRechargeAmount;
+  String rechargeThreshold;
+  List<User> children;
 
-    public String getId() { return id; }
-    public void setId(String id) { this.id = id; }
+  public String getId() {
+    return id;
+  }
 
-    public String getName() { return name; }
-    public void setName(String name) { this.name = name; }
+  public void setId(String id) {
+    this.id = id;
+  }
 
-    public String getEmail() { return email; }
-    public void setEmail(String email) { this.email = email; }
+  public String getName() {
+    return name;
+  }
 
-    public String getPhoneNumber() { return phoneNumber; }
-    public void setPhoneNumber(String phoneNumber) { this.phoneNumber = phoneNumber; }
+  public void setName(String name) {
+    this.name = name;
+  }
 
-    public String getBalance() { return balance; }
-    public void setBalance(String balance) { this.balance = balance; }
+  public String getEmail() {
+    return email;
+  }
 
-    public String getRechargeAmount() { return rechargeAmount; }
-    public void setRechargeAmount(String rechargeAmount) {
-      this.rechargeAmount = rechargeAmount;
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public String getPhoneNumber() {
+    return phoneNumber;
+  }
+
+  public void setPhoneNumber(String phoneNumber) {
+    this.phoneNumber = phoneNumber;
+  }
+
+  public String getBalance() {
+    return balance;
+  }
+
+  public void setBalance(String balance) {
+    this.balance = balance;
+  }
+
+  public String getRechargeAmount() {
+    return rechargeAmount;
+  }
+
+  public void setRechargeAmount(String rechargeAmount) {
+    this.rechargeAmount = rechargeAmount;
+  }
+
+  public String getSecondaryRechargeAmount() {
+    return secondaryRechargeAmount;
+  }
+
+  public void setSecondaryRechargeAmount(String secondaryRechargeAmount) {
+    this.secondaryRechargeAmount = secondaryRechargeAmount;
+  }
+
+  public String getRechargeThreshold() {
+    return rechargeThreshold;
+  }
+
+  public void setRechargeThreshold(String rechargeThreshold) {
+    this.rechargeThreshold = rechargeThreshold;
+  }
+
+  public List<User> getChildren() {
+    return children;
+  }
+
+  public void setChildren(List<User> children) {
+    this.children = children;
+  }
+
+  // retrieve
+  public static User retrieve(String id) throws EasyPostException {
+    return retrieve(id, null);
+  }
+
+  public static User retrieve(String id, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, instanceURL(User.class, id), null, User.class, apiKey);
+  }
+
+  // retrieve me
+  public static User retrieveMe() throws EasyPostException {
+    return retrieveMe(null);
+  }
+
+  public static User retrieveMe(String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, classURL(User.class), null, User.class, apiKey);
+  }
+
+  // create
+  public static User create() throws EasyPostException {
+    return create(null, null);
+  }
+
+  public static User create(Map<String, Object> params) throws EasyPostException {
+    return create(params, null);
+  }
+
+  public static User create(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("user", params);
+
+    return request(RequestMethod.POST, classURL(User.class), wrappedParams, User.class, apiKey, false);
+  }
+
+  // update
+  public User update(Map<String, Object> params) throws EasyPostException {
+    return update(params, null);
+  }
+
+  public User update(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("user", params);
+
+    User response = request(RequestMethod.PUT, instanceURL(User.class, this.getId()), wrappedParams, User.class,
+        apiKey);
+
+    this.merge(this, response);
+    return this;
+  }
+
+  // delete
+  public void delete() throws EasyPostException {
+    this.delete(null);
+  }
+
+  public void delete(String apiKey) throws EasyPostException {
+    request(RequestMethod.DELETE, instanceURL(User.class, this.getId()), null, User.class, apiKey);
+  }
+
+  // api keys
+  public List<ApiKey> apiKeys() throws EasyPostException {
+    ApiKeys parentKeys = ApiKeys.all();
+
+    if (this.getId() == parentKeys.getId()) {
+      return parentKeys.getKeys();
     }
 
-    public String getSecondaryRechargeAmount() { return secondaryRechargeAmount; }
-    public void setSecondaryRechargeAmount(String secondaryRechargeAmount) {
-      this.secondaryRechargeAmount = secondaryRechargeAmount;
-    }
-
-    public String getRechargeThreshold() { return rechargeThreshold; }
-    public void setRechargeThreshold(String rechargeThreshold) {
-      this.rechargeThreshold = rechargeThreshold;
-    }
-
-    public List<User> getChildren() { return children; }
-    public void setChildren(List<User> children) { this.children = children; }
-
-    // retrieve
-    public static User retrieve(String id) throws EasyPostException {
-      return retrieve(id, null);
-    }
-    public static User retrieve(String id, String apiKey) throws EasyPostException {
-      return request(RequestMethod.GET, instanceURL(User.class, id),
-        null, User.class, apiKey);
-    }
-
-    // retrieve me
-    public static User retrieveMe() throws EasyPostException {
-      return retrieveMe(null);
-    }
-    public static User retrieveMe(String apiKey) throws EasyPostException {
-      return request(RequestMethod.GET, classURL(User.class), null, User.class, apiKey);
-    }
-
-    // create
-    public static User create() throws EasyPostException {
-      return create(null, null);
-    }
-    public static User create(Map<String, Object> params) throws EasyPostException {
-      return create(params, null);
-    }
-    public static User create(Map<String, Object> params, String apiKey)
-        throws EasyPostException
-    {
-      Map<String, Object> wrappedParams = new HashMap<String, Object>();
-      wrappedParams.put("user", params);
-
-      return request(RequestMethod.POST, classURL(User.class), wrappedParams,
-          User.class, apiKey, false);
-    }
-
-    // update
-    public User update(Map<String, Object> params) throws EasyPostException {
-      return update(params, null);
-    }
-    public User update(Map<String, Object> params, String apiKey) throws EasyPostException {
-      Map<String, Object> wrappedParams = new HashMap<String, Object>();
-      wrappedParams.put("user", params);
-
-      User response = request(RequestMethod.PUT,
-        instanceURL(User.class, this.getId()),
-        wrappedParams, User.class, apiKey);
-
-      this.merge(this, response);
-      return this;
-    }
-
-    // delete
-    public void delete() throws EasyPostException {
-        this.delete(null);
-    }
-    public void delete(String apiKey) throws EasyPostException {
-        request(RequestMethod.DELETE, instanceURL(User.class, this.getId()), null, User.class, apiKey);
-    }
-
-    // api keys
-    public List<ApiKey> apiKeys() throws EasyPostException {
-      ApiKeys parentKeys = ApiKeys.all();
-
-      if (this.getId() == parentKeys.getId()) {
-        return parentKeys.getKeys();
+    for (int i = 0; i < parentKeys.children.size(); i++) {
+      if (this.getId().equals(parentKeys.children.get(i).getId())) {
+        return parentKeys.children.get(i).getKeys();
       }
-
-      for(int i=0; i < parentKeys.children.size(); i++) {
-        if(this.getId().equals(parentKeys.children.get(i).getId())) {
-          return parentKeys.children.get(i).getKeys();
-        }
-      }
-
-      throw new EasyPostException("Unable to find api key. Please contact support@easypost.com");
     }
+
+    throw new EasyPostException("Unable to find api key. Please contact support@easypost.com");
+  }
 }
-

--- a/src/main/java/com/easypost/model/Webhook.java
+++ b/src/main/java/com/easypost/model/Webhook.java
@@ -8,93 +8,105 @@ import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
 public class Webhook extends EasyPostResource {
-    public String id;
-    String mode;
-    String url;
-    Date disabledAt;
+  public String id;
+  String mode;
+  String url;
+  Date disabledAt;
 
-    public String getId() {
-        return id;
-    }
-    public void setId(String id) {
-        this.id = id;
-    }
+  public String getId() {
+    return id;
+  }
 
-    public String getMode() {
-        return mode;
-    }
-    public void setMode(String mode) {
-        this.mode = mode;
-    }
+  public void setId(String id) {
+    this.id = id;
+  }
 
-    public String getUrl() {
-        return url;
-    }
-    public void setUrl(String url) {
-        this.url = url;
-    }
+  public String getMode() {
+    return mode;
+  }
 
-    public Date getDisabledAt() {
-        return disabledAt;
-    }
-    public void setDisabledAt(Date disabledAt) {
-        this.disabledAt = disabledAt;
-    }
+  public void setMode(String mode) {
+    this.mode = mode;
+  }
 
-    // create
-    public static Webhook create(Map<String, Object> params) throws EasyPostException {
-        return create(params, null);
-    }
-    public static Webhook create(Map<String, Object> params, String apiKey) throws EasyPostException {
-        Map<String, Object> wrappedParams = new HashMap<String, Object>();
-        wrappedParams.put("webhook", params);
+  public String getUrl() {
+    return url;
+  }
 
-        return request(RequestMethod.POST, classURL(Webhook.class), wrappedParams, Webhook.class, apiKey);
-    }
+  public void setUrl(String url) {
+    this.url = url;
+  }
 
-    // retrieve
-    public static Webhook retrieve(String id) throws EasyPostException {
-        return retrieve(id, null);
-    }
-    public static Webhook retrieve(String id, String apiKey) throws EasyPostException {
-        return request(RequestMethod.GET, instanceURL(Webhook.class, id), null, Webhook.class, apiKey);
-    }
+  public Date getDisabledAt() {
+    return disabledAt;
+  }
 
-    // all
-    public static WebhookCollection all() throws EasyPostException {
-        Map<String, Object> params = new HashMap<String, Object>();
-        return all(params, null);
-    }
-    public static WebhookCollection all(Map<String, Object> params) throws EasyPostException {
-        return all(params, null);
-    }
-    public static WebhookCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
-        return request(RequestMethod.GET, classURL(Webhook.class), params, WebhookCollection.class, apiKey);
-    }
+  public void setDisabledAt(Date disabledAt) {
+    this.disabledAt = disabledAt;
+  }
 
-    // delete
-    public void delete() throws EasyPostException {
-        this.delete(null);
-    }
-    public void delete(String apiKey) throws EasyPostException {
-        request(RequestMethod.DELETE, instanceURL(Webhook.class, this.getId()), null, Webhook.class, apiKey);
-    }
+  // create
+  public static Webhook create(Map<String, Object> params) throws EasyPostException {
+    return create(params, null);
+  }
 
-    // update
-    public Webhook update() throws EasyPostException {
-        Map<String, Object> params = new HashMap<String, Object>();
-        return this.update(params, null);
-    }
-    public Webhook update(Map<String, Object> params) throws EasyPostException {
-        return this.update(params, null);
-    }
-    public Webhook update(Map<String, Object> params, String apiKey) throws EasyPostException {
-        Map<String, Object> wrappedParams = new HashMap<String, Object>();
-        wrappedParams.put("webhook", params);
+  public static Webhook create(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("webhook", params);
 
-        Webhook response = request(RequestMethod.PUT, instanceURL(Webhook.class, this.getId()), wrappedParams, Webhook.class, apiKey);
+    return request(RequestMethod.POST, classURL(Webhook.class), wrappedParams, Webhook.class, apiKey);
+  }
 
-        this.merge(this, response);
-        return this;
-    }
+  // retrieve
+  public static Webhook retrieve(String id) throws EasyPostException {
+    return retrieve(id, null);
+  }
+
+  public static Webhook retrieve(String id, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, instanceURL(Webhook.class, id), null, Webhook.class, apiKey);
+  }
+
+  // all
+  public static WebhookCollection all() throws EasyPostException {
+    Map<String, Object> params = new HashMap<String, Object>();
+    return all(params, null);
+  }
+
+  public static WebhookCollection all(Map<String, Object> params) throws EasyPostException {
+    return all(params, null);
+  }
+
+  public static WebhookCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
+    return request(RequestMethod.GET, classURL(Webhook.class), params, WebhookCollection.class, apiKey);
+  }
+
+  // delete
+  public void delete() throws EasyPostException {
+    this.delete(null);
+  }
+
+  public void delete(String apiKey) throws EasyPostException {
+    request(RequestMethod.DELETE, instanceURL(Webhook.class, this.getId()), null, Webhook.class, apiKey);
+  }
+
+  // update
+  public Webhook update() throws EasyPostException {
+    Map<String, Object> params = new HashMap<String, Object>();
+    return this.update(params, null);
+  }
+
+  public Webhook update(Map<String, Object> params) throws EasyPostException {
+    return this.update(params, null);
+  }
+
+  public Webhook update(Map<String, Object> params, String apiKey) throws EasyPostException {
+    Map<String, Object> wrappedParams = new HashMap<String, Object>();
+    wrappedParams.put("webhook", params);
+
+    Webhook response = request(RequestMethod.PUT, instanceURL(Webhook.class, this.getId()), wrappedParams,
+        Webhook.class, apiKey);
+
+    this.merge(this, response);
+    return this;
+  }
 }

--- a/src/main/java/com/easypost/model/WebhookCollection.java
+++ b/src/main/java/com/easypost/model/WebhookCollection.java
@@ -4,12 +4,13 @@ import java.util.List;
 import com.easypost.net.EasyPostResource;
 
 public class WebhookCollection extends EasyPostResource {
-    List<Webhook> webhooks;
+  List<Webhook> webhooks;
 
-    public List<Webhook> getWebhooks() {
-        return webhooks;
-    }
-    public void setWebhooks(List<Webhook> webhooks) {
-        this.webhooks = webhooks;
-    }
+  public List<Webhook> getWebhooks() {
+    return webhooks;
+  }
+
+  public void setWebhooks(List<Webhook> webhooks) {
+    this.webhooks = webhooks;
+  }
 }

--- a/src/main/java/com/easypost/net/EasyPostResource.java
+++ b/src/main/java/com/easypost/net/EasyPostResource.java
@@ -7,7 +7,6 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Field;
-import java.lang.reflect.Type;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -24,10 +23,8 @@ import java.util.Date;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.reflect.TypeToken;
 import com.easypost.EasyPost;
 import com.easypost.exception.EasyPostException;
-import com.easypost.model.BatchStatus;
 import com.easypost.model.Event;
 import com.easypost.model.EventDeserializer;
 import com.easypost.model.Fee;
@@ -38,573 +35,576 @@ import com.easypost.model.TrackingDetail;
 
 public abstract class EasyPostResource {
 
-	public static final Gson gson = new GsonBuilder()
-		.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-		.registerTypeAdapter(Event.class, new EventDeserializer())
-		.registerTypeAdapter(Rate.class, new RateDeserializer())
-		.create();
+  public static final Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+      .registerTypeAdapter(Event.class, new EventDeserializer()).registerTypeAdapter(Rate.class, new RateDeserializer())
+      .create();
 
-	public static final Gson prettyPrintGson = new GsonBuilder().
-		setPrettyPrinting().
-		serializeNulls().
-		setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).
-		registerTypeAdapter(Event.class, new EventDeserializer()).
-		create();
+  public static final Gson prettyPrintGson = new GsonBuilder().setPrettyPrinting().serializeNulls()
+      .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+      .registerTypeAdapter(Event.class, new EventDeserializer()).create();
 
-	@Override public String toString() {
+  @Override
+  public String toString() {
 
-		return (String) this.getIdString();
-	}
+    return (String) this.getIdString();
+  }
 
-	public String prettyPrint() {
-		return String.format(
-			"<%s@%s id=%s> JSON: %s",
-			this.getClass().getName(),
-			System.identityHashCode(this),
-			this.getIdString(),
-			prettyPrintGson.toJson(this));
-	}
+  public String prettyPrint() {
+    return String.format("<%s@%s id=%s> JSON: %s", this.getClass().getName(), System.identityHashCode(this),
+        this.getIdString(), prettyPrintGson.toJson(this));
+  }
 
-	private Object getIdString() {
-		try {
-			Field idField = this.getClass().getDeclaredField("id");
-			return idField.get(this);
-		} catch (SecurityException e) {
-			return "";
-		} catch (NoSuchFieldException e) {
-			return "";
-		} catch (IllegalArgumentException e) {
-			return "";
-		} catch (IllegalAccessException e) {
-			return "";
-		}
-	}
+  private Object getIdString() {
+    try {
+      Field idField = this.getClass().getDeclaredField("id");
+      return idField.get(this);
+    } catch (SecurityException e) {
+      return "";
+    } catch (NoSuchFieldException e) {
+      return "";
+    } catch (IllegalArgumentException e) {
+      return "";
+    } catch (IllegalAccessException e) {
+      return "";
+    }
+  }
 
-	private static String className(Class<?> clazz) {
-		return clazz.getSimpleName().replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase().replace("$", "");
+  private static String className(Class<?> clazz) {
+    return clazz.getSimpleName().replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase().replace("$", "");
 
-	}
+  }
 
-	protected static String singleClassURL(Class<?> clazz) {
-		return String.format("%s/%s", EasyPost.API_BASE, className(clazz));
-	}
+  protected static String singleClassURL(Class<?> clazz) {
+    return String.format("%s/%s", EasyPost.API_BASE, className(clazz));
+  }
 
-	protected static String classURL(Class<?> clazz) {
-		String singleURL = singleClassURL(clazz);
-		if (singleURL.charAt(singleURL.length() - 1) == 's' || singleURL.charAt(singleURL.length() - 1) == 'h') {
-			return String.format("%ses", singleClassURL(clazz));
-		} else {
-			return String.format("%ss", singleClassURL(clazz));
-		}
-	}
+  protected static String classURL(Class<?> clazz) {
+    String singleURL = singleClassURL(clazz);
+    if (singleURL.charAt(singleURL.length() - 1) == 's' || singleURL.charAt(singleURL.length() - 1) == 'h') {
+      return String.format("%ses", singleClassURL(clazz));
+    } else {
+      return String.format("%ss", singleClassURL(clazz));
+    }
+  }
 
-	protected static String instanceURL(Class<?> clazz, String id) {
-		return String.format("%s/%s", classURL(clazz), id);
-	}
+  protected static String instanceURL(Class<?> clazz, String id) {
+    return String.format("%s/%s", classURL(clazz), id);
+  }
 
-	public void merge(EasyPostResource obj, EasyPostResource update) {
-	    if (!obj.getClass().isAssignableFrom(update.getClass())) {
-	        return;
-	    }
+  public void merge(EasyPostResource obj, EasyPostResource update) {
+    if (!obj.getClass().isAssignableFrom(update.getClass())) {
+      return;
+    }
 
-	    Method[] methods = obj.getClass().getMethods();
+    Method[] methods = obj.getClass().getMethods();
 
-	    for (Method fromMethod: methods) {
-	        if ((fromMethod.getDeclaringClass().equals(obj.getClass()) && fromMethod.getName().startsWith("get"))
-					|| GLOBAL_FIELD_ACCESSORS.contains(fromMethod.getName())) {
+    for (Method fromMethod : methods) {
+      if ((fromMethod.getDeclaringClass().equals(obj.getClass()) && fromMethod.getName().startsWith("get"))
+          || GLOBAL_FIELD_ACCESSORS.contains(fromMethod.getName())) {
 
-	            String fromName = fromMethod.getName();
-	            String toName = fromName.replace("get", "set");
+        String fromName = fromMethod.getName();
+        String toName = fromName.replace("get", "set");
 
-	            try {
-	                Object value = fromMethod.invoke(update, (Object[]) null);
-	                if (value != null) {
-		                Method toMethod = obj.getClass().getMethod(toName, fromMethod.getReturnType());
-	                    toMethod.invoke(obj, value);
-	                }
-	            } catch (Exception e) {
-	                e.printStackTrace();
-	            }
-	        }
-	    }
-	}
-
-	public static final String CHARSET = "UTF-8";
-
-	private static final String DNS_CACHE_TTL_PROPERTY_NAME = "networkaddress.cache.ttl";
-
-
-	// Set this property to override your environment's default URLStreamHandler.
-	private static final String CUSTOM_URL_STREAM_HANDLER_PROPERTY_NAME = "com.easypost.net.customURLStreamHandler";
-
-	protected enum RequestMethod {
-		GET, POST, DELETE, PUT
-	}
-
-	private static String urlEncodePair(String k, String v) throws UnsupportedEncodingException {
-		return String.format("%s=%s", URLEncoder.encode(k, CHARSET), URLEncoder.encode(v, CHARSET));
-	}
-
-	static Map<String, String> getHeaders(String apiKey) {
-		Map<String, String> headers = new HashMap<String, String>();
-		headers.put("Accept-Charset", CHARSET);
-		headers.put("User-Agent", String.format("EasyPost/v2 JavaClient/%s", EasyPost.VERSION));
-
-		if (apiKey == null) {
-			apiKey = EasyPost.apiKey;
-		}
-
-		headers.put("Authorization", String.format("Bearer %s", apiKey));
-
-		// debug headers
-		String[] propertyNames = { "os.name", "os.version", "os.arch",
-			"java.version", "java.vendor", "java.vm.version",
-			"java.vm.vendor" };
-		Map<String, String> propertyMap = new HashMap<String, String>();
-		for (String propertyName : propertyNames) {
-			propertyMap.put(propertyName, System.getProperty(propertyName));
-		}
-		propertyMap.put("lang", "Java");
-		propertyMap.put("publisher", "EasyPost");
-		headers.put("X-Client-User-Agent", gson.toJson(propertyMap));
-
-		return headers;
-	}
-
-	private static javax.net.ssl.HttpsURLConnection createEasyPostConnection(String url, String apiKey) throws IOException {
-		URL easypostURL = null;
-		String customURLStreamHandlerClassName = System.getProperty(CUSTOM_URL_STREAM_HANDLER_PROPERTY_NAME, null);
-		if (customURLStreamHandlerClassName != null) {
-			// instantiate the custom handler provided
-			try {
-				Class<URLStreamHandler> clazz = (Class<URLStreamHandler>) Class.forName(customURLStreamHandlerClassName);
-				Constructor<URLStreamHandler> constructor = clazz.getConstructor();
-				URLStreamHandler customHandler = constructor.newInstance();
-				easypostURL = new URL(null, url, customHandler);
-			} catch (ClassNotFoundException e) {
-				throw new IOException(e);
-			} catch (SecurityException e) {
-				throw new IOException(e);
-			} catch (NoSuchMethodException e) {
-				throw new IOException(e);
-			} catch (IllegalArgumentException e) {
-				throw new IOException(e);
-			} catch (InstantiationException e) {
-				throw new IOException(e);
-			} catch (IllegalAccessException e) {
-				throw new IOException(e);
-			} catch (InvocationTargetException e) {
-				throw new IOException(e);
-			}
-		} else {
-			easypostURL = new URL(url);
-		}
-		javax.net.ssl.HttpsURLConnection conn = (javax.net.ssl.HttpsURLConnection) easypostURL.openConnection();
-		conn.setConnectTimeout(20000); // 20 seconds
-
-		int readTimeout;
-		if (EasyPost.readTimeout != 0) {
-			readTimeout = EasyPost.readTimeout;
-		} else{
-			readTimeout = 40000;                  // 40 seconds by default
-		}
-		conn.setReadTimeout(readTimeout);
-
-		conn.setUseCaches(false);
-		for (Map.Entry<String, String> header : getHeaders(apiKey).entrySet()) {
-			conn.setRequestProperty(header.getKey(), header.getValue());
-		}
-
-		return conn;
-	}
-
-	private static javax.net.ssl.HttpsURLConnection createGetConnection(String url, String query, String apiKey) throws IOException {
-		String getURL = String.format("%s?%s", url, query);
-		javax.net.ssl.HttpsURLConnection conn = createEasyPostConnection(getURL, apiKey);
-		conn.setRequestMethod("GET");
-		return conn;
-	}
-
-	private static javax.net.ssl.HttpsURLConnection createPostConnection(String url, String query, String apiKey) throws IOException {
-		javax.net.ssl.HttpsURLConnection conn = createEasyPostConnection(url, apiKey);
-		conn.setDoOutput(true);
-		conn.setRequestMethod("POST");
-		conn.setRequestProperty("Content-Type", String.format("application/x-www-form-urlencoded;charset=%s", CHARSET));
-		OutputStream output = null;
-		try {
-			output = conn.getOutputStream();
-			output.write(query.getBytes(CHARSET));
-		} finally {
-			if (output != null) {
-				output.close();
-			}
-		}
-		return conn;
-	}
-
-	private static javax.net.ssl.HttpsURLConnection createDeleteConnection(String url, String query, String apiKey) throws IOException {
-		String deleteUrl = String.format("%s?%s", url, query);
-		javax.net.ssl.HttpsURLConnection conn = createEasyPostConnection(deleteUrl, apiKey);
-		conn.setRequestMethod("DELETE");
-		return conn;
-	}
-
-	private static javax.net.ssl.HttpsURLConnection createPutConnection(String url, String query, String apiKey) throws IOException {
-		javax.net.ssl.HttpsURLConnection conn = createEasyPostConnection(url, apiKey);
-		conn.setDoOutput(true);
-		conn.setRequestMethod("PUT");
-		conn.setRequestProperty("Content-Type", String.format("application/x-www-form-urlencoded;charset=%s", CHARSET));
-		OutputStream output = null;
-		try {
-			output = conn.getOutputStream();
-			output.write(query.getBytes(CHARSET));
-		} finally {
-			if (output != null) {
-				output.close();
-			}
-		}
-		return conn;
-	}
-
-	private static String createQuery(Map<String, Object> params) throws UnsupportedEncodingException {
-		Map<String, String> flatParams = flattenParams(params);
-		StringBuffer queryStringBuffer = new StringBuffer();
-		for (Map.Entry<String, String> entry : flatParams.entrySet()) {
-			queryStringBuffer.append("&");
-			queryStringBuffer.append(urlEncodePair(entry.getKey(), entry.getValue()));
-		}
-		if (queryStringBuffer.length() > 0) {
-			queryStringBuffer.deleteCharAt(0);
-		}
-		return queryStringBuffer.toString();
-	}
-
-	private static Map<String, String> flattenParams(Map<String, Object> params) {
-		if (params == null) {
-			return new HashMap<String, String>();
-		}
-		Map<String, String> flatParams = new HashMap<String, String>();
-		for (Map.Entry<String, Object> entry : params.entrySet()) {
-			String key = entry.getKey();
-			Object value = entry.getValue();
-			if (value instanceof Map<?, ?>) {
-				Map<String, Object> flatNestedMap = new HashMap<String, Object>();
-				Map<?, ?> nestedMap = (Map<?, ?>) value;
-				for (Map.Entry<?, ?> nestedEntry : nestedMap.entrySet()) {
-					flatNestedMap.put(
-						String.format("%s[%s]", key, nestedEntry.getKey()),
-						nestedEntry.getValue());
-				}
-				flatParams.putAll(flattenParams(flatNestedMap));
-			} else if (value instanceof List) {
-				Map<String, Object> flatNestedMap = new HashMap<String, Object>();
-				List<?> nestedList = (List<?>) value;
-				for (int i = 0; i < nestedList.size(); i++) {
-					flatNestedMap.put(
-						String.format("%s[%s]", key, i),
-						nestedList.get(i));
-					flatParams.putAll(flattenParams(flatNestedMap));
-				}
-			} else if (value instanceof EasyPostResource) {
-				flatParams.put(
-						String.format("%s[%s]", key, "id"),
-						value.toString());
-
-			} else if (value != null) {
-				flatParams.put(key, value.toString());
-			}
-		}
-
-        // System.out.println(flatParams);
-
-		return flatParams;
-	}
-
-	// represents Errors returned as JSON
-	private static class ErrorContainer {
-		private EasyPostResource.Error error;
-	}
-
-	private static class Error {
-		@SuppressWarnings("unused")
-		String type;
-		String message;
-		String code;
-		String param;
-		String error;
-	}
-
-	private static String getResponseBody(InputStream responseStream) throws IOException {
-		String rBody = new Scanner(responseStream, CHARSET).useDelimiter("\\A").next();
-		responseStream.close();
-		return rBody;
-	}
-
-	private static EasyPostResponse makeURLConnectionRequest(EasyPostResource.RequestMethod method, String url, String query, String apiKey) throws EasyPostException {
-		javax.net.ssl.HttpsURLConnection conn = null;
-		try {
-			switch (method) {
-			case GET:
-				conn = createGetConnection(url, query, apiKey);
-				break;
-			case POST:
-				conn = createPostConnection(url, query, apiKey);
-				break;
-			case DELETE:
-				conn = createDeleteConnection(url, query, apiKey);
-				break;
-			case PUT:
-				conn = createPutConnection(url, query, apiKey);
-				break;
-			default:
-				throw new EasyPostException(
-					String.format("Unrecognized HTTP method %s. Please contact EasyPost at support@easypost.com.", method));
-			}
-			int rCode = conn.getResponseCode(); // sends the request
-			String rBody = null;
-			if (rCode == 204) {
-				rBody = "";
-			} else if (rCode >= 200 && rCode < 300) {
-				rBody = getResponseBody(conn.getInputStream());
-			} else {
-				rBody = getResponseBody(conn.getErrorStream());
-			}
-			return new EasyPostResponse(rCode, rBody);
-		} catch (IOException e) {
-			throw new EasyPostException(
-				String.format(
-					"Could not connect to EasyPost (%s). "
-						+ "Please check your internet connection and try again. If this problem persists,"
-						+ "please contact us at support@easypost.com.", EasyPost.API_BASE), e);
-		} finally {
-			if (conn != null) {
-				conn.disconnect();
-			}
-		}
-	}
-
-	protected static <T> T request(EasyPostResource.RequestMethod method, String url, Map<String, Object> params, Class<T> clazz, String apiKey) throws EasyPostException {
-		return request(method, url, params, clazz, apiKey, true);
-	}
-
-	protected static <T> T request(EasyPostResource.RequestMethod method, String url, Map<String, Object> params, Class<T> clazz, String apiKey, boolean apiKeyRequired) throws EasyPostException {
-		String originalDNSCacheTTL = null;
-		Boolean allowedToSetTTL = true;
-		try {
-			originalDNSCacheTTL = java.security.Security.getProperty(DNS_CACHE_TTL_PROPERTY_NAME);
-			// disable DNS cache
-			java.security.Security.setProperty(DNS_CACHE_TTL_PROPERTY_NAME, "0");
-		} catch (SecurityException se) {
-			allowedToSetTTL = false;
-		}
-
-		try {
-			return _request(method, url, params, clazz, apiKey, apiKeyRequired);
-		} finally {
-			if (allowedToSetTTL) {
-				if (originalDNSCacheTTL == null) {
-					// value unspecified by implementation
-					java.security.Security.setProperty(DNS_CACHE_TTL_PROPERTY_NAME, "-1"); // cache forever
-				} else {
-					java.security.Security.setProperty(DNS_CACHE_TTL_PROPERTY_NAME, originalDNSCacheTTL);
-				}
-			}
-		}
-	}
-
-	protected static <T> T _request(EasyPostResource.RequestMethod method, String url, Map<String, Object> params, Class<T> clazz, String apiKey, boolean apiKeyRequired) throws EasyPostException {
-		if ((EasyPost.apiKey == null || EasyPost.apiKey.length() == 0) && (apiKey == null || apiKey.length() == 0)) {
-			if (apiKeyRequired) {
-				throw new EasyPostException(
-						"No API key provided. (set your API key using 'EasyPost.apiKey = {KEY}'. "
-								+ "Your API key can be found in your EasyPost dashboard, or you can email us at support@easypost.com for assistance.");
-
-			}
-		}
-
-		if (apiKey == null) {
-			apiKey = EasyPost.apiKey;
-		}
-
-		String query;
-		try {
-			query = createQuery(params);
-		} catch (UnsupportedEncodingException e) {
-			throw new EasyPostException("Unable to encode parameters to "
-				+ CHARSET
-				+ ". Please email support@easypost.com for assistance.", e);
-		}
-
-        // System.out.println(url);
-
-		EasyPostResponse response;
-		try {
-			// HTTPSURLConnection verifies SSL cert by default
-			response = makeURLConnectionRequest(method, url, query, apiKey);
-		} catch (ClassCastException ce) {
-			// appengine
-			String appEngineEnv = System.getProperty("com.google.appengine.runtime.environment", null);
-			if (appEngineEnv != null) {
-				response = makeAppEngineRequest(method, url, query, apiKey);
-			} else {
-				throw ce;
-			}
-		}
-		int rCode = response.responseCode;
-		String rBody = response.responseBody;
-		if (rCode < 200 || rCode >= 300) {
-			handleAPIError(rBody, rCode);
-		}
-
-		return gson.fromJson(rBody, clazz);
-	}
-
-	private static void handleAPIError(String rBody, int rCode) throws EasyPostException {
-		try {
-			EasyPostResource.Error error = gson.fromJson(rBody, EasyPostResource.Error.class);
-
-			if(error.error.length() > 0) {
-				throw new EasyPostException(error.error);
-			}
-
-			throw new EasyPostException(error.message, error.param, null);
-		} catch (Exception e) {
-            throw new EasyPostException(String.format("An error occured. Response code: %s Response body: %s", rCode, rBody));
+        try {
+          Object value = fromMethod.invoke(update, (Object[]) null);
+          if (value != null) {
+            Method toMethod = obj.getClass().getMethod(toName, fromMethod.getReturnType());
+            toMethod.invoke(obj, value);
+          }
+        } catch (Exception e) {
+          e.printStackTrace();
         }
-	}
+      }
+    }
+  }
 
-	private static EasyPostResponse makeAppEngineRequest(RequestMethod method, String url, String query, String apiKey) throws EasyPostException {
-		String unknownErrorMessage = "Sorry, an unknown error occurred while trying to use the "
-			+ "Google App Engine runtime. Please email support@easypost.com for assistance.";
-		try {
-			if (method == RequestMethod.GET || method == RequestMethod.DELETE) {
-				url = String.format("%s?%s", url, query);
-			}
-			URL fetchURL = new URL(url);
+  public static final String CHARSET = "UTF-8";
 
-			Class<?> requestMethodClass = Class.forName("com.google.appengine.api.urlfetch.HTTPMethod");
-			Object httpMethod = requestMethodClass.getDeclaredField(method.name()).get(null);
+  private static final String DNS_CACHE_TTL_PROPERTY_NAME = "networkaddress.cache.ttl";
 
-			Class<?> fetchOptionsBuilderClass = Class.forName("com.google.appengine.api.urlfetch.FetchOptions$Builder");
-			Object fetchOptions = null;
-			try {
-				fetchOptions = fetchOptionsBuilderClass.getDeclaredMethod("validateCertificate").invoke(null);
-			} catch (NoSuchMethodException e) {
-				System.err
-					.println("Warning: this App Engine SDK version does not allow verification of SSL certificates;"
-						+ "this exposes you to a MITM attack. Please upgrade your App Engine SDK to >=1.5.0. "
-						+ "If you have questions, email support@easypost.com.");
-				fetchOptions = fetchOptionsBuilderClass.getDeclaredMethod("withDefaults").invoke(null);
-			}
+  // Set this property to override your environment's default URLStreamHandler.
+  private static final String CUSTOM_URL_STREAM_HANDLER_PROPERTY_NAME = "com.easypost.net.customURLStreamHandler";
 
-			Class<?> fetchOptionsClass = Class.forName("com.google.appengine.api.urlfetch.FetchOptions");
+  protected enum RequestMethod {
+    GET, POST, DELETE, PUT
+  }
 
-			// Heroku times out after 30s, so leave some time for the API to return a response
-			fetchOptionsClass.getDeclaredMethod("setDeadline", java.lang.Double.class).invoke(fetchOptions, new Double(20));
+  private static String urlEncodePair(String k, String v) throws UnsupportedEncodingException {
+    return String.format("%s=%s", URLEncoder.encode(k, CHARSET), URLEncoder.encode(v, CHARSET));
+  }
 
-			Class<?> requestClass = Class.forName("com.google.appengine.api.urlfetch.HTTPRequest");
+  static Map<String, String> getHeaders(String apiKey) {
+    Map<String, String> headers = new HashMap<String, String>();
+    headers.put("Accept-Charset", CHARSET);
+    headers.put("User-Agent", String.format("EasyPost/v2 JavaClient/%s", EasyPost.VERSION));
 
-			Object request = requestClass.getDeclaredConstructor(URL.class, requestMethodClass, fetchOptionsClass).newInstance(fetchURL, httpMethod, fetchOptions);
+    if (apiKey == null) {
+      apiKey = EasyPost.apiKey;
+    }
 
-			if (method == RequestMethod.POST) {
-				requestClass.getDeclaredMethod("setPayload", byte[].class).invoke(request, query.getBytes());
-			}
+    headers.put("Authorization", String.format("Bearer %s", apiKey));
 
-			for (Map.Entry<String, String> header : getHeaders(apiKey).entrySet()) {
-				Class<?> httpHeaderClass = Class.forName("com.google.appengine.api.urlfetch.HTTPHeader");
-				Object reqHeader = httpHeaderClass.getDeclaredConstructor(String.class, String.class).newInstance(header.getKey(), header.getValue());
-				requestClass.getDeclaredMethod("setHeader", httpHeaderClass).invoke(request, reqHeader);
-			}
+    // debug headers
+    String[] propertyNames = { "os.name", "os.version", "os.arch", "java.version", "java.vendor", "java.vm.version",
+        "java.vm.vendor" };
+    Map<String, String> propertyMap = new HashMap<String, String>();
+    for (String propertyName : propertyNames) {
+      propertyMap.put(propertyName, System.getProperty(propertyName));
+    }
+    propertyMap.put("lang", "Java");
+    propertyMap.put("publisher", "EasyPost");
+    headers.put("X-Client-User-Agent", gson.toJson(propertyMap));
 
-			Class<?> urlFetchFactoryClass = Class.forName("com.google.appengine.api.urlfetch.URLFetchServiceFactory");
-			Object urlFetchService = urlFetchFactoryClass.getDeclaredMethod("getURLFetchService").invoke(null);
+    return headers;
+  }
 
-			Method fetchMethod = urlFetchService.getClass().getDeclaredMethod("fetch", requestClass);
-			fetchMethod.setAccessible(true);
-			Object response = fetchMethod.invoke(urlFetchService, request);
+  private static javax.net.ssl.HttpsURLConnection createEasyPostConnection(String url, String apiKey)
+      throws IOException {
+    URL easypostURL = null;
+    String customURLStreamHandlerClassName = System.getProperty(CUSTOM_URL_STREAM_HANDLER_PROPERTY_NAME, null);
+    if (customURLStreamHandlerClassName != null) {
+      // instantiate the custom handler provided
+      try {
+        Class<URLStreamHandler> clazz = (Class<URLStreamHandler>) Class.forName(customURLStreamHandlerClassName);
+        Constructor<URLStreamHandler> constructor = clazz.getConstructor();
+        URLStreamHandler customHandler = constructor.newInstance();
+        easypostURL = new URL(null, url, customHandler);
+      } catch (ClassNotFoundException e) {
+        throw new IOException(e);
+      } catch (SecurityException e) {
+        throw new IOException(e);
+      } catch (NoSuchMethodException e) {
+        throw new IOException(e);
+      } catch (IllegalArgumentException e) {
+        throw new IOException(e);
+      } catch (InstantiationException e) {
+        throw new IOException(e);
+      } catch (IllegalAccessException e) {
+        throw new IOException(e);
+      } catch (InvocationTargetException e) {
+        throw new IOException(e);
+      }
+    } else {
+      easypostURL = new URL(url);
+    }
+    javax.net.ssl.HttpsURLConnection conn = (javax.net.ssl.HttpsURLConnection) easypostURL.openConnection();
+    conn.setConnectTimeout(20000); // 20 seconds
 
-			int responseCode = (Integer) response.getClass().getDeclaredMethod("getResponseCode").invoke(response);
-			String body = new String((byte[]) response.getClass().getDeclaredMethod("getContent").invoke(response), CHARSET);
+    int readTimeout;
+    if (EasyPost.readTimeout != 0) {
+      readTimeout = EasyPost.readTimeout;
+    } else {
+      readTimeout = 40000; // 40 seconds by default
+    }
+    conn.setReadTimeout(readTimeout);
 
-			return new EasyPostResponse(responseCode, body);
+    conn.setUseCaches(false);
+    for (Map.Entry<String, String> header : getHeaders(apiKey).entrySet()) {
+      conn.setRequestProperty(header.getKey(), header.getValue());
+    }
 
-		} catch (InvocationTargetException e) {
-			throw new EasyPostException(unknownErrorMessage, e);
-		} catch (MalformedURLException e) {
-			throw new EasyPostException(unknownErrorMessage, e);
-		} catch (NoSuchFieldException e) {
-			throw new EasyPostException(unknownErrorMessage, e);
-		} catch (SecurityException e) {
-			throw new EasyPostException(unknownErrorMessage, e);
-		} catch (NoSuchMethodException e) {
-			throw new EasyPostException(unknownErrorMessage, e);
-		} catch (ClassNotFoundException e) {
-			throw new EasyPostException(unknownErrorMessage, e);
-		} catch (IllegalArgumentException e) {
-			throw new EasyPostException(unknownErrorMessage, e);
-		} catch (IllegalAccessException e) {
-			throw new EasyPostException(unknownErrorMessage, e);
-		} catch (InstantiationException e) {
-			throw new EasyPostException(unknownErrorMessage, e);
-		} catch (UnsupportedEncodingException e) {
-			throw new EasyPostException(unknownErrorMessage, e);
-		}
-	}
+    return conn;
+  }
 
-	public static final ArrayList<String> GLOBAL_FIELD_ACCESSORS = new ArrayList<>(Arrays.asList("getCreatedAt", "getUpdatedAt", "getFees"));
-	Date CreatedAt;
-	Date UpdatedAt;
-	ArrayList<Fee> fees;
+  private static javax.net.ssl.HttpsURLConnection createGetConnection(String url, String query, String apiKey)
+      throws IOException {
+    String getURL = String.format("%s?%s", url, query);
+    javax.net.ssl.HttpsURLConnection conn = createEasyPostConnection(getURL, apiKey);
+    conn.setRequestMethod("GET");
+    return conn;
+  }
 
-	public Date getCreatedAt() {
-		return CreatedAt;
-	}
-	public void setCreatedAt(Date createdAt) {
-		CreatedAt = createdAt;
-	}
+  private static javax.net.ssl.HttpsURLConnection createPostConnection(String url, String query, String apiKey)
+      throws IOException {
+    javax.net.ssl.HttpsURLConnection conn = createEasyPostConnection(url, apiKey);
+    conn.setDoOutput(true);
+    conn.setRequestMethod("POST");
+    conn.setRequestProperty("Content-Type", String.format("application/x-www-form-urlencoded;charset=%s", CHARSET));
+    OutputStream output = null;
+    try {
+      output = conn.getOutputStream();
+      output.write(query.getBytes(CHARSET));
+    } finally {
+      if (output != null) {
+        output.close();
+      }
+    }
+    return conn;
+  }
 
-	public Date getUpdatedAt() {
-		return UpdatedAt;
-	}
-	public void setUpdatedAt(Date updatedAt) {
-		UpdatedAt = updatedAt;
-	}
+  private static javax.net.ssl.HttpsURLConnection createDeleteConnection(String url, String query, String apiKey)
+      throws IOException {
+    String deleteUrl = String.format("%s?%s", url, query);
+    javax.net.ssl.HttpsURLConnection conn = createEasyPostConnection(deleteUrl, apiKey);
+    conn.setRequestMethod("DELETE");
+    return conn;
+  }
 
-	public ArrayList<Fee> getFees() {
-		return fees;
-	}
-	public void setFees(ArrayList<Fee> fees) {
-		this.fees = fees;
-	}
+  private static javax.net.ssl.HttpsURLConnection createPutConnection(String url, String query, String apiKey)
+      throws IOException {
+    javax.net.ssl.HttpsURLConnection conn = createEasyPostConnection(url, apiKey);
+    conn.setDoOutput(true);
+    conn.setRequestMethod("PUT");
+    conn.setRequestProperty("Content-Type", String.format("application/x-www-form-urlencoded;charset=%s", CHARSET));
+    OutputStream output = null;
+    try {
+      output = conn.getOutputStream();
+      output.write(query.getBytes(CHARSET));
+    } finally {
+      if (output != null) {
+        output.close();
+      }
+    }
+    return conn;
+  }
 
-	public String getId() {
-		return "";
-	}
-	public String getMode() {
-		return "";
-	}
-	// Batch
-	public List<Shipment> getShipments() {
-		return new ArrayList<Shipment>();
-	}
-	// public BatchStatus getStatus() {
-	// 	return new BatchStatus();
-	// }
-	public String getLabelUrl() {
-		return "";
-	}
-	// Tracker
-	public String getShipmentId() {
-		return "";
-	}
-	public String getTrackingCode() {
-		return "";
-	}
-	public String getStatus() {
-		return "";
-	}
-	public List<TrackingDetail> getTrackingDetails() {
-		return new ArrayList<TrackingDetail>();
-	}
+  private static String createQuery(Map<String, Object> params) throws UnsupportedEncodingException {
+    Map<String, String> flatParams = flattenParams(params);
+    StringBuffer queryStringBuffer = new StringBuffer();
+    for (Map.Entry<String, String> entry : flatParams.entrySet()) {
+      queryStringBuffer.append("&");
+      queryStringBuffer.append(urlEncodePair(entry.getKey(), entry.getValue()));
+    }
+    if (queryStringBuffer.length() > 0) {
+      queryStringBuffer.deleteCharAt(0);
+    }
+    return queryStringBuffer.toString();
+  }
+
+  private static Map<String, String> flattenParams(Map<String, Object> params) {
+    if (params == null) {
+      return new HashMap<String, String>();
+    }
+    Map<String, String> flatParams = new HashMap<String, String>();
+    for (Map.Entry<String, Object> entry : params.entrySet()) {
+      String key = entry.getKey();
+      Object value = entry.getValue();
+      if (value instanceof Map<?, ?>) {
+        Map<String, Object> flatNestedMap = new HashMap<String, Object>();
+        Map<?, ?> nestedMap = (Map<?, ?>) value;
+        for (Map.Entry<?, ?> nestedEntry : nestedMap.entrySet()) {
+          flatNestedMap.put(String.format("%s[%s]", key, nestedEntry.getKey()), nestedEntry.getValue());
+        }
+        flatParams.putAll(flattenParams(flatNestedMap));
+      } else if (value instanceof List) {
+        Map<String, Object> flatNestedMap = new HashMap<String, Object>();
+        List<?> nestedList = (List<?>) value;
+        for (int i = 0; i < nestedList.size(); i++) {
+          flatNestedMap.put(String.format("%s[%s]", key, i), nestedList.get(i));
+          flatParams.putAll(flattenParams(flatNestedMap));
+        }
+      } else if (value instanceof EasyPostResource) {
+        flatParams.put(String.format("%s[%s]", key, "id"), value.toString());
+
+      } else if (value != null) {
+        flatParams.put(key, value.toString());
+      }
+    }
+
+    // System.out.println(flatParams);
+
+    return flatParams;
+  }
+
+  // represents Errors returned as JSON
+  private static class ErrorContainer {
+    private EasyPostResource.Error error;
+  }
+
+  private static class Error {
+    @SuppressWarnings("unused")
+    String type;
+    String message;
+    String code;
+    String param;
+    String error;
+  }
+
+  private static String getResponseBody(InputStream responseStream) throws IOException {
+    String rBody = new Scanner(responseStream, CHARSET).useDelimiter("\\A").next();
+    responseStream.close();
+    return rBody;
+  }
+
+  private static EasyPostResponse makeURLConnectionRequest(EasyPostResource.RequestMethod method, String url,
+      String query, String apiKey) throws EasyPostException {
+    javax.net.ssl.HttpsURLConnection conn = null;
+    try {
+      switch (method) {
+        case GET:
+          conn = createGetConnection(url, query, apiKey);
+          break;
+        case POST:
+          conn = createPostConnection(url, query, apiKey);
+          break;
+        case DELETE:
+          conn = createDeleteConnection(url, query, apiKey);
+          break;
+        case PUT:
+          conn = createPutConnection(url, query, apiKey);
+          break;
+        default:
+          throw new EasyPostException(
+              String.format("Unrecognized HTTP method %s. Please contact EasyPost at support@easypost.com.", method));
+      }
+      int rCode = conn.getResponseCode(); // sends the request
+      String rBody = null;
+      if (rCode == 204) {
+        rBody = "";
+      } else if (rCode >= 200 && rCode < 300) {
+        rBody = getResponseBody(conn.getInputStream());
+      } else {
+        rBody = getResponseBody(conn.getErrorStream());
+      }
+      return new EasyPostResponse(rCode, rBody);
+    } catch (IOException e) {
+      throw new EasyPostException(String.format("Could not connect to EasyPost (%s). "
+          + "Please check your internet connection and try again. If this problem persists,"
+          + "please contact us at support@easypost.com.", EasyPost.API_BASE), e);
+    } finally {
+      if (conn != null) {
+        conn.disconnect();
+      }
+    }
+  }
+
+  protected static <T> T request(EasyPostResource.RequestMethod method, String url, Map<String, Object> params,
+      Class<T> clazz, String apiKey) throws EasyPostException {
+    return request(method, url, params, clazz, apiKey, true);
+  }
+
+  protected static <T> T request(EasyPostResource.RequestMethod method, String url, Map<String, Object> params,
+      Class<T> clazz, String apiKey, boolean apiKeyRequired) throws EasyPostException {
+    String originalDNSCacheTTL = null;
+    Boolean allowedToSetTTL = true;
+    try {
+      originalDNSCacheTTL = java.security.Security.getProperty(DNS_CACHE_TTL_PROPERTY_NAME);
+      // disable DNS cache
+      java.security.Security.setProperty(DNS_CACHE_TTL_PROPERTY_NAME, "0");
+    } catch (SecurityException se) {
+      allowedToSetTTL = false;
+    }
+
+    try {
+      return _request(method, url, params, clazz, apiKey, apiKeyRequired);
+    } finally {
+      if (allowedToSetTTL) {
+        if (originalDNSCacheTTL == null) {
+          // value unspecified by implementation
+          java.security.Security.setProperty(DNS_CACHE_TTL_PROPERTY_NAME, "-1"); // cache forever
+        } else {
+          java.security.Security.setProperty(DNS_CACHE_TTL_PROPERTY_NAME, originalDNSCacheTTL);
+        }
+      }
+    }
+  }
+
+  protected static <T> T _request(EasyPostResource.RequestMethod method, String url, Map<String, Object> params,
+      Class<T> clazz, String apiKey, boolean apiKeyRequired) throws EasyPostException {
+    if ((EasyPost.apiKey == null || EasyPost.apiKey.length() == 0) && (apiKey == null || apiKey.length() == 0)) {
+      if (apiKeyRequired) {
+        throw new EasyPostException("No API key provided. (set your API key using 'EasyPost.apiKey = {KEY}'. "
+            + "Your API key can be found in your EasyPost dashboard, or you can email us at support@easypost.com for assistance.");
+
+      }
+    }
+
+    if (apiKey == null) {
+      apiKey = EasyPost.apiKey;
+    }
+
+    String query;
+    try {
+      query = createQuery(params);
+    } catch (UnsupportedEncodingException e) {
+      throw new EasyPostException(
+          "Unable to encode parameters to " + CHARSET + ". Please email support@easypost.com for assistance.", e);
+    }
+
+    // System.out.println(url);
+
+    EasyPostResponse response;
+    try {
+      // HTTPSURLConnection verifies SSL cert by default
+      response = makeURLConnectionRequest(method, url, query, apiKey);
+    } catch (ClassCastException ce) {
+      // appengine
+      String appEngineEnv = System.getProperty("com.google.appengine.runtime.environment", null);
+      if (appEngineEnv != null) {
+        response = makeAppEngineRequest(method, url, query, apiKey);
+      } else {
+        throw ce;
+      }
+    }
+    int rCode = response.responseCode;
+    String rBody = response.responseBody;
+    if (rCode < 200 || rCode >= 300) {
+      handleAPIError(rBody, rCode);
+    }
+
+    return gson.fromJson(rBody, clazz);
+  }
+
+  private static void handleAPIError(String rBody, int rCode) throws EasyPostException {
+    try {
+      EasyPostResource.Error error = gson.fromJson(rBody, EasyPostResource.Error.class);
+
+      if (error.error.length() > 0) {
+        throw new EasyPostException(error.error);
+      }
+
+      throw new EasyPostException(error.message, error.param, null);
+    } catch (Exception e) {
+      throw new EasyPostException(String.format("An error occured. Response code: %s Response body: %s", rCode, rBody));
+    }
+  }
+
+  private static EasyPostResponse makeAppEngineRequest(RequestMethod method, String url, String query, String apiKey)
+      throws EasyPostException {
+    String unknownErrorMessage = "Sorry, an unknown error occurred while trying to use the "
+        + "Google App Engine runtime. Please email support@easypost.com for assistance.";
+    try {
+      if (method == RequestMethod.GET || method == RequestMethod.DELETE) {
+        url = String.format("%s?%s", url, query);
+      }
+      URL fetchURL = new URL(url);
+
+      Class<?> requestMethodClass = Class.forName("com.google.appengine.api.urlfetch.HTTPMethod");
+      Object httpMethod = requestMethodClass.getDeclaredField(method.name()).get(null);
+
+      Class<?> fetchOptionsBuilderClass = Class.forName("com.google.appengine.api.urlfetch.FetchOptions$Builder");
+      Object fetchOptions = null;
+      try {
+        fetchOptions = fetchOptionsBuilderClass.getDeclaredMethod("validateCertificate").invoke(null);
+      } catch (NoSuchMethodException e) {
+        System.err.println("Warning: this App Engine SDK version does not allow verification of SSL certificates;"
+            + "this exposes you to a MITM attack. Please upgrade your App Engine SDK to >=1.5.0. "
+            + "If you have questions, email support@easypost.com.");
+        fetchOptions = fetchOptionsBuilderClass.getDeclaredMethod("withDefaults").invoke(null);
+      }
+
+      Class<?> fetchOptionsClass = Class.forName("com.google.appengine.api.urlfetch.FetchOptions");
+
+      // Heroku times out after 30s, so leave some time for the API to return a
+      // response
+      fetchOptionsClass.getDeclaredMethod("setDeadline", java.lang.Double.class).invoke(fetchOptions, new Double(20));
+
+      Class<?> requestClass = Class.forName("com.google.appengine.api.urlfetch.HTTPRequest");
+
+      Object request = requestClass.getDeclaredConstructor(URL.class, requestMethodClass, fetchOptionsClass)
+          .newInstance(fetchURL, httpMethod, fetchOptions);
+
+      if (method == RequestMethod.POST) {
+        requestClass.getDeclaredMethod("setPayload", byte[].class).invoke(request, query.getBytes());
+      }
+
+      for (Map.Entry<String, String> header : getHeaders(apiKey).entrySet()) {
+        Class<?> httpHeaderClass = Class.forName("com.google.appengine.api.urlfetch.HTTPHeader");
+        Object reqHeader = httpHeaderClass.getDeclaredConstructor(String.class, String.class)
+            .newInstance(header.getKey(), header.getValue());
+        requestClass.getDeclaredMethod("setHeader", httpHeaderClass).invoke(request, reqHeader);
+      }
+
+      Class<?> urlFetchFactoryClass = Class.forName("com.google.appengine.api.urlfetch.URLFetchServiceFactory");
+      Object urlFetchService = urlFetchFactoryClass.getDeclaredMethod("getURLFetchService").invoke(null);
+
+      Method fetchMethod = urlFetchService.getClass().getDeclaredMethod("fetch", requestClass);
+      fetchMethod.setAccessible(true);
+      Object response = fetchMethod.invoke(urlFetchService, request);
+
+      int responseCode = (Integer) response.getClass().getDeclaredMethod("getResponseCode").invoke(response);
+      String body = new String((byte[]) response.getClass().getDeclaredMethod("getContent").invoke(response), CHARSET);
+
+      return new EasyPostResponse(responseCode, body);
+
+    } catch (InvocationTargetException e) {
+      throw new EasyPostException(unknownErrorMessage, e);
+    } catch (MalformedURLException e) {
+      throw new EasyPostException(unknownErrorMessage, e);
+    } catch (NoSuchFieldException e) {
+      throw new EasyPostException(unknownErrorMessage, e);
+    } catch (SecurityException e) {
+      throw new EasyPostException(unknownErrorMessage, e);
+    } catch (NoSuchMethodException e) {
+      throw new EasyPostException(unknownErrorMessage, e);
+    } catch (ClassNotFoundException e) {
+      throw new EasyPostException(unknownErrorMessage, e);
+    } catch (IllegalArgumentException e) {
+      throw new EasyPostException(unknownErrorMessage, e);
+    } catch (IllegalAccessException e) {
+      throw new EasyPostException(unknownErrorMessage, e);
+    } catch (InstantiationException e) {
+      throw new EasyPostException(unknownErrorMessage, e);
+    } catch (UnsupportedEncodingException e) {
+      throw new EasyPostException(unknownErrorMessage, e);
+    }
+  }
+
+  public static final ArrayList<String> GLOBAL_FIELD_ACCESSORS = new ArrayList<>(
+      Arrays.asList("getCreatedAt", "getUpdatedAt", "getFees"));
+  Date CreatedAt;
+  Date UpdatedAt;
+  ArrayList<Fee> fees;
+
+  public Date getCreatedAt() {
+    return CreatedAt;
+  }
+
+  public void setCreatedAt(Date createdAt) {
+    CreatedAt = createdAt;
+  }
+
+  public Date getUpdatedAt() {
+    return UpdatedAt;
+  }
+
+  public void setUpdatedAt(Date updatedAt) {
+    UpdatedAt = updatedAt;
+  }
+
+  public ArrayList<Fee> getFees() {
+    return fees;
+  }
+
+  public void setFees(ArrayList<Fee> fees) {
+    this.fees = fees;
+  }
+
+  public String getId() {
+    return "";
+  }
+
+  public String getMode() {
+    return "";
+  }
+
+  // Batch
+  public List<Shipment> getShipments() {
+    return new ArrayList<Shipment>();
+  }
+
+  // public BatchStatus getStatus() {
+  // return new BatchStatus();
+  // }
+  public String getLabelUrl() {
+    return "";
+  }
+
+  // Tracker
+  public String getShipmentId() {
+    return "";
+  }
+
+  public String getTrackingCode() {
+    return "";
+  }
+
+  public String getStatus() {
+    return "";
+  }
+
+  public List<TrackingDetail> getTrackingDetails() {
+    return new ArrayList<TrackingDetail>();
+  }
 
 }

--- a/src/main/java/com/easypost/net/EasyPostResponse.java
+++ b/src/main/java/com/easypost/net/EasyPostResponse.java
@@ -2,29 +2,27 @@ package com.easypost.net;
 
 public class EasyPostResponse {
 
-	int responseCode;
-	String responseBody;
+  int responseCode;
+  String responseBody;
 
-	public EasyPostResponse(int responseCode, String responseBody) {
-		this.responseCode = responseCode;
-		this.responseBody = responseBody;
+  public EasyPostResponse(int responseCode, String responseBody) {
+    this.responseCode = responseCode;
+    this.responseBody = responseBody;
+  }
 
-    // System.out.println(this.responseBody);
-	}
+  public int getResponseCode() {
+    return responseCode;
+  }
 
-	public int getResponseCode() {
-		return responseCode;
-	}
+  public void setResponseCode(int responseCode) {
+    this.responseCode = responseCode;
+  }
 
-	public void setResponseCode(int responseCode) {
-		this.responseCode = responseCode;
-	}
+  public String getResponseBody() {
+    return responseBody;
+  }
 
-	public String getResponseBody() {
-		return responseBody;
-	}
-
-	public void setResponseBody(String responseBody) {
-		this.responseBody = responseBody;
-	}
+  public void setResponseBody(String responseBody) {
+    this.responseBody = responseBody;
+  }
 }

--- a/src/test/java/com/easypost/EasyPostTest.java
+++ b/src/test/java/com/easypost/EasyPostTest.java
@@ -253,28 +253,22 @@ public class EasyPostTest {
     assertNotNull(tracker.getFees());
     assertEquals(tracker.getFees().size(), 1);
 
-    // This Est Delivery Date test confirms that the timestamps are within 1.5 seconds of each other
+    // This Est Delivery Date test confirms that the timestamps are within 1.5
+    // seconds of each other
     // (rather than exactly equal)
-    assertTrue(
-        "Est delivery dates aren't within expected timeframe",
+    assertTrue("Est delivery dates aren't within expected timeframe",
         Math.abs((new Date()).getTime() - tracker.getEstDeliveryDate().getTime()) < 1500);
 
     assertEquals("Weights don't match", 17.6, tracker.getWeight(), 0.0001);
     assertEquals("Signed By doesn't match", "John Tester", tracker.getSignedBy());
-    assertEquals(
-        "Service levels don't match", "FEDEX_GROUND", tracker.getCarrierDetail().getService());
-    assertEquals(
-        "Containers don't match", "YOUR_PACKAGING", tracker.getCarrierDetail().getContainerType());
+    assertEquals("Service levels don't match", "FEDEX_GROUND", tracker.getCarrierDetail().getService());
+    assertEquals("Containers don't match", "YOUR_PACKAGING", tracker.getCarrierDetail().getContainerType());
 
-    assertNotNull(
-        "Destination Location is null", tracker.getCarrierDetail().getDestinationLocation());
-    assertNotNull(
-        "Initial Delivery Attempt is null", tracker.getCarrierDetail().getInitialDeliveryAttempt());
+    assertNotNull("Destination Location is null", tracker.getCarrierDetail().getDestinationLocation());
+    assertNotNull("Initial Delivery Attempt is null", tracker.getCarrierDetail().getInitialDeliveryAttempt());
 
-    assertNotNull(
-        "Est delivery Date local is null", tracker.getCarrierDetail().getEstDeliveryDateLocal());
-    assertNotNull(
-        "Est delivery Time local is null", tracker.getCarrierDetail().getEstDeliveryTimeLocal());
+    assertNotNull("Est delivery Date local is null", tracker.getCarrierDetail().getEstDeliveryDateLocal());
+    assertNotNull("Est delivery Time local is null", tracker.getCarrierDetail().getEstDeliveryTimeLocal());
     assertNotNull("Created at is null", tracker.getCreatedAt());
     assertNotNull("Updated at is null", tracker.getUpdateAt());
     assertNotNull("PublicURL is not null", tracker.getPublicUrl());
@@ -288,19 +282,13 @@ public class EasyPostTest {
     assertNotNull(tracker.getCarrier());
     assertNotNull(retrieved.getCarrier());
     assertEquals("Tracker carriers are not the same", tracker.getCarrier(), retrieved.getCarrier());
-    assertEquals(
-        "Tracker StatusDetail is not populated",
-        "arrived_at_destination",
-        tracker.getStatusDetail());
+    assertEquals("Tracker StatusDetail is not populated", "arrived_at_destination", tracker.getStatusDetail());
 
     TrackingDetail trackingDetail = tracker.getTrackingDetails().get(0);
     TrackingDetail retrievedDetail = tracker.getTrackingDetails().get(0);
 
     assertEquals("TrackingDetails are not the same", trackingDetail, retrievedDetail);
-    assertEquals(
-        "TrackingDetail StatusDetail is not populated",
-        "status_update",
-        trackingDetail.getStatusDetail());
+    assertEquals("TrackingDetail StatusDetail is not populated", "status_update", trackingDetail.getStatusDetail());
 
     TrackingLocation trackingLocation = trackingDetail.getTrackingLocation();
     TrackingLocation retrievedLocation = retrievedDetail.getTrackingLocation();
@@ -353,9 +341,7 @@ public class EasyPostTest {
 
     assertEquals("Incorrect length received", trackers.getTrackers().size(), 30);
     assertTrue("'has_more' should be true", trackers.getHasMore());
-    assertEquals(
-        "Tracker ids in create response and all response are not the same",
-        trackers.getTrackers().get(0).id,
+    assertEquals("Tracker ids in create response and all response are not the same", trackers.getTrackers().get(0).id,
         tracker.id);
 
     // create another test tracker
@@ -370,9 +356,7 @@ public class EasyPostTest {
 
     assertEquals("Incorrect length received", trackers2.getTrackers().size(), 1);
     assertFalse("'has_more' should be true", trackers2.getHasMore());
-    assertEquals(
-        "Tracker ids in create response and all response are not the same",
-        trackers2.getTrackers().get(0).id,
+    assertEquals("Tracker ids in create response and all response are not the same", trackers2.getTrackers().get(0).id,
         tracker3.id);
   }
 
@@ -471,14 +455,9 @@ public class EasyPostTest {
 
     Map<String, AddressVerification> verifications = address.getVerifications();
     assertEquals("Verification did not succeed.", verifications.get("delivery").getSuccess(), true);
-    assertEquals(
-        "Verification had errors.",
-        verifications.get("delivery").getErrors(),
-        Collections.emptyList());
+    assertEquals("Verification had errors.", verifications.get("delivery").getErrors(), Collections.emptyList());
     assertNotNull("Address details is null.", verifications.get("delivery").getAddressDetail());
-    assertEquals(
-        "Address details did not have TZ.",
-        verifications.get("delivery").getAddressDetail().getTimeZone(),
+    assertEquals("Address details did not have TZ.", verifications.get("delivery").getAddressDetail().getTimeZone(),
         "America/Los_Angeles");
   }
 
@@ -504,18 +483,17 @@ public class EasyPostTest {
     assertEquals("City did not verify", address.getCity(), "SAN FRANCISCO");
 
     Map<String, AddressVerification> verifications = address.getVerifications();
-    assertEquals(
-        "Verification did not succeed.", verifications.get("delivery").getSuccess(), false);
+    assertEquals("Verification did not succeed.", verifications.get("delivery").getSuccess(), false);
 
     List<com.easypost.model.Error> errors = verifications.get("delivery").getErrors();
 
     assertTrue("At least two errors are present", errors.size() >= 2);
     assertEquals("Verification had a suggestion.", errors.get(0).getSuggestion(), null);
-    assertEquals(
-        "Verification error did not have a code.", errors.get(0).getCode(), "E.ADDRESS.NOT_FOUND");
+    assertEquals("Verification error did not have a code.", errors.get(0).getCode(), "E.ADDRESS.NOT_FOUND");
   }
 
-  @Rule public ExpectedException verifyStrictException = ExpectedException.none();
+  @Rule
+  public ExpectedException verifyStrictException = ExpectedException.none();
 
   @Test
   public void testAddressCreateWithVerifyStrictFails() throws EasyPostException {
@@ -538,7 +516,8 @@ public class EasyPostTest {
     Address address = Address.create(addressHash);
   }
 
-  @Rule public ExpectedException exception = ExpectedException.none();
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
 
   @Test
   public void testAddressErrorParses() throws EasyPostException {
@@ -574,10 +553,8 @@ public class EasyPostTest {
 
       assertThat(e.getMessage(), containsString("An error occured"));
       assertThat(e.getMessage(), containsString("Response code: 422"));
-      assertThat(
-          e.getMessage(),
-          containsString(
-              "\"error\":{\"code\":\"ADDRESS.VERIFY.FAILURE\",\"message\":\"Unable to verify address.\""));
+      assertThat(e.getMessage(),
+          containsString("\"error\":{\"code\":\"ADDRESS.VERIFY.FAILURE\",\"message\":\"Unable to verify address.\""));
     }
   }
 
@@ -799,14 +776,13 @@ public class EasyPostTest {
     buyCarriers.add("USPS");
     shipment = shipment.buy(shipment.lowestRate(buyCarriers));
 
-    ///System.out.println("Shipment.getForms(): >>"+shipment.getForms()+"<<");
+    /// System.out.println("Shipment.getForms(): >>"+shipment.getForms()+"<<");
     /// java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
     /// Form does not exists. Invalid test
     /*
-    assertTrue(
-        "Customs Form was not submitted electronically",
-        shipment.getForms().get(0).getSubmittedElectronically());
-        */
+     * assertTrue( "Customs Form was not submitted electronically",
+     * shipment.getForms().get(0).getSubmittedElectronically());
+     */
   }
 
   @Test
@@ -852,11 +828,8 @@ public class EasyPostTest {
 
     Insurance insurance2 = Insurance.retrieve(insurance.getId());
     assertNotNull("ID is null", insurance2.getId());
-    assertEquals(
-        "Create and Retrieve returned different ids", insurance.getId(), insurance2.getId());
-    assertEquals(
-        "Create and Retrieve returned different tracking codes",
-        insurance.getTrackingCode(),
+    assertEquals("Create and Retrieve returned different ids", insurance.getId(), insurance2.getId());
+    assertEquals("Create and Retrieve returned different tracking codes", insurance.getTrackingCode(),
         insurance2.getTrackingCode());
 
     Map<String, Object> index_params = new HashMap<String, Object>();
@@ -882,12 +855,8 @@ public class EasyPostTest {
     // Retrieve a shipment report
     Report shipmentReport2 = Report.retrieve(shipmentReport.getId());
     assertNotNull("ID is null", shipmentReport2.getId());
-    assertThat(
-        "ID is not a shipment report ID", shipmentReport2.getId(), containsString("shprep_"));
-    assertEquals(
-        "Create and Retrieve returned different ids",
-        shipmentReport.getId(),
-        shipmentReport2.getId());
+    assertThat("ID is not a shipment report ID", shipmentReport2.getId(), containsString("shprep_"));
+    assertEquals("Create and Retrieve returned different ids", shipmentReport.getId(), shipmentReport2.getId());
 
     // Index shipment reports
     paramMap.put("page_size", "4");
@@ -911,10 +880,7 @@ public class EasyPostTest {
     Report trackerReport2 = Report.retrieve(trackerReport.getId());
     assertNotNull("ID is null", trackerReport2.getId());
     assertThat("ID is not a tracker report ID", trackerReport2.getId(), containsString("trkrep_"));
-    assertEquals(
-        "Create and Retrieve returned different ids",
-        trackerReport.getId(),
-        trackerReport2.getId());
+    assertEquals("Create and Retrieve returned different ids", trackerReport.getId(), trackerReport2.getId());
 
     // Index tracker reports
     paramMap.put("page_size", "4");
@@ -932,18 +898,13 @@ public class EasyPostTest {
     // Create a payment_log report
     Report paymentLogReport = Report.create(paramMap);
     assertNotNull("ID is null", paymentLogReport.getId());
-    assertThat(
-        "ID is not a payment_log report ID", paymentLogReport.getId(), containsString("plrep_"));
+    assertThat("ID is not a payment_log report ID", paymentLogReport.getId(), containsString("plrep_"));
 
     // Retrieve a payment_log report
     Report paymentLogReport2 = Report.retrieve(paymentLogReport.getId());
     assertNotNull("ID is null", paymentLogReport2.getId());
-    assertThat(
-        "ID is not a payment_log report ID", paymentLogReport2.getId(), containsString("plrep_"));
-    assertEquals(
-        "Create and Retrieve returned different ids",
-        paymentLogReport.getId(),
-        paymentLogReport2.getId());
+    assertThat("ID is not a payment_log report ID", paymentLogReport2.getId(), containsString("plrep_"));
+    assertEquals("Create and Retrieve returned different ids", paymentLogReport.getId(), paymentLogReport2.getId());
 
     // Index payment_log reports
     paramMap.put("page_size", "4");
@@ -979,9 +940,7 @@ public class EasyPostTest {
 
     // Index webhooks
     WebhookCollection webhooks = Webhook.all();
-    assertEquals(
-        "Create and Retrieve returned different ids",
-        webhook.getId(),
+    assertEquals("Create and Retrieve returned different ids", webhook.getId(),
         webhooks.getWebhooks().get(webhooks.getWebhooks().size() - 1).getId());
 
     // Delete webhook
@@ -992,10 +951,8 @@ public class EasyPostTest {
     } catch (EasyPostException e) {
       assertThat(e.getMessage(), containsString("An error occured"));
       assertThat(e.getMessage(), containsString("Response code: 404"));
-      assertThat(
-          e.getMessage(),
-          containsString(
-              "{\"error\":{\"code\":\"NOT_FOUND\",\"message\":\"The requested resource could not be found.\",\"errors\":[]}}"));
+      assertThat(e.getMessage(), containsString(
+          "{\"error\":{\"code\":\"NOT_FOUND\",\"message\":\"The requested resource could not be found.\",\"errors\":[]}}"));
     }
   }
 
@@ -1015,9 +972,7 @@ public class EasyPostTest {
     ScanForm scanForm = ScanForm.create(paramMap);
 
     assertNotNull("No ID returned", scanForm.getId());
-    assertEquals(
-        "Shipment's tracking code not on Scan Form",
-        scanForm.getTrackingCodes().get(0),
+    assertEquals("Shipment's tracking code not on Scan Form", scanForm.getTrackingCodes().get(0),
         shipment.getTrackingCode());
 
     // retrieve ScanForm
@@ -1033,227 +988,222 @@ public class EasyPostTest {
   }
 
   /*
-  //This test needs to have new set of dates to avoid "report already exists" error
-  @Test
-  public void testShipmentReportDates() throws EasyPostException {
-    // Define request params
-    Map<String, Object> paramMap = new HashMap<String, Object>();
-    paramMap.put("type", "shipment");
-    paramMap.put("start_date", "2017-10-01");
-    paramMap.put("end_date", "2017-10-30");
-
-    // Create a shipment report
-    Report shipmentReport = Report.create(paramMap);
-    assertNotNull("ID is null", shipmentReport.getId());
-    assertThat("ID is not a shipment report ID", shipmentReport.getId(), containsString("shprep_"));
-
-    // Retrieve a shipment report
-    Report shipmentReport2 = Report.retrieve(shipmentReport.getId());
-    assertNotNull("ID is null", shipmentReport2.getId());
-    assertThat(
-        "ID is not a shipment report ID", shipmentReport2.getId(), containsString("shprep_"));
-    assertEquals(
-        "Create and Retrieve returned different ids",
-        shipmentReport.getId(),
-        shipmentReport2.getId());
-    assertEquals("Incorrect ShipmentReport start_date", shipmentReport2.getStartDate().toString(), "Sun Oct 01 00:00:00 PDT 2017");
-    assertEquals("Incorrect ShipmentReport end_date", shipmentReport2.getEndDate().toString(), "Mon Oct 30 00:00:00 PDT 2017");
-  }
-  */
+   * //This test needs to have new set of dates to avoid "report already exists"
+   * error
+   * 
+   * @Test public void testShipmentReportDates() throws EasyPostException { //
+   * Define request params Map<String, Object> paramMap = new HashMap<String,
+   * Object>(); paramMap.put("type", "shipment"); paramMap.put("start_date",
+   * "2017-10-01"); paramMap.put("end_date", "2017-10-30");
+   * 
+   * // Create a shipment report Report shipmentReport = Report.create(paramMap);
+   * assertNotNull("ID is null", shipmentReport.getId());
+   * assertThat("ID is not a shipment report ID", shipmentReport.getId(),
+   * containsString("shprep_"));
+   * 
+   * // Retrieve a shipment report Report shipmentReport2 =
+   * Report.retrieve(shipmentReport.getId()); assertNotNull("ID is null",
+   * shipmentReport2.getId()); assertThat( "ID is not a shipment report ID",
+   * shipmentReport2.getId(), containsString("shprep_")); assertEquals(
+   * "Create and Retrieve returned different ids", shipmentReport.getId(),
+   * shipmentReport2.getId()); assertEquals("Incorrect ShipmentReport start_date",
+   * shipmentReport2.getStartDate().toString(), "Sun Oct 01 00:00:00 PDT 2017");
+   * assertEquals("Incorrect ShipmentReport end_date",
+   * shipmentReport2.getEndDate().toString(), "Mon Oct 30 00:00:00 PDT 2017"); }
+   */
 
   /*
-   // This test requires a FedExSameDayCity account
-   @Test
-   public void testShipmentMessageInRateError() throws EasyPostException {
-     EasyPost.apiKey = "KEY";
-       Map<String, Object> address = new HashMap<String, Object>();
-       address.put("street1", "UNDELIVERABLE ST");
-       address.put("city", "SAN FRANCISCO");
-       address.put("state", "CA");
-       address.put("zip", "94105");
-       address.put("country", "US");
-     Map<String, Object> shipmentMap = new HashMap<String, Object>();
-     shipmentMap.put("to_address", address);
-     shipmentMap.put("from_address", defaultFromAddress);
-     shipmentMap.put("parcel", defaultParcel);
-     shipmentMap.put("carrier_accounts", "ca_123xyz");   // FedExSameDayCity carrier account id
-     Shipment shipment = Shipment.create(shipmentMap);
-             System.out.println(shipment.prettyPrint());
-     List<ShipmentMessage> messages = shipment.getMessages();
-     assertNotNull(messages);
-     assertEquals("Shipment message as an object did not parse.",messages.get(0).getMessage().toString(),
-                 "{code=E.ADDRESS.NOT_FOUND, field=address, message=Address not found, suggestion=null}");
-   }
-  */
+   * // This test requires a FedExSameDayCity account
+   * 
+   * @Test public void testShipmentMessageInRateError() throws EasyPostException {
+   * EasyPost.apiKey = "KEY"; Map<String, Object> address = new HashMap<String,
+   * Object>(); address.put("street1", "UNDELIVERABLE ST"); address.put("city",
+   * "SAN FRANCISCO"); address.put("state", "CA"); address.put("zip", "94105");
+   * address.put("country", "US"); Map<String, Object> shipmentMap = new
+   * HashMap<String, Object>(); shipmentMap.put("to_address", address);
+   * shipmentMap.put("from_address", defaultFromAddress);
+   * shipmentMap.put("parcel", defaultParcel); shipmentMap.put("carrier_accounts",
+   * "ca_123xyz"); // FedExSameDayCity carrier account id Shipment shipment =
+   * Shipment.create(shipmentMap); System.out.println(shipment.prettyPrint());
+   * List<ShipmentMessage> messages = shipment.getMessages();
+   * assertNotNull(messages);
+   * assertEquals("Shipment message as an object did not parse.",messages.get(0).
+   * getMessage().toString(),
+   * "{code=E.ADDRESS.NOT_FOUND, field=address, message=Address not found, suggestion=null}"
+   * ); }
+   */
 
   /*
-  // This test requires a FedEx account
-  @Test
-  public void testShipmentWithForm() throws EasyPostException {
-    Map<String, Object> optionsMap = new HashMap<String, Object>();
-    optionsMap.put("cod_amount", 10);
+   * // This test requires a FedEx account
+   * 
+   * @Test public void testShipmentWithForm() throws EasyPostException {
+   * Map<String, Object> optionsMap = new HashMap<String, Object>();
+   * optionsMap.put("cod_amount", 10);
+   * 
+   * Map<String, Object> shipmentMap = new HashMap<String, Object>();
+   * shipmentMap.put("to_address", defaultToAddress);
+   * shipmentMap.put("from_address", defaultFromAddress);
+   * shipmentMap.put("parcel", defaultParcel); shipmentMap.put("options",
+   * optionsMap); Shipment shipment = Shipment.create(shipmentMap);
+   * 
+   * List<String> buyCarriers = new ArrayList<String>(); buyCarriers.add("FEDEX");
+   * List<String> buyServices = new ArrayList<String>();
+   * buyServices.add("FEDEX_2_DAY"); shipment.buy(shipment.lowestRate(buyCarriers,
+   * buyServices));
+   * 
+   * assertNotNull(shipment.getForms().get(0).getFormUrl()); }
+   */
 
-    Map<String, Object> shipmentMap = new HashMap<String, Object>();
-    shipmentMap.put("to_address", defaultToAddress);
-    shipmentMap.put("from_address", defaultFromAddress);
-    shipmentMap.put("parcel", defaultParcel);
-    shipmentMap.put("options", optionsMap);
-    Shipment shipment = Shipment.create(shipmentMap);
+  // // This test requires a production api key
+  // @Test
+  // public void testUserMethods() throws EasyPostException {
+  // EasyPost.apiKey = "KEY"; // easypost private production key
+  //
+  // User user = User.retrieveMe();
+  //
+  // System.out.println(user.getPhoneNumber());
+  // System.out.println(user.getRechargeAmount());
+  // System.out.println(user.getSecondaryRechargeAmount());
+  //
+  // user.setSecondaryRechargeAmount("$200.00");
+  //
+  // Map<String, Object> userHash = new HashMap<String, Object>();
+  // userHash.put("secondary_recharge_amount", 100000.00);
+  //
+  // user.update(userHash);
+  //
+  // System.out.println(user.getSecondaryRechargeAmount());
+  //
+  // System.out.println(user.getRechargeThreshold());
+  // }
 
-    List<String> buyCarriers = new ArrayList<String>();
-    buyCarriers.add("FEDEX");
-    List<String> buyServices = new ArrayList<String>();
-    buyServices.add("FEDEX_2_DAY");
-    shipment.buy(shipment.lowestRate(buyCarriers, buyServices));
-
-    assertNotNull(shipment.getForms().get(0).getFormUrl());
-  }
-  */
-
-  //  //  This test requires a production api key
-  //  @Test
-  //  public void testUserMethods() throws EasyPostException {
-  //    EasyPost.apiKey = "KEY"; // easypost private production key
+  // // This test requires a production api key
+  // @Test
+  // public void testUserCreateAndDelete() throws EasyPostException {
+  // EasyPost.apiKey = "KEY"; // easypost private production key
   //
-  //    User user = User.retrieveMe();
-  //
-  //    System.out.println(user.getPhoneNumber());
-  //    System.out.println(user.getRechargeAmount());
-  //    System.out.println(user.getSecondaryRechargeAmount());
-  //
-  //    user.setSecondaryRechargeAmount("$200.00");
-  //
-  //    Map<String, Object> userHash = new HashMap<String, Object>();
-  //    userHash.put("secondary_recharge_amount", 100000.00);
-  //
-  //    user.update(userHash);
-  //
-  //    System.out.println(user.getSecondaryRechargeAmount());
-  //
-  //    System.out.println(user.getRechargeThreshold());
-  //  }
-
-  //  //  This test requires a production api key
-  //  @Test
-  //  public void testUserCreateAndDelete() throws EasyPostException {
-  //    EasyPost.apiKey = "KEY"; // easypost private production key
-  //
-  //    Map<String, Object> userHash = new HashMap<String, Object>();
-  //    userHash.put("name", "Chad DeVader");
-  //    userHash.put("password", "4theempire");
-  //    userHash.put("password_confirmation", "4theempire");
-  //    userHash.put("phone_number", "555-123-4321");
+  // Map<String, Object> userHash = new HashMap<String, Object>();
+  // userHash.put("name", "Chad DeVader");
+  // userHash.put("password", "4theempire");
+  // userHash.put("password_confirmation", "4theempire");
+  // userHash.put("phone_number", "555-123-4321");
   //
   //
-  //    User child = User.create(userHash);
+  // User child = User.create(userHash);
   //
-  //    assertEquals("Child's name is incorrect", child.getName(), "Chad DeVader");
-  //    assertNotNull("Child's email is not present", child.getEmail());
-  //    assertNotNull("Child's phone_number is not present", child.getPhoneNumber());
-  //    assertNotNull("Child's ID is not present", child.getId());
+  // assertEquals("Child's name is incorrect", child.getName(), "Chad DeVader");
+  // assertNotNull("Child's email is not present", child.getEmail());
+  // assertNotNull("Child's phone_number is not present", child.getPhoneNumber());
+  // assertNotNull("Child's ID is not present", child.getId());
   //
-  //    User fetchedChild = User.retrieve(child.getId());
-  //    assertEquals("Child's ID is not the same as FetchedChild's ID", fetchedChild.getId(),
+  // User fetchedChild = User.retrieve(child.getId());
+  // assertEquals("Child's ID is not the same as FetchedChild's ID",
+  // fetchedChild.getId(),
   // child.getId());
   //
-  //    fetchedChild.delete();
+  // fetchedChild.delete();
   //
-  //    try {
-  //      User newFetchedChild = User.retrieve(child.getId());
-  //      assertNull("Child is not deleted", newFetchedChild);
-  //    } catch (EasyPostException e) {
-  //      assertThat(e.getMessage(), containsString("An error occured"));
-  //      assertThat(e.getMessage(), containsString("Response code: 404"));
-  //      assertThat(e.getMessage(),
-  // containsString("{\"error\":{\"code\":\"NOT_FOUND\",\"message\":\"The requested resource could
+  // try {
+  // User newFetchedChild = User.retrieve(child.getId());
+  // assertNull("Child is not deleted", newFetchedChild);
+  // } catch (EasyPostException e) {
+  // assertThat(e.getMessage(), containsString("An error occured"));
+  // assertThat(e.getMessage(), containsString("Response code: 404"));
+  // assertThat(e.getMessage(),
+  // containsString("{\"error\":{\"code\":\"NOT_FOUND\",\"message\":\"The
+  // requested resource could
   // not be found.\",\"errors\":[]}}"));
-  //    }
-  //  }
+  // }
+  // }
 
-  //  //  This test requires a production api key
-  //  @Test
-  //  public void testUserCreateAndDeleteFailsOnParent() throws EasyPostException {
-  //    EasyPost.apiKey = "KEY"; // easypost private production key
+  // // This test requires a production api key
+  // @Test
+  // public void testUserCreateAndDeleteFailsOnParent() throws EasyPostException {
+  // EasyPost.apiKey = "KEY"; // easypost private production key
   //
-  //    User fetchedSelf = User.retrieveMe();
-  //    assertNotNull("Parent's ID is not present", fetchedSelf);
+  // User fetchedSelf = User.retrieveMe();
+  // assertNotNull("Parent's ID is not present", fetchedSelf);
   //
-  //    try {
-  //      fetchedSelf.delete();
-  //      assertFalse("User did not delete", true);
-  //    } catch (EasyPostException e) {
-  //      assertThat(e.getMessage(), containsString("An error occured"));
-  //      assertThat(e.getMessage(), containsString("Response code: 404"));
-  //      assertThat(e.getMessage(),
-  // containsString("{\"error\":{\"code\":\"NOT_FOUND\",\"message\":\"The requested resource could
+  // try {
+  // fetchedSelf.delete();
+  // assertFalse("User did not delete", true);
+  // } catch (EasyPostException e) {
+  // assertThat(e.getMessage(), containsString("An error occured"));
+  // assertThat(e.getMessage(), containsString("Response code: 404"));
+  // assertThat(e.getMessage(),
+  // containsString("{\"error\":{\"code\":\"NOT_FOUND\",\"message\":\"The
+  // requested resource could
   // not be found.\",\"errors\":[]}}"));
-  //    }
-  //  }
+  // }
+  // }
 
-  //  //  This test requires a production api key
-  //  @Test
-  //  public void testCarrierAccountMutability() throws EasyPostException {
-  //    EasyPost.apiKey = "KEY"; // easypost private production key
+  // // This test requires a production api key
+  // @Test
+  // public void testCarrierAccountMutability() throws EasyPostException {
+  // EasyPost.apiKey = "KEY"; // easypost private production key
   //
-  //    Map<String, Object> listHash = new HashMap<String, Object>();
-  //    listHash.put("type", "UpsAccount");
-  //    List<CarrierAccount> carrierAccounts = CarrierAccount.all(listHash);
-  //    assertNotNull(carrierAccounts);
+  // Map<String, Object> listHash = new HashMap<String, Object>();
+  // listHash.put("type", "UpsAccount");
+  // List<CarrierAccount> carrierAccounts = CarrierAccount.all(listHash);
+  // assertNotNull(carrierAccounts);
   //
-  //    int originalNumCarrierAccounts = carrierAccounts.size();
+  // int originalNumCarrierAccounts = carrierAccounts.size();
   //
-  //    String description = "A java client library test account";
-  //    String reference = "FedexJavaTest-1";
-  //    String accountNumber = "B2B2B2";
-  //    Map<String, Object> credentials = new HashMap<String, Object>();
-  //    credentials.put("account_number", accountNumber);
-  //    credentials.put("user_id", "UPSDOTCOM_USERNAME");
-  //    credentials.put("password", "UPSDOTCOM_PASSWORD");
-  //    credentials.put("access_license_number", "UPS_ACCESS_LICENSE_NUMBER");
+  // String description = "A java client library test account";
+  // String reference = "FedexJavaTest-1";
+  // String accountNumber = "B2B2B2";
+  // Map<String, Object> credentials = new HashMap<String, Object>();
+  // credentials.put("account_number", accountNumber);
+  // credentials.put("user_id", "UPSDOTCOM_USERNAME");
+  // credentials.put("password", "UPSDOTCOM_PASSWORD");
+  // credentials.put("access_license_number", "UPS_ACCESS_LICENSE_NUMBER");
   //
-  //    Map<String, Object> carrierParams = new HashMap<String, Object>();
-  //    carrierParams.put("type", "UpsAccount");
-  //    carrierParams.put("description", description);
-  //    carrierParams.put("reference", reference);
-  //    carrierParams.put("credentials", credentials);
+  // Map<String, Object> carrierParams = new HashMap<String, Object>();
+  // carrierParams.put("type", "UpsAccount");
+  // carrierParams.put("description", description);
+  // carrierParams.put("reference", reference);
+  // carrierParams.put("credentials", credentials);
   //
-  //    CarrierAccount carrierAccount = CarrierAccount.create(carrierParams);
-  //    CarrierAccount retrieved = CarrierAccount.retrieve(carrierAccount.getId());
+  // CarrierAccount carrierAccount = CarrierAccount.create(carrierParams);
+  // CarrierAccount retrieved = CarrierAccount.retrieve(carrierAccount.getId());
   //
-  //    assertNotNull(retrieved);
-  //    assertEquals(carrierAccount.getId(), retrieved.getId());
-  //    assertEquals(retrieved.getDescription(), description);
-  //    assertEquals(retrieved.getReference(), reference);
-  //    assertEquals(retrieved.getCredentials().get("account_number"), accountNumber);
+  // assertNotNull(retrieved);
+  // assertEquals(carrierAccount.getId(), retrieved.getId());
+  // assertEquals(retrieved.getDescription(), description);
+  // assertEquals(retrieved.getReference(), reference);
+  // assertEquals(retrieved.getCredentials().get("account_number"),
+  // accountNumber);
   //
-  //    List<CarrierAccount> updatedCarrierAccounts = CarrierAccount.all(listHash);
-  //    assertNotNull(updatedCarrierAccounts);
+  // List<CarrierAccount> updatedCarrierAccounts = CarrierAccount.all(listHash);
+  // assertNotNull(updatedCarrierAccounts);
   //
-  //    int updatedNumCarrierAccounts = updatedCarrierAccounts.size();
-  //    assertEquals(originalNumCarrierAccounts + 1, updatedNumCarrierAccounts);
+  // int updatedNumCarrierAccounts = updatedCarrierAccounts.size();
+  // assertEquals(originalNumCarrierAccounts + 1, updatedNumCarrierAccounts);
   //
-  //    String newDescription = "A java client library test account that has been edited";
+  // String newDescription = "A java client library test account that has been
+  // edited";
   //
-  //    String newAccountNumber = "C3C3C3C3";
-  //    credentials.put("account_number", newAccountNumber);
+  // String newAccountNumber = "C3C3C3C3";
+  // credentials.put("account_number", newAccountNumber);
   //
-  //    Map<String, Object> newParams = new HashMap<String, Object>();
-  //    newParams.put("description", newDescription);
-  //    newParams.put("credentials", credentials);
+  // Map<String, Object> newParams = new HashMap<String, Object>();
+  // newParams.put("description", newDescription);
+  // newParams.put("credentials", credentials);
   //
-  //    CarrierAccount mutated = retrieved.update(newParams);
+  // CarrierAccount mutated = retrieved.update(newParams);
   //
-  //    assertNotNull(mutated);
-  //    assertEquals(carrierAccount.getId(), mutated.getId());
-  //    assertEquals(mutated.getDescription(), newDescription);
-  //    assertEquals(mutated.getCredentials().get("account_number"), newAccountNumber);
+  // assertNotNull(mutated);
+  // assertEquals(carrierAccount.getId(), mutated.getId());
+  // assertEquals(mutated.getDescription(), newDescription);
+  // assertEquals(mutated.getCredentials().get("account_number"),
+  // newAccountNumber);
   //
-  //    mutated.delete();
+  // mutated.delete();
   //
-  //    List<CarrierAccount> deletedCarrierAccounts = CarrierAccount.all(listHash);
-  //    assertNotNull(deletedCarrierAccounts);
+  // List<CarrierAccount> deletedCarrierAccounts = CarrierAccount.all(listHash);
+  // assertNotNull(deletedCarrierAccounts);
   //
-  //    int finalNumCarrierAccounts = deletedCarrierAccounts.size();
-  //    assertEquals(originalNumCarrierAccounts, finalNumCarrierAccounts);
-  //  }
+  // int finalNumCarrierAccounts = deletedCarrierAccounts.size();
+  // assertEquals(originalNumCarrierAccounts, finalNumCarrierAccounts);
+  // }
 }

--- a/src/test/java/com/easypost/EventTest.java
+++ b/src/test/java/com/easypost/EventTest.java
@@ -8,11 +8,11 @@ import static org.junit.Assert.assertNull;
 
 public class EventTest {
 
-    @Test
-    public void testEventWithNullPreviousAttributes() {
-        String eventJson = "{\"result\": {\"id\": \"rfnd_b550a6f968be4c61a2306e3c10c12345\", \"object\": \"Refund\", \"created_at\": \"2019-12-12T00:10:49Z\", \"updated_at\": \"2019-12-12T00:10:49Z\", \"tracking_code\": \"778827012345\", \"confirmation_number\": null, \"status\": \"refunded\", \"carrier\": \"FedEx\", \"shipment_id\": \"shp_b4fba1b233d94ecabfbb455ff9112345\"}, \"description\": \"refund.successful\", \"mode\": \"production\", \"previous_attributes\": null, \"pending_urls\": [\"hook_4ed7ff31c6974ff180e2463bb2912345\", \"hook_b43bc6d4eb3848bfaaee8e131f712345\"], \"completed_urls\": null, \"id\": \"evt_5786b354576049bb91e845b6d5712345\", \"user_id\": \"user_7b4c654836a743a492e59573a0512345\", \"status\": \"pending\", \"object\": \"Event\"}";
-        Event event = EasyPostResource.gson.fromJson(eventJson, Event.class);
-        assertNull(event.getPreviousAttributes());
-    }
+  @Test
+  public void testEventWithNullPreviousAttributes() {
+    String eventJson = "{\"result\": {\"id\": \"rfnd_b550a6f968be4c61a2306e3c10c12345\", \"object\": \"Refund\", \"created_at\": \"2019-12-12T00:10:49Z\", \"updated_at\": \"2019-12-12T00:10:49Z\", \"tracking_code\": \"778827012345\", \"confirmation_number\": null, \"status\": \"refunded\", \"carrier\": \"FedEx\", \"shipment_id\": \"shp_b4fba1b233d94ecabfbb455ff9112345\"}, \"description\": \"refund.successful\", \"mode\": \"production\", \"previous_attributes\": null, \"pending_urls\": [\"hook_4ed7ff31c6974ff180e2463bb2912345\", \"hook_b43bc6d4eb3848bfaaee8e131f712345\"], \"completed_urls\": null, \"id\": \"evt_5786b354576049bb91e845b6d5712345\", \"user_id\": \"user_7b4c654836a743a492e59573a0512345\", \"status\": \"pending\", \"object\": \"Event\"}";
+    Event event = EasyPostResource.gson.fromJson(eventJson, Event.class);
+    assertNull(event.getPreviousAttributes());
+  }
 
 }

--- a/src/test/java/com/easypost/ThreadTest.java
+++ b/src/test/java/com/easypost/ThreadTest.java
@@ -3,23 +3,15 @@ package com.easypost;
 import com.easypost.model.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 
-import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Date;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 
 import java.lang.InterruptedException;
 
 import com.easypost.exception.EasyPostException;
-
-import static org.junit.Assert.*;
 
 public class ThreadTest {
   static Map<String, Object> defaultFromAddress = new HashMap<String, Object>();
@@ -67,17 +59,14 @@ public class ThreadTest {
     public void run() {
       try {
         for (int i = 0; i < this.orders.size(); i++) {
-          System.out.format("Thread %s: starting order creation...%n",
-            Thread.currentThread().getName());
+          System.out.format("Thread %s: starting order creation...%n", Thread.currentThread().getName());
 
           Order order = Order.create(this.orders.get(i));
           // save order id to database or buy now
 
-          System.out.format("Thread %s: created order %s%n",
-            Thread.currentThread().getName(),
-            order.getId());
+          System.out.format("Thread %s: created order %s%n", Thread.currentThread().getName(), order.getId());
         }
-      } catch(EasyPostException e) {
+      } catch (EasyPostException e) {
         System.out.println("EasyPost Exception caught creating order.");
       }
     }
@@ -121,4 +110,3 @@ public class ThreadTest {
 
   }
 }
-

--- a/src/test/java/com/easypost/UserTest.java
+++ b/src/test/java/com/easypost/UserTest.java
@@ -1,64 +1,45 @@
 /*
-package com.easypost;
-
-import com.easypost.model.*;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
-
-import java.text.ParseException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Date;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-
-import java.lang.InterruptedException;
-
-import com.easypost.exception.EasyPostException;
-
-import static org.junit.Assert.*;
-
-public class UserTest {
-
-  @BeforeClass
-  public static void setUp() {
-    EasyPost.apiKey = "PROD_KEY"; // PROD KEY REQUIRED
-  }
-
-  @Test
-  public void testRetrieveMe() throws EasyPostException {
-    User me = User.retrieveMe();
-
-    assertNotNull(me.getName());
-    assertNotNull(me.getEmail());
-  }
-
-  @Test
-  public void testCreateChild() throws EasyPostException {
-    User child = User.create();
-    assertNotNull(child.getName());
-    assertNotNull(child.getEmail());
-
-    List<ApiKey> childKeys = child.apiKeys();
-    assertNotNull(childKeys.get(0).getKey()); // one is test and one is prod
-    assertNotNull(childKeys.get(1).getKey()); // check getMode()
-  }
-
-  @Test
-  public void testEditUser() throws EasyPostException {
-    User me = User.retrieveMe();
-
-    Map<String, Object> params = new HashMap<String, Object>();
-    params.put("name", "New Name2736");
-    me.update(params);
-
-    assertEquals("User was not updated successfully", "New Name2736", me.getName());
-    System.out.println(me.prettyPrint());
-  }
-}
-*/
-
+ * package com.easypost;
+ * 
+ * import com.easypost.model.*; import org.junit.BeforeClass; import
+ * org.junit.Test; import org.junit.Rule; import
+ * org.junit.rules.ExpectedException;
+ * 
+ * import java.text.ParseException; import java.util.HashMap; import
+ * java.util.Map; import java.util.List; import java.util.ArrayList; import
+ * java.util.Date; import java.text.DateFormat; import
+ * java.text.SimpleDateFormat;
+ * 
+ * import java.lang.InterruptedException;
+ * 
+ * import com.easypost.exception.EasyPostException;
+ * 
+ * import static org.junit.Assert.*;
+ * 
+ * public class UserTest {
+ * 
+ * @BeforeClass public static void setUp() { EasyPost.apiKey = "PROD_KEY"; //
+ * PROD KEY REQUIRED }
+ * 
+ * @Test public void testRetrieveMe() throws EasyPostException { User me =
+ * User.retrieveMe();
+ * 
+ * assertNotNull(me.getName()); assertNotNull(me.getEmail()); }
+ * 
+ * @Test public void testCreateChild() throws EasyPostException { User child =
+ * User.create(); assertNotNull(child.getName());
+ * assertNotNull(child.getEmail());
+ * 
+ * List<ApiKey> childKeys = child.apiKeys();
+ * assertNotNull(childKeys.get(0).getKey()); // one is test and one is prod
+ * assertNotNull(childKeys.get(1).getKey()); // check getMode() }
+ * 
+ * @Test public void testEditUser() throws EasyPostException { User me =
+ * User.retrieveMe();
+ * 
+ * Map<String, Object> params = new HashMap<String, Object>();
+ * params.put("name", "New Name2736"); me.update(params);
+ * 
+ * assertEquals("User was not updated successfully", "New Name2736",
+ * me.getName()); System.out.println(me.prettyPrint()); } }
+ */


### PR DESCRIPTION
This repo is incredibly difficult to navigate due to the various unused imports, varying indent and organization spacing, etc

* Styles each file to use 2 spaces for consistency (this is the preferred spacing convention if following Google's style guide)
* Breaks up single function lines into multi-line for better readability
* Removes unused imports in each file
* Removes hard coded API Keys from README and example files (tests still have this present for now, will remove those in an upcoming PR).
* Replaces a `Boolean` deprecation in favor of its new usage
* Removes unused `.travis.yml` file

I will eventually put up another PR to add a linter to the project along with fixing the remaining lint errors, but this is a good initial step as we start beefing up this client library and need to be able to edit it easily.