### PR TITLE
Migrate from urlencoded to JSON bodies for POST/PUT requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ settings.xml
 
 src/scratch
 
+/easypostdevtools_java/

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ settings.xml
 
 src/scratch
 
-/easypostdevtools_java/

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ settings.xml
 
 
 src/scratch
-src/scratch/*
+

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ src/test/test.iml
 
 *.class
 settings.xml
+
+
+src/scratch
+src/scratch/*

--- a/src/main/java/com/easypost/model/Tracker.java
+++ b/src/main/java/com/easypost/model/Tracker.java
@@ -10,159 +10,159 @@ import java.util.List;
 import java.util.Map;
 
 public class Tracker extends EasyPostResource {
-	public String id;
-	String mode;
-	String trackingCode;
-	String status;
-	String shipmentId;
-	String carrier;
-	List<TrackingDetail> trackingDetails;
-	float weight;
-	Date estDeliveryDate;
-	String signedBy;
-	CarrierDetail carrierDetail;
-	String publicUrl;
-	String statusDetail;
+    public String id;
+    String mode;
+    String trackingCode;
+    String status;
+    String shipmentId;
+    String carrier;
+    List<TrackingDetail> trackingDetails;
+    float weight;
+    Date estDeliveryDate;
+    String signedBy;
+    CarrierDetail carrierDetail;
+    String publicUrl;
+    String statusDetail;
 
-	public String getId() {
-		return id;
-	}
-	public void setId(String id) {
-		this.id = id;
-	}
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
 
-	public String getMode() {
-		return mode;
-	}
-	public void setMode(String mode) {
-		this.mode = mode;
-	}
+    public String getMode() {
+        return mode;
+    }
+    public void setMode(String mode) {
+        this.mode = mode;
+    }
 
-	public String getShipmentId() {
-		return shipmentId;
-	}
-	public void setShipmentId(String shipmentId) {
-		this.shipmentId = shipmentId;
-	}
+    public String getShipmentId() {
+        return shipmentId;
+    }
+    public void setShipmentId(String shipmentId) {
+        this.shipmentId = shipmentId;
+    }
 
-	public String getCarrier() {
-		return carrier;
-	}
-	public void setCarrier(String carrier) {
-		this.carrier = carrier;
-	}
+    public String getCarrier() {
+        return carrier;
+    }
+    public void setCarrier(String carrier) {
+        this.carrier = carrier;
+    }
 
-	public String getTrackingCode() {
-		return trackingCode;
-	}
-	public void setTrackingCode(String trackingCode) {
-		this.trackingCode = trackingCode;
-	}
+    public String getTrackingCode() {
+        return trackingCode;
+    }
+    public void setTrackingCode(String trackingCode) {
+        this.trackingCode = trackingCode;
+    }
 
-	public String getStatus() {
-		return status;
-	}
-	public void setStatus(String status) {
-		this.status = status;
-	}
+    public String getStatus() {
+        return status;
+    }
+    public void setStatus(String status) {
+        this.status = status;
+    }
 
-	public List<TrackingDetail> getTrackingDetails() {
-		return trackingDetails;
-	}
-	public void setTrackingDetails(List<TrackingDetail> trackingDetails) {
-		this.trackingDetails = trackingDetails;
-	}
+    public List<TrackingDetail> getTrackingDetails() {
+        return trackingDetails;
+    }
+    public void setTrackingDetails(List<TrackingDetail> trackingDetails) {
+        this.trackingDetails = trackingDetails;
+    }
 
-	public float getWeight() {
-		return weight;
-	}
-	public void setWeight(float weight) {
-		this.weight = weight;
-	}
+    public float getWeight() {
+        return weight;
+    }
+    public void setWeight(float weight) {
+        this.weight = weight;
+    }
 
-	public Date getEstDeliveryDate() {
-		return estDeliveryDate;
-	}
-	public void setEstDeliveryDate(Date estDeliveryDate) {
-		this.estDeliveryDate = estDeliveryDate;
-	}
+    public Date getEstDeliveryDate() {
+        return estDeliveryDate;
+    }
+    public void setEstDeliveryDate(Date estDeliveryDate) {
+        this.estDeliveryDate = estDeliveryDate;
+    }
 
-	public String getSignedBy() {
-		return signedBy;
-	}
-	public void setSignedBy(String signedBy) {
-		this.signedBy = signedBy;
-	}
+    public String getSignedBy() {
+        return signedBy;
+    }
+    public void setSignedBy(String signedBy) {
+        this.signedBy = signedBy;
+    }
 
-	public CarrierDetail getCarrierDetail() { return carrierDetail; }
-	public void setCarrierDetail(CarrierDetail carrierDetail) { this.carrierDetail = carrierDetail; }
+    public CarrierDetail getCarrierDetail() { return carrierDetail; }
+    public void setCarrierDetail(CarrierDetail carrierDetail) { this.carrierDetail = carrierDetail; }
 
-	// This method is a misspelling, but it persists to avoid breaking backwards compatibility
-	public Date getUpdateAt() {
-		return getUpdatedAt();
-	}
-	public void setUpdateAt(Date updatedAt) {
-		setUpdatedAt(updatedAt);
-	}
+    // This method is a misspelling, but it persists to avoid breaking backwards compatibility
+    public Date getUpdateAt() {
+        return getUpdatedAt();
+    }
+    public void setUpdateAt(Date updatedAt) {
+        setUpdatedAt(updatedAt);
+    }
 
-	public String getPublicUrl() { return publicUrl; }
-	public void setPublicUrl(String publicUrl) { this.publicUrl = publicUrl; }
+    public String getPublicUrl() { return publicUrl; }
+    public void setPublicUrl(String publicUrl) { this.publicUrl = publicUrl; }
 
-	public String getStatusDetail() {
-		return statusDetail;
-	}
-	public void setStatusDetail(String statusDetail) {
-		this.statusDetail = statusDetail;
-	}
+    public String getStatusDetail() {
+        return statusDetail;
+    }
+    public void setStatusDetail(String statusDetail) {
+        this.statusDetail = statusDetail;
+    }
 
-	// create
-	public static Tracker create(Map<String, Object> params) throws EasyPostException {
-		return create(params, null);
-	}
-	public static Tracker create(Map<String, Object> params, String apiKey) throws EasyPostException {
-		Map<String, Object> wrappedParams = new HashMap<String, Object>();
-		wrappedParams.put("tracker", params);
+    // create
+    public static Tracker create(Map<String, Object> params) throws EasyPostException {
+        return create(params, null);
+    }
+    public static Tracker create(Map<String, Object> params, String apiKey) throws EasyPostException {
+        Map<String, Object> wrappedParams = new HashMap<String, Object>();
+        wrappedParams.put("tracker", params);
 
-		return request(RequestMethod.POST, classURL(Tracker.class), wrappedParams, Tracker.class, apiKey);
-	}
+        return request(RequestMethod.POST, classURL(Tracker.class), wrappedParams, Tracker.class, apiKey);
+    }
 
-	// retrieve
-	public static Tracker retrieve(String id) throws EasyPostException {
-		return retrieve(id, null);
-	}
-	public static Tracker retrieve(String id, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, instanceURL(Tracker.class, id), null, Tracker.class, apiKey);
-	}
+    // retrieve
+    public static Tracker retrieve(String id) throws EasyPostException {
+        return retrieve(id, null);
+    }
+    public static Tracker retrieve(String id, String apiKey) throws EasyPostException {
+        return request(RequestMethod.GET, instanceURL(Tracker.class, id), null, Tracker.class, apiKey);
+    }
 
-	// all
-	public static TrackerCollection all(Map<String, Object> params) throws EasyPostException {
-		return all(params, null);
-	}
-	public static TrackerCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
-		return request(RequestMethod.GET, classURL(Tracker.class), params, TrackerCollection.class, apiKey);
-	}
+    // all
+    public static TrackerCollection all(Map<String, Object> params) throws EasyPostException {
+        return all(params, null);
+    }
+    public static TrackerCollection all(Map<String, Object> params, String apiKey) throws EasyPostException {
+        return request(RequestMethod.GET, classURL(Tracker.class), params, TrackerCollection.class, apiKey);
+    }
 
-	// createList
-	public static boolean createList(Map<String, Object> params) throws EasyPostException {
-		return createList(params, null);
-	}
-	public static boolean createList(Map<String, Object> params, String apiKey) throws EasyPostException {
-		try {
-			String createListUrl = String.format("%s/create_list", classURL(Tracker.class));
+    // createList
+    public static boolean createList(Map<String, Object> params) throws EasyPostException {
+        return createList(params, null);
+    }
+    public static boolean createList(Map<String, Object> params, String apiKey) throws EasyPostException {
+        try {
+            String createListUrl = String.format("%s/create_list", classURL(Tracker.class));
 
-			int count = 0;
-			Map<String, Object> newParams = new HashMap<String, Object>();
-			Map<String, Object> trackers = new HashMap<String, Object>();
-			for (Object tracker : (ArrayList) params.get("trackers")) {
-				trackers.put(String.valueOf(count), tracker);
-				count++;
-			}
-			newParams.put("trackers", trackers);
+            int count = 0;
+            Map<String, Object> newParams = new HashMap<String, Object>();
+            Map<String, Object> trackers = new HashMap<String, Object>();
+            for (Object tracker : (ArrayList) params.get("trackers")) {
+                trackers.put(String.valueOf(count), tracker);
+                count++;
+            }
+            newParams.put("trackers", trackers);
 
-			request(RequestMethod.POST, createListUrl, newParams, Object.class, apiKey);
-			return true;
-		} catch (Exception e) {
+            request(RequestMethod.POST, createListUrl, newParams, Object.class, apiKey);
+            return true;
+        } catch (Exception e) {
             throw new EasyPostException("Cannot create list of trackers", e);
-		}
-	}
+        }
+    }
 }

--- a/src/main/java/com/easypost/model/Tracker.java
+++ b/src/main/java/com/easypost/model/Tracker.java
@@ -3,6 +3,7 @@ package com.easypost.model;
 import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -148,7 +149,16 @@ public class Tracker extends EasyPostResource {
 	public static boolean createList(Map<String, Object> params, String apiKey) throws EasyPostException {
 		String createListUrl = String.format("%s/create_list", classURL(Tracker.class));
 
-		request(RequestMethod.POST, createListUrl, params, Object.class, apiKey);
+		int count = 0;
+		Map<String, Object> newParams = new HashMap<String, Object>();
+		Map<String, Object> trackers = new HashMap<String, Object>();
+		for (Object tracker : (ArrayList)params.get("trackers")) {
+			trackers.put(String.valueOf(count), tracker);
+			count++;
+		}
+		newParams.put("trackers", trackers);
+
+		request(RequestMethod.POST, createListUrl, newParams, Object.class, apiKey);
 		return true;
 	}
 

--- a/src/main/java/com/easypost/model/Tracker.java
+++ b/src/main/java/com/easypost/model/Tracker.java
@@ -147,19 +147,22 @@ public class Tracker extends EasyPostResource {
 		return createList(params, null);
 	}
 	public static boolean createList(Map<String, Object> params, String apiKey) throws EasyPostException {
-		String createListUrl = String.format("%s/create_list", classURL(Tracker.class));
+		try {
+			String createListUrl = String.format("%s/create_list", classURL(Tracker.class));
 
-		int count = 0;
-		Map<String, Object> newParams = new HashMap<String, Object>();
-		Map<String, Object> trackers = new HashMap<String, Object>();
-		for (Object tracker : (ArrayList)params.get("trackers")) {
-			trackers.put(String.valueOf(count), tracker);
-			count++;
+			int count = 0;
+			Map<String, Object> newParams = new HashMap<String, Object>();
+			Map<String, Object> trackers = new HashMap<String, Object>();
+			for (Object tracker : (ArrayList)params.get("trackers")) {
+				trackers.put(String.valueOf(count), tracker);
+				count++;
+			}
+			newParams.put("trackers", trackers);
+
+			request(RequestMethod.POST, createListUrl, newParams, Object.class, apiKey);
+			return true;
+		} catch (Exception e) {
+			return false;
 		}
-		newParams.put("trackers", trackers);
-
-		request(RequestMethod.POST, createListUrl, newParams, Object.class, apiKey);
-		return true;
 	}
-
 }

--- a/src/main/java/com/easypost/model/Tracker.java
+++ b/src/main/java/com/easypost/model/Tracker.java
@@ -153,7 +153,7 @@ public class Tracker extends EasyPostResource {
 			int count = 0;
 			Map<String, Object> newParams = new HashMap<String, Object>();
 			Map<String, Object> trackers = new HashMap<String, Object>();
-			for (Object tracker : (ArrayList)params.get("trackers")) {
+			for (Object tracker : (ArrayList) params.get("trackers")) {
 				trackers.put(String.valueOf(count), tracker);
 				count++;
 			}
@@ -162,7 +162,7 @@ public class Tracker extends EasyPostResource {
 			request(RequestMethod.POST, createListUrl, newParams, Object.class, apiKey);
 			return true;
 		} catch (Exception e) {
-			return false;
+            throw new EasyPostException("Cannot create list of trackers", e);
 		}
 	}
 }

--- a/src/main/java/com/easypost/net/EasyPostResource.java
+++ b/src/main/java/com/easypost/net/EasyPostResource.java
@@ -274,15 +274,15 @@ public abstract class EasyPostResource {
 
 	private static String createQuery(Map<String, Object> params) throws UnsupportedEncodingException {
 		Map<String, String> flatParams = flattenParams(params);
-		StringBuilder queryStringBuffer = new StringBuilder();
+		StringBuilder queryStringBuilder = new StringBuilder();
 		for (Map.Entry<String, String> entry : flatParams.entrySet()) {
-			queryStringBuffer.append("&");
-			queryStringBuffer.append(urlEncodePair(entry.getKey(), entry.getValue()));
+			queryStringBuilder.append("&");
+			queryStringBuilder.append(urlEncodePair(entry.getKey(), entry.getValue()));
 		}
-		if (queryStringBuffer.length() > 0) {
-			queryStringBuffer.deleteCharAt(0);
+		if (queryStringBuilder.length() > 0) {
+			queryStringBuilder.deleteCharAt(0);
 		}
-		return queryStringBuffer.toString();
+		return queryStringBuilder.toString();
 	}
 
 	private static Map<String, String> flattenParams(Map<String, Object> params) {

--- a/src/main/java/com/easypost/net/EasyPostResource.java
+++ b/src/main/java/com/easypost/net/EasyPostResource.java
@@ -268,7 +268,8 @@ public abstract class EasyPostResource {
 	}
 
 	private static JsonObject createBody(Map<String, Object> params) {
-		return createJsonObjectFromMap(params);
+		Gson gson = new Gson();
+		return gson.toJsonTree(params).getAsJsonObject();
 	}
 
 	private static String createQuery(Map<String, Object> params) throws UnsupportedEncodingException {
@@ -282,11 +283,6 @@ public abstract class EasyPostResource {
 			queryStringBuffer.deleteCharAt(0);
 		}
 		return queryStringBuffer.toString();
-	}
-
-	private static JsonObject createJsonObjectFromMap(Map<String, Object> map) {
-		Gson gson = new Gson();
-		return gson.toJsonTree(map).getAsJsonObject();
 	}
 
 	private static Map<String, String> flattenParams(Map<String, Object> params) {
@@ -450,7 +446,12 @@ public abstract class EasyPostResource {
 					break;
 				case POST:
 				case PUT:
-					body = createBody(params);
+					try {
+						body = createBody(params);
+					} catch (Exception e) {
+						throw new EasyPostException(
+								String.format("Unable to create JSON body from parameters. Please email %s for assistance.", EasyPostResource.EASYPOST_SUPPORT_EMAIL), e);
+					}
 					break;
 				default:
 					break;

--- a/src/main/java/com/easypost/net/EasyPostResource.java
+++ b/src/main/java/com/easypost/net/EasyPostResource.java
@@ -397,7 +397,7 @@ public abstract class EasyPostResource {
 
 	protected static <T> T request(EasyPostResource.RequestMethod method, String url, Map<String, Object> params, Class<T> clazz, String apiKey, boolean apiKeyRequired) throws EasyPostException {
 		String originalDNSCacheTTL = null;
-		boolean allowedToSetTTL = true;
+		Boolean allowedToSetTTL = true;
 		try {
 			originalDNSCacheTTL = java.security.Security.getProperty(DNS_CACHE_TTL_PROPERTY_NAME);
 			// disable DNS cache

--- a/src/test/java/com/easypost/EasyPostTest.java
+++ b/src/test/java/com/easypost/EasyPostTest.java
@@ -625,7 +625,7 @@ public class EasyPostTest {
     } catch (EasyPostException e) {
       assertNotNull(e);
 
-      assertThat(e.getMessage(), containsString("An error occured"));
+      assertThat(e.getMessage(), containsString("An error occurred"));
       assertThat(e.getMessage(), containsString("Response code: 422"));
       assertThat(
           e.getMessage(),
@@ -1044,7 +1044,7 @@ public class EasyPostTest {
       Webhook.retrieve(webhook.getId());
       assertFalse("Webhook did not delete", true);
     } catch (EasyPostException e) {
-      assertThat(e.getMessage(), containsString("An error occured"));
+      assertThat(e.getMessage(), containsString("An error occurred"));
       assertThat(e.getMessage(), containsString("Response code: 404"));
       assertThat(
           e.getMessage(),
@@ -1217,7 +1217,7 @@ public class EasyPostTest {
   //      User newFetchedChild = User.retrieve(child.getId());
   //      assertNull("Child is not deleted", newFetchedChild);
   //    } catch (EasyPostException e) {
-  //      assertThat(e.getMessage(), containsString("An error occured"));
+  //      assertThat(e.getMessage(), containsString("An error occurred"));
   //      assertThat(e.getMessage(), containsString("Response code: 404"));
   //      assertThat(e.getMessage(),
   // containsString("{\"error\":{\"code\":\"NOT_FOUND\",\"message\":\"The requested resource could
@@ -1237,7 +1237,7 @@ public class EasyPostTest {
   //      fetchedSelf.delete();
   //      assertFalse("User did not delete", true);
   //    } catch (EasyPostException e) {
-  //      assertThat(e.getMessage(), containsString("An error occured"));
+  //      assertThat(e.getMessage(), containsString("An error occurred"));
   //      assertThat(e.getMessage(), containsString("Response code: 404"));
   //      assertThat(e.getMessage(),
   // containsString("{\"error\":{\"code\":\"NOT_FOUND\",\"message\":\"The requested resource could


### PR DESCRIPTION
Java library will now send data as JSON in the request body for POST and PUT requests, rather than sending them as urlencoded data.
Still uses urlencoded data for GET and DELETE functions.

This allows for future support for things such as Tax Identifiers.