### PR TITLE
Provide enums for values with set of options

### DIFF
--- a/src/main/java/com/easypost/app/BatchManifestExample.java
+++ b/src/main/java/com/easypost/app/BatchManifestExample.java
@@ -4,6 +4,7 @@ import com.easypost.EasyPost;
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.Batch;
 import com.easypost.model.Shipment;
+import com.easypost.model.enums.BatchState;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,7 +47,7 @@ public class BatchManifestExample {
             while(true) {
                 batch = batch.refresh();
 
-                if (batch.getState() == "created") {
+                if (batch.getState() == BatchState.CREATED) {
                     break;
                 }
 

--- a/src/main/java/com/easypost/model/Address.java
+++ b/src/main/java/com/easypost/model/Address.java
@@ -1,6 +1,7 @@
 package com.easypost.model;
 
 import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.Mode;
 import com.easypost.net.EasyPostResource;
 
 import java.util.HashMap;
@@ -9,7 +10,7 @@ import java.util.Map;
 
 public class Address extends EasyPostResource {
   public String id;
-  String mode;
+  Mode mode;
   String name;
   String company;
   String street1;
@@ -33,10 +34,10 @@ public class Address extends EasyPostResource {
     this.id = id;
   }
 
-  public String getMode() {
+  public Mode getMode() {
     return mode;
   }
-  public void setMode(String mode) {
+  public void setMode(Mode mode) {
     this.mode = mode;
   }
 

--- a/src/main/java/com/easypost/model/ApiKey.java
+++ b/src/main/java/com/easypost/model/ApiKey.java
@@ -1,13 +1,14 @@
 package com.easypost.model;
 
+import com.easypost.model.enums.Mode;
 import com.easypost.net.EasyPostResource;
 
 public class ApiKey extends EasyPostResource {
-    String mode;
+    Mode mode;
     String key;
 
-    public String getMode() { return mode; }
-    public void setMode(String mode) { this.mode = mode; }
+    public Mode getMode() { return mode; }
+    public void setMode(Mode mode) { this.mode = mode; }
 
     public String getKey() { return key; }
     public void setKey(String key) { this.key = key; }

--- a/src/main/java/com/easypost/model/Batch.java
+++ b/src/main/java/com/easypost/model/Batch.java
@@ -1,6 +1,8 @@
 package com.easypost.model;
 
 import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.BatchState;
+import com.easypost.model.enums.Mode;
 import com.easypost.net.EasyPostResource;
 
 import java.util.HashMap;
@@ -9,8 +11,8 @@ import java.util.Map;
 
 public class Batch extends EasyPostResource {
 	public String id;
-	String mode;
-	String state;
+	Mode mode;
+	BatchState state;
 	public BatchStatus status;
   Number numShipments;
 	List<Shipment> shipments;
@@ -25,17 +27,17 @@ public class Batch extends EasyPostResource {
 		this.id = id;
 	}
 
-	public String getMode() {
+	public Mode getMode() {
 		return mode;
 	}
-	public void setMode(String mode) {
+	public void setMode(Mode mode) {
 		this.mode = mode;
 	}
 
-	public String getState() {
+	public BatchState getState() {
 		return state;
 	}
-	public void setState(String state) {
+	public void setState(BatchState state) {
 		this.state = state;
 	}
 

--- a/src/main/java/com/easypost/model/CustomsInfo.java
+++ b/src/main/java/com/easypost/model/CustomsInfo.java
@@ -1,6 +1,9 @@
 package com.easypost.model;
 
 import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.CustomsContentsType;
+import com.easypost.model.enums.CustomsNonDeliveryOption;
+import com.easypost.model.enums.CustomsRestrictionType;
 import com.easypost.net.EasyPostResource;
 
 import java.util.HashMap;
@@ -9,12 +12,12 @@ import java.util.Map;
 
 public class CustomsInfo extends EasyPostResource {
 	public String id;
-	String contentsType;
+	CustomsContentsType contentsType;
 	String contentsExplanation;
 	boolean customsCertify;
 	String customsSigner;
-	String nonDeliveryOption;
-	String restrictionType;
+	CustomsNonDeliveryOption nonDeliveryOption;
+	CustomsRestrictionType restrictionType;
 	String restrictionComments;
 	List<CustomsItem> customsItems;
 
@@ -25,10 +28,10 @@ public class CustomsInfo extends EasyPostResource {
 		this.id = id;
 	}
 
-	public String getContentsType() {
+	public CustomsContentsType getContentsType() {
 		return contentsType;
 	}
-	public void setContentsType(String contentsType) {
+	public void setContentsType(CustomsContentsType contentsType) {
 		this.contentsType = contentsType;
 	}
 
@@ -53,17 +56,17 @@ public class CustomsInfo extends EasyPostResource {
 		this.customsSigner = customsSigner;
 	}
 
-	public String getNonDeliveryOption() {
+	public CustomsNonDeliveryOption getNonDeliveryOption() {
 		return nonDeliveryOption;
 	}
-	public void setNonDeliveryOption(String nonDeliveryOption) {
+	public void setNonDeliveryOption(CustomsNonDeliveryOption nonDeliveryOption) {
 		this.nonDeliveryOption = nonDeliveryOption;
 	}
 
-	public String getRestrictionType() {
+	public CustomsRestrictionType getRestrictionType() {
 		return restrictionType;
 	}
-	public void setRestrictionType(String restrictionType) {
+	public void setRestrictionType(CustomsRestrictionType restrictionType) {
 		this.restrictionType = restrictionType;
 	}
 

--- a/src/main/java/com/easypost/model/Event.java
+++ b/src/main/java/com/easypost/model/Event.java
@@ -1,6 +1,7 @@
 package com.easypost.model;
 
 import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.Mode;
 import com.easypost.net.EasyPostResource;
 
 import java.util.Map;
@@ -8,7 +9,7 @@ import java.util.Map;
 public class Event extends EasyPostResource {
 	public String id;
 	String description;
-	String mode;
+	Mode mode;
 	EasyPostResource result;
 	Map<String, Object> previousAttributes;
 
@@ -27,10 +28,10 @@ public class Event extends EasyPostResource {
 		this.description = description;
 	}
 
-	public String getMode() {
+	public Mode getMode() {
 		return mode;
 	}
-	public void setMode(String mode) {
+	public void setMode(Mode mode) {
 		this.mode = mode;
 	}
 

--- a/src/main/java/com/easypost/model/EventDeserializer.java
+++ b/src/main/java/com/easypost/model/EventDeserializer.java
@@ -1,5 +1,7 @@
 package com.easypost.model;
 
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.Mode;
 import com.easypost.net.EasyPostResource;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
@@ -104,7 +106,11 @@ public class EventDeserializer implements JsonDeserializer<Event> {
 		}
         event.setId(jsonObject.get("id").getAsString());
         event.setDescription(jsonObject.get("description").getAsString());
-        event.setMode(jsonObject.get("mode").getAsString());
+		try {
+			event.setMode(Mode.getEnum(jsonObject.get("mode").getAsString()));
+		} catch (EasyPostException e) {
+			e.printStackTrace();
+		}
 
 		return event;
 	}

--- a/src/main/java/com/easypost/model/Fee.java
+++ b/src/main/java/com/easypost/model/Fee.java
@@ -1,15 +1,17 @@
 package com.easypost.model;
 
+import com.easypost.model.enums.FeeType;
+
 public class Fee{
-    String type;
+    FeeType type;
     float amount;
     Boolean charged;
     Boolean refunded;
 
-    public String getType() {
+    public FeeType getType() {
         return type;
     }
-    public void setType(String type) {
+    public void setType(FeeType type) {
         this.type = type;
     }
 

--- a/src/main/java/com/easypost/model/Form.java
+++ b/src/main/java/com/easypost/model/Form.java
@@ -1,9 +1,12 @@
 package com.easypost.model;
 
+import com.easypost.model.enums.FormType;
+import com.easypost.model.enums.Mode;
+
 public class Form {
   public String id;
-  String mode;
-  String formType;
+  Mode mode;
+  FormType formType;
   String formUrl;
   Boolean submittedElectronically;
 
@@ -14,17 +17,17 @@ public class Form {
     this.id = id;
   }
 
-  public String getMode() {
+  public Mode getMode() {
     return mode;
   }
-  public void setMode(String mode) {
+  public void setMode(Mode mode) {
     this.mode = mode;
   }
 
-  public String getFormType() {
+  public FormType getFormType() {
     return formType;
   }
-  public void setFormType(String formType) {
+  public void setFormType(FormType formType) {
     this.formType = formType;
   }
 

--- a/src/main/java/com/easypost/model/Insurance.java
+++ b/src/main/java/com/easypost/model/Insurance.java
@@ -1,6 +1,8 @@
 package com.easypost.model;
 
 import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.InsuranceStatus;
+import com.easypost.model.enums.Mode;
 import com.easypost.net.EasyPostResource;
 
 import java.util.HashMap;
@@ -9,7 +11,7 @@ import java.util.Map;
 
 public class Insurance extends EasyPostResource {
 	public String id;
-	String mode;
+	Mode mode;
 	String reference;
 	Address toAddress;
 	Address fromAddress;
@@ -17,7 +19,7 @@ public class Insurance extends EasyPostResource {
 	String provider;
 	String providerId;
 	String trackingCode;
-	String status;
+	InsuranceStatus status;
 	String shipmentId;
 	Float amount;
 	List<String> messages;
@@ -25,8 +27,8 @@ public class Insurance extends EasyPostResource {
 	public String getId() { return id; }
 	public void setId(String id) { this.id = id; }
 
-	public String getMode() { return mode; }
-	public void setMode(String mode) { this.mode = mode; }
+	public Mode getMode() { return mode; }
+	public void setMode(Mode mode) { this.mode = mode; }
 
 	public String getReference() { return reference; }
 	public void setReference(String reference) { this.reference = reference; }
@@ -49,8 +51,8 @@ public class Insurance extends EasyPostResource {
 	public String getTrackingCode() { return trackingCode; }
 	public void setTrackingCode(String trackingCode) { this.trackingCode = trackingCode; }
 
-	public String getStatus() { return status; }
-	public void setStatus(String status) { this.status = status; }
+	public InsuranceStatus getStatus() { return status; }
+	public void setStatus(InsuranceStatus status) { this.status = status; }
 
 	public String getShipmentId() { return shipmentId; }
 	public void setShipmentId(String shipmentId) { this.shipmentId = shipmentId; }

--- a/src/main/java/com/easypost/model/Order.java
+++ b/src/main/java/com/easypost/model/Order.java
@@ -1,6 +1,7 @@
 package com.easypost.model;
 
 import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.Mode;
 import com.easypost.net.EasyPostResource;
 
 import java.util.HashMap;
@@ -9,7 +10,7 @@ import java.util.Map;
 
 public class Order extends EasyPostResource {
   public String id;
-  String mode;
+  Mode mode;
   String reference;
   Boolean isReturn;
   Address toAddress;
@@ -29,10 +30,10 @@ public class Order extends EasyPostResource {
     this.id = id;
   }
 
-  public String getMode() {
+  public Mode getMode() {
     return mode;
   }
-  public void setMode(String mode) {
+  public void setMode(Mode mode) {
     this.mode = mode;
   }
 

--- a/src/main/java/com/easypost/model/Pickup.java
+++ b/src/main/java/com/easypost/model/Pickup.java
@@ -1,6 +1,8 @@
 package com.easypost.model;
 
 import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.Mode;
+import com.easypost.model.enums.PickupStatus;
 import com.easypost.net.EasyPostResource;
 
 import java.util.Date;
@@ -10,8 +12,8 @@ import java.util.Map;
 
 public class Pickup extends EasyPostResource {
     public String id;
-    String mode;
-    String status;
+    Mode mode;
+    PickupStatus status;
     String reference;
     Date minDatetime;
     Date maxDatetime;
@@ -30,17 +32,17 @@ public class Pickup extends EasyPostResource {
         this.id = id;
     }
 
-    public String getMode() {
+    public Mode getMode() {
         return mode;
     }
-    public void setMode(String mode) {
+    public void setMode(Mode mode) {
         this.mode = mode;
     }
 
-    public String getStatus() {
+    public PickupStatus getStatus() {
         return status;
     }
-    public void setStatus(String status) {
+    public void setStatus(PickupStatus status) {
         this.status = status;
     }
 

--- a/src/main/java/com/easypost/model/PickupRate.java
+++ b/src/main/java/com/easypost/model/PickupRate.java
@@ -1,10 +1,11 @@
 package com.easypost.model;
 
+import com.easypost.model.enums.Mode;
 import com.easypost.net.EasyPostResource;
 
 public class PickupRate extends EasyPostResource {
     public String id;
-    String mode;
+    Mode mode;
     String carrier;
     String service;
     Float rate;
@@ -17,8 +18,8 @@ public class PickupRate extends EasyPostResource {
         this.id = id;
     }
 
-    public String getMode() { return mode; }
-    public void setMode(String mode) { this.mode = mode; }
+    public Mode getMode() { return mode; }
+    public void setMode(Mode mode) { this.mode = mode; }
 
     public String getCarrier() { return carrier; }
     public void setCarrier(String carrier) { this.carrier = carrier; }

--- a/src/main/java/com/easypost/model/Refund.java
+++ b/src/main/java/com/easypost/model/Refund.java
@@ -1,6 +1,7 @@
 package com.easypost.model;
 
 import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.RefundStatus;
 import com.easypost.net.EasyPostResource;
 
 import java.util.HashMap;
@@ -11,7 +12,7 @@ public class Refund extends EasyPostResource {
 	public String id;
 	String trackingCode;
 	String confirmationNumber;
-	String status;
+	RefundStatus status;
 	String carrier;
 	String shipmentId;
 	
@@ -36,10 +37,10 @@ public class Refund extends EasyPostResource {
 		this.confirmationNumber = confirmationNumber;
 	}
 
-	public String getStatus() {
+	public RefundStatus getStatus() {
 		return status;
 	}
-	public void setStatus(String status) {
+	public void setStatus(RefundStatus status) {
 		this.status = status;
 	}
 

--- a/src/main/java/com/easypost/model/Report.java
+++ b/src/main/java/com/easypost/model/Report.java
@@ -2,6 +2,8 @@ package com.easypost.model;
 
 import com.easypost.EasyPost;
 import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.Mode;
+import com.easypost.model.enums.ReportStatus;
 import com.easypost.net.EasyPostResource;
 
 import java.net.URLEncoder;
@@ -13,8 +15,8 @@ public class Report extends EasyPostResource {
   public String id;
   Date startDate;
   Date endDate;
-  String mode;
-  String status;
+  Mode mode;
+  ReportStatus status;
   Boolean includeChildren;
   String url;
   Date urlExpiresAt;
@@ -43,19 +45,19 @@ public class Report extends EasyPostResource {
     this.endDate = endDate;
   }
 
-  public String getMode() {
+  public Mode getMode() {
     return mode;
   }
 
-  public void setMode(String mode) {
+  public void setMode(Mode mode) {
     this.mode = mode;
   }
 
-  public String getStatus() {
+  public ReportStatus getStatus() {
     return status;
   }
 
-  public void setStatus(String status) {
+  public void setStatus(ReportStatus status) {
     this.status = status;
   }
 

--- a/src/main/java/com/easypost/model/ScanForm.java
+++ b/src/main/java/com/easypost/model/ScanForm.java
@@ -1,6 +1,7 @@
 package com.easypost.model;
 
 import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.ScanFormStatus;
 import com.easypost.net.EasyPostResource;
 
 import java.util.List;
@@ -8,7 +9,7 @@ import java.util.Map;
 
 public class ScanForm extends EasyPostResource {
 	public String id;
-	String status;
+	ScanFormStatus status;
 	String message;
 	Address fromAddress;
 	List<String> trackingCodes;
@@ -24,10 +25,10 @@ public class ScanForm extends EasyPostResource {
 		this.id = id;
 	}
 
-	public String getStatus() {
-	return status;
+	public ScanFormStatus getStatus() {
+		return status;
 	}
-	public void setStatus(String status) {
+	public void setStatus(ScanFormStatus status) {
     this.status = status;
   }
 

--- a/src/main/java/com/easypost/model/Shipment.java
+++ b/src/main/java/com/easypost/model/Shipment.java
@@ -1,6 +1,8 @@
 package com.easypost.model;
 
 import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.Mode;
+import com.easypost.model.enums.TrackerStatus;
 import com.easypost.net.EasyPostResource;
 
 import java.util.HashMap;
@@ -9,7 +11,7 @@ import java.util.Map;
 
 public class Shipment extends EasyPostResource {
 	public String id;
-	String mode;
+	Mode mode;
 	String reference;
 	Boolean isReturn;
 	Address toAddress;
@@ -27,7 +29,7 @@ public class Shipment extends EasyPostResource {
 	Tracker tracker;
 	String insurance;
 	String trackingCode;
-	String status;
+	TrackerStatus status;
 	String refundStatus;
 	String batchId;
 	String batchStatus;
@@ -43,10 +45,10 @@ public class Shipment extends EasyPostResource {
 		this.id = id;
 	}
 
-	public String getMode() {
+	public Mode getMode() {
 		return mode;
 	}
-	public void setMode(String mode) {
+	public void setMode(Mode mode) {
 		this.mode = mode;
 	}
 
@@ -162,10 +164,10 @@ public class Shipment extends EasyPostResource {
 		this.trackingCode = trackingCode;
 	}
 
-	public String getStatus() {
+	public TrackerStatus getStatus() {
 		return status;
 	}
-	public void setStatus(String status) {
+	public void setStatus(TrackerStatus status) {
 		this.status = status;
 	}
 

--- a/src/main/java/com/easypost/model/Tracker.java
+++ b/src/main/java/com/easypost/model/Tracker.java
@@ -1,6 +1,8 @@
 package com.easypost.model;
 
 import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.Mode;
+import com.easypost.model.enums.TrackerStatus;
 import com.easypost.net.EasyPostResource;
 
 import java.util.Date;
@@ -10,9 +12,9 @@ import java.util.Map;
 
 public class Tracker extends EasyPostResource {
 	public String id;
-	String mode;
+	Mode mode;
 	String trackingCode;
-	String status;
+	TrackerStatus status;
 	String shipmentId;
 	String carrier;
 	List<TrackingDetail> trackingDetails;
@@ -30,10 +32,10 @@ public class Tracker extends EasyPostResource {
 		this.id = id;
 	}
 
-	public String getMode() {
+	public Mode getMode() {
 		return mode;
 	}
-	public void setMode(String mode) {
+	public void setMode(Mode mode) {
 		this.mode = mode;
 	}
 
@@ -58,10 +60,10 @@ public class Tracker extends EasyPostResource {
 		this.trackingCode = trackingCode;
 	}
 
-	public String getStatus() {
+	public TrackerStatus getStatus() {
 		return status;
 	}
-	public void setStatus(String status) {
+	public void setStatus(TrackerStatus status) {
 		this.status = status;
 	}
 

--- a/src/main/java/com/easypost/model/Webhook.java
+++ b/src/main/java/com/easypost/model/Webhook.java
@@ -1,6 +1,7 @@
 package com.easypost.model;
 
 import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.Mode;
 import com.easypost.net.EasyPostResource;
 
 import java.util.Date;
@@ -9,7 +10,7 @@ import java.util.Map;
 
 public class Webhook extends EasyPostResource {
     public String id;
-    String mode;
+    Mode mode;
     String url;
     Date disabledAt;
 
@@ -20,10 +21,10 @@ public class Webhook extends EasyPostResource {
         this.id = id;
     }
 
-    public String getMode() {
+    public Mode getMode() {
         return mode;
     }
-    public void setMode(String mode) {
+    public void setMode(Mode mode) {
         this.mode = mode;
     }
 

--- a/src/main/java/com/easypost/model/enums/BatchState.java
+++ b/src/main/java/com/easypost/model/enums/BatchState.java
@@ -1,0 +1,28 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum BatchState implements EasyPostEnum {
+    CREATING("creating"),
+    CREATION_FAILED("creation_failed"),
+    CREATED("created"),
+    PURCHASING("purchasing"),
+    PURCHASE_FAILED("purchase_failed"),
+    PURCHASED("purchased"),
+    LABEL_GENERATING("label_generating"),
+    LABEL_GENERATED("label_generated");
+
+    private String value;
+
+    BatchState(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static BatchState getEnum(String value) throws EasyPostException {
+        return (BatchState) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/BatchState.java
+++ b/src/main/java/com/easypost/model/enums/BatchState.java
@@ -1,15 +1,24 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum BatchState implements EasyPostEnum {
+    @SerializedName("creating")
     CREATING("creating"),
+    @SerializedName("creation_failed")
     CREATION_FAILED("creation_failed"),
+    @SerializedName("created")
     CREATED("created"),
+    @SerializedName("purchasing")
     PURCHASING("purchasing"),
+    @SerializedName("purchase_failed")
     PURCHASE_FAILED("purchase_failed"),
+    @SerializedName("purchased")
     PURCHASED("purchased"),
+    @SerializedName("label_generating")
     LABEL_GENERATING("label_generating"),
+    @SerializedName("label_generated")
     LABEL_GENERATED("label_generated");
 
     private String value;
@@ -23,6 +32,6 @@ public enum BatchState implements EasyPostEnum {
     }
 
     public static BatchState getEnum(String value) throws EasyPostException {
-        return (BatchState) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (BatchState) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/BatchStatus.java
+++ b/src/main/java/com/easypost/model/enums/BatchStatus.java
@@ -1,11 +1,16 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum BatchStatus implements EasyPostEnum {
+    @SerializedName("postage_purchased")
     POSTAGE_PURCHASED("postage_purchased"),
+    @SerializedName("postage_purchase_failed")
     POSTAGE_PURCHASE_FAILED("postage_purchase_failed"),
+    @SerializedName("queued_for_purchase")
     QUEUED_FOR_PURCHASE("queued_for_purchase"),
+    @SerializedName("creation_failed")
     CREATION_FAILED("creation_failed");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/BatchStatus.java
+++ b/src/main/java/com/easypost/model/enums/BatchStatus.java
@@ -1,0 +1,24 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum BatchStatus implements EasyPostEnum {
+    POSTAGE_PURCHASED("postage_purchased"),
+    POSTAGE_PURCHASE_FAILED("postage_purchase_failed"),
+    QUEUED_FOR_PURCHASE("queued_for_purchase"),
+    CREATION_FAILED("creation_failed");
+
+    private String value;
+
+    BatchStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static BatchStatus getEnum(String value) throws EasyPostException {
+        return (BatchStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/BatchStatus.java
+++ b/src/main/java/com/easypost/model/enums/BatchStatus.java
@@ -19,6 +19,6 @@ public enum BatchStatus implements EasyPostEnum {
     }
 
     public static BatchStatus getEnum(String value) throws EasyPostException {
-        return (BatchStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (BatchStatus) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/Carrier.java
+++ b/src/main/java/com/easypost/model/enums/Carrier.java
@@ -1,71 +1,136 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum Carrier implements EasyPostEnum {
+    @SerializedName("AmazonMws")
     Amazon_Mws("AmazonMws"),
+    @SerializedName("APC")
     APC("APC"),
+    @SerializedName("Asendia")
     Asendia("Asendia"),
+    @SerializedName("AsendiaUsa")
     Asendia_USA("AsendiaUsa"),
+    @SerializedName("AustraliaPost")
     Australia_Post("AustraliaPost"),
+    @SerializedName("AxlehireV3")
     AxlehireV3("AxlehireV3"),
+    @SerializedName("BetterTrucks")
     Better_Trucks("BetterTrucks"),
+    @SerializedName("Bond")
     Bond("Bond"),
+    @SerializedName("Cainiao")
     Cainiao("Cainiao"),
+    @SerializedName("CanadaPost")
     Canada_Post("CanadaPost"),
+    @SerializedName("Canpar")
     Canpar("Canpar"),
+    @SerializedName("ColumbusLastMile")
     CDL_Last_Mile_Solutions("ColumbusLastMile"),
+    @SerializedName("Chronopost")
     Chronopost("Chronopost"),
+    @SerializedName("CloudSort")
     CloudSort("CloudSort"),
+    @SerializedName("CourrierExpress")
     Courier_Express("CourierExpress"),
+    @SerializedName("CouriersPlease")
     CouriersPlease("CouriersPlease"),
+    @SerializedName("DaiPost")
     Dai_Post("DaiPost"),
+    @SerializedName("DeutschePost")
     Deutsche_Post("DeutschePost"),
+    @SerializedName("DeutschePostUK")
     Deutsche_Post_UK("DeutschePostUK"),
+    @SerializedName("DHLEcommerceAsia")
     DHL_eCommerce_Asia("DHLEcommerceAsia"),
+    @SerializedName("DhlEcs")
     DHL_eCommerce_Solutions("DhlEcs"),
+    @SerializedName("DHLExpress")
     DHL_Express("DHLExpress"),
+    @SerializedName("DPD")
     DPD("DPD"),
+    @SerializedName("DPDUK")
     DPD_UK("DPDUK"),
+    @SerializedName("ePostlobal")
     ePost_Global("ePostGlobal"),
+    @SerializedName("Estafeta")
     Estafeta("Estafeta"),
+    @SerializedName("Fastway")
     Fastway("Fastway"),
+    @SerializedName("FedEx")
     FedEx("FedEx"),
+    @SerializedName("FedExCrossBorder")
     FedEx_Cross_Border("FedExCrossBorder"),
+    @SerializedName("FedExMailview")
     FedEx_Mailview("FedExMailview"),
+    @SerializedName("FedExSameDayCity")
     FedEx_SameDay_City("FedExSameDayCity"),
+    @SerializedName("FedExSmartPost")
     FedEx_SmartPost("FedExSmartPost"),
+    @SerializedName("FirstMile")
     FirstMile("FirstMile"),
+    @SerializedName("Globegistics")
     Globegistics("Globegistics"),
+    @SerializedName("GSO")
     GSO("GSO"),
+    @SerializedName("Hermes")
     Hermes("Hermes"),
+    @SerializedName("InterlinkExpress")
     Interlink_Express("InterlinkExpress"),
+    @SerializedName("JPPost")
     JP_Post("JPPost"),
+    @SerializedName("KuronekoYamato")
     Kuroneko_Yamato("KuronekoYamato"),
+    @SerializedName("LaPoste")
     La_Poste("LaPoste"),
+    @SerializedName("Lasership")
     LaserShip("Lasership"),
+    @SerializedName("LoomisExpress")
     Loomis_Express("LoomisExpress"),
+    @SerializedName("LSO")
     LSO("LSO"),
+    @SerializedName("Newgistics")
     Newgistics("Newgistics"),
+    @SerializedName("OnTrac")
     OnTrac("OnTrac"),
+    @SerializedName("OsmWorldwide")
     Osm_Worldwide("OsmWorldwide"),
+    @SerializedName("Parcelforce")
     Parcelforce("Parcelforce"),
+    @SerializedName("Passport")
     Passport("Passport"),
+    @SerializedName("PcfFinalMile")
     PCF_Final_Mile("PcfFinalMile"),
+    @SerializedName("PostNL")
     PostNL("PostNL"),
+    @SerializedName("Purolator")
     Purolator("Purolator"),
+    @SerializedName("RoyalMail")
     Royal_Mail("RoyalMail"),
+    @SerializedName("OmniParcel")
     SEKO_OmniParcel("OmniParcel"),
+    @SerializedName("SFExpress")
     SF_Express("SFExpress"),
+    @SerializedName("SpeeDee")
     Spee_Dee("SpeeDee"),
+    @SerializedName("StarTrack")
     StarTrack("StarTrack"),
+    @SerializedName("TForce")
     TForce("TForce"),
+    @SerializedName("UDS")
     UDS("UDS"),
+    @SerializedName("UPS")
     UPS("UPS"),
+    @SerializedName("UPSIparcel")
     UPS_i_parcel("UPSIparcel"),
+    @SerializedName("UPSMailInnovations")
     UPS_Mail_Innovations("UPSMailInnovations"),
+    @SerializedName("USPS")
     USPS("USPS"),
+    @SerializedName("Veho")
     Veho("Veho"),
+    @SerializedName("Yanwen")
     Yanwen("Yanwen");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/Carrier.java
+++ b/src/main/java/com/easypost/model/enums/Carrier.java
@@ -79,6 +79,6 @@ public enum Carrier implements EasyPostEnum {
     }
 
     public static Carrier getEnum(String value) throws EasyPostException {
-        return (Carrier) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (Carrier) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/Carrier.java
+++ b/src/main/java/com/easypost/model/enums/Carrier.java
@@ -1,0 +1,84 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum Carrier implements EasyPostEnum {
+    Amazon_Mws("AmazonMws"),
+    APC("APC"),
+    Asendia("Asendia"),
+    Asendia_USA("AsendiaUsa"),
+    Australia_Post("AustraliaPost"),
+    AxlehireV3("AxlehireV3"),
+    Better_Trucks("BetterTrucks"),
+    Bond("Bond"),
+    Cainiao("Cainiao"),
+    Canada_Post("CanadaPost"),
+    Canpar("Canpar"),
+    CDL_Last_Mile_Solutions("ColumbusLastMile"),
+    Chronopost("Chronopost"),
+    CloudSort("CloudSort"),
+    Courier_Express("CourierExpress"),
+    CouriersPlease("CouriersPlease"),
+    Dai_Post("DaiPost"),
+    Deutsche_Post("DeutschePost"),
+    Deutsche_Post_UK("DeutschePostUK"),
+    DHL_eCommerce_Asia("DHLEcommerceAsia"),
+    DHL_eCommerce_Solutions("DhlEcs"),
+    DHL_Express("DHLExpress"),
+    DPD("DPD"),
+    DPD_UK("DPDUK"),
+    ePost_Global("ePostGlobal"),
+    Estafeta("Estafeta"),
+    Fastway("Fastway"),
+    FedEx("FedEx"),
+    FedEx_Cross_Border("FedExCrossBorder"),
+    FedEx_Mailview("FedExMailview"),
+    FedEx_SameDay_City("FedExSameDayCity"),
+    FedEx_SmartPost("FedExSmartPost"),
+    FirstMile("FirstMile"),
+    Globegistics("Globegistics"),
+    GSO("GSO"),
+    Hermes("Hermes"),
+    Interlink_Express("InterlinkExpress"),
+    JP_Post("JPPost"),
+    Kuroneko_Yamato("KuronekoYamato"),
+    La_Poste("LaPoste"),
+    LaserShip("Lasership"),
+    Loomis_Express("LoomisExpress"),
+    LSO("LSO"),
+    Newgistics("Newgistics"),
+    OnTrac("OnTrac"),
+    Osm_Worldwide("OsmWorldwide"),
+    Parcelforce("Parcelforce"),
+    Passport("Passport"),
+    PCF_Final_Mile("PcfFinalMile"),
+    PostNL("PostNL"),
+    Purolator("Purolator"),
+    Royal_Mail("RoyalMail"),
+    SEKO_OmniParcel("OmniParcel"),
+    SF_Express("SFExpress"),
+    Spee_Dee("SpeeDee"),
+    StarTrack("StarTrack"),
+    TForce("TForce"),
+    UDS("UDS"),
+    UPS("UPS"),
+    UPS_i_parcel("UPSIparcel"),
+    UPS_Mail_Innovations("UPSMailInnovations"),
+    USPS("USPS"),
+    Veho("Veho"),
+    Yanwen("Yanwen");
+
+    private String value;
+
+    Carrier(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static Carrier getEnum(String value) throws EasyPostException {
+        return (Carrier) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/CredentialsVisibility.java
+++ b/src/main/java/com/easypost/model/enums/CredentialsVisibility.java
@@ -20,6 +20,6 @@ public enum CredentialsVisibility implements EasyPostEnum {
     }
 
     public static CredentialsVisibility getEnum(String value) throws EasyPostException {
-        return (CredentialsVisibility) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (CredentialsVisibility) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/CredentialsVisibility.java
+++ b/src/main/java/com/easypost/model/enums/CredentialsVisibility.java
@@ -1,0 +1,25 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum CredentialsVisibility implements EasyPostEnum {
+    VISIBLE("visible"),
+    CHECKBOX("checkbox"),
+    FAKE("fake"),
+    PASSWORD("password"),
+    MASKED("masked");
+
+    private String value;
+
+    CredentialsVisibility(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static CredentialsVisibility getEnum(String value) throws EasyPostException {
+        return (CredentialsVisibility) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/CredentialsVisibility.java
+++ b/src/main/java/com/easypost/model/enums/CredentialsVisibility.java
@@ -1,12 +1,18 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum CredentialsVisibility implements EasyPostEnum {
+    @SerializedName("visible")
     VISIBLE("visible"),
+    @SerializedName("checkbox")
     CHECKBOX("checkbox"),
+    @SerializedName("fake")
     FAKE("fake"),
+    @SerializedName("password")
     PASSWORD("password"),
+    @SerializedName("masked")
     MASKED("masked");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/CustomsContentsType.java
+++ b/src/main/java/com/easypost/model/enums/CustomsContentsType.java
@@ -1,0 +1,26 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum CustomsContentsType implements EasyPostEnum {
+    DOCUMENTS("documents"),
+    GIFT("gift"),
+    MERCHANDISE("merchandise"),
+    RETURNED_GOODS("returned_goods"),
+    SAMPLE("sample"),
+    OTHER("other");
+
+    private String value;
+
+    CustomsContentsType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static CustomsContentsType getEnum(String value) throws EasyPostException {
+        return (CustomsContentsType) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/CustomsContentsType.java
+++ b/src/main/java/com/easypost/model/enums/CustomsContentsType.java
@@ -1,13 +1,20 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum CustomsContentsType implements EasyPostEnum {
+    @SerializedName("documents")
     DOCUMENTS("documents"),
+    @SerializedName("gift")
     GIFT("gift"),
+    @SerializedName("merchandise")
     MERCHANDISE("merchandise"),
+    @SerializedName("returned_goods")
     RETURNED_GOODS("returned_goods"),
+    @SerializedName("sample")
     SAMPLE("sample"),
+    @SerializedName("other")
     OTHER("other");
 
     private String value;
@@ -21,6 +28,6 @@ public enum CustomsContentsType implements EasyPostEnum {
     }
 
     public static CustomsContentsType getEnum(String value) throws EasyPostException {
-        return (CustomsContentsType) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (CustomsContentsType) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/CustomsNonDeliveryOption.java
+++ b/src/main/java/com/easypost/model/enums/CustomsNonDeliveryOption.java
@@ -1,0 +1,28 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum CustomsNonDeliveryOption implements EasyPostEnum {
+    ABANDON("abandon"),
+    RETURN("return");
+
+    private String value;
+
+    CustomsNonDeliveryOption(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static CustomsNonDeliveryOption getEnum(String value)
+            throws EasyPostException {
+        return (CustomsNonDeliveryOption) EasyPostEnum.getEnumFromValue(
+                Mode.class, value);
+    }
+
+    public static CustomsNonDeliveryOption getDefault() {
+        return RETURN;
+    }
+}

--- a/src/main/java/com/easypost/model/enums/CustomsNonDeliveryOption.java
+++ b/src/main/java/com/easypost/model/enums/CustomsNonDeliveryOption.java
@@ -1,9 +1,12 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum CustomsNonDeliveryOption implements EasyPostEnum {
+    @SerializedName("abandon")
     ABANDON("abandon"),
+    @SerializedName("return")
     RETURN("return");
 
     private String value;
@@ -19,7 +22,7 @@ public enum CustomsNonDeliveryOption implements EasyPostEnum {
     public static CustomsNonDeliveryOption getEnum(String value)
             throws EasyPostException {
         return (CustomsNonDeliveryOption) EasyPostEnum.getEnumFromValue(
-                Mode.class, value);
+                values(), value);
     }
 
     public static CustomsNonDeliveryOption getDefault() {

--- a/src/main/java/com/easypost/model/enums/CustomsRestrictionType.java
+++ b/src/main/java/com/easypost/model/enums/CustomsRestrictionType.java
@@ -1,0 +1,24 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum CustomsRestrictionType implements EasyPostEnum {
+    NONE("none"), OTHER("other"), QUARANTINE("quarantine"),
+    SANITARY_PHYTOSANITARY_INSPECTION("sanitary_phytosanitary_inspection");
+
+    private String value;
+
+    CustomsRestrictionType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static CustomsRestrictionType getEnum(String value)
+            throws EasyPostException {
+        return (CustomsRestrictionType) EasyPostEnum.getEnumFromValue(
+                Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/CustomsRestrictionType.java
+++ b/src/main/java/com/easypost/model/enums/CustomsRestrictionType.java
@@ -1,9 +1,16 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum CustomsRestrictionType implements EasyPostEnum {
-    NONE("none"), OTHER("other"), QUARANTINE("quarantine"),
+    @SerializedName("none")
+    NONE("none"),
+    @SerializedName("other")
+    OTHER("other"),
+    @SerializedName("quarantine")
+    QUARANTINE("quarantine"),
+    @SerializedName("sanitary_phytosanitary_inspection")
     SANITARY_PHYTOSANITARY_INSPECTION("sanitary_phytosanitary_inspection");
 
     private String value;
@@ -19,6 +26,6 @@ public enum CustomsRestrictionType implements EasyPostEnum {
     public static CustomsRestrictionType getEnum(String value)
             throws EasyPostException {
         return (CustomsRestrictionType) EasyPostEnum.getEnumFromValue(
-                Mode.class, value);
+                values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/Customs_EEL_PFC.java
+++ b/src/main/java/com/easypost/model/enums/Customs_EEL_PFC.java
@@ -1,9 +1,12 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum Customs_EEL_PFC implements EasyPostEnum {
+    @SerializedName ("EEL")
     EEL("EEL"),
+    @SerializedName("PFC")
     PFC("PFC");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/Customs_EEL_PFC.java
+++ b/src/main/java/com/easypost/model/enums/Customs_EEL_PFC.java
@@ -1,0 +1,24 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum Customs_EEL_PFC implements EasyPostEnum {
+    EEL("EEL"),
+    PFC("PFC");
+
+    private String value;
+
+    Customs_EEL_PFC(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static Customs_EEL_PFC getEnum(String value)
+            throws EasyPostException {
+        return (Customs_EEL_PFC) EasyPostEnum.getEnumFromValue(Mode.class,
+                value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/Customs_EEL_PFC.java
+++ b/src/main/java/com/easypost/model/enums/Customs_EEL_PFC.java
@@ -18,7 +18,7 @@ public enum Customs_EEL_PFC implements EasyPostEnum {
 
     public static Customs_EEL_PFC getEnum(String value)
             throws EasyPostException {
-        return (Customs_EEL_PFC) EasyPostEnum.getEnumFromValue(Mode.class,
+        return (Customs_EEL_PFC) EasyPostEnum.getEnumFromValue(values(),
                 value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/DeliveryConfirmation.java
+++ b/src/main/java/com/easypost/model/enums/DeliveryConfirmation.java
@@ -1,0 +1,23 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum DeliveryConfirmation implements EasyPostEnum {
+    ADULT_SIGNATURE("ADULT_SIGNATURE"),
+    SIGNATURE("SIGNATURE"),
+    NO_SIGNATURE("NO_SIGNATURE");
+
+    private String value;
+
+    DeliveryConfirmation(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static DeliveryConfirmation getEnum(String value) throws EasyPostException {
+        return (DeliveryConfirmation) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/DeliveryConfirmation.java
+++ b/src/main/java/com/easypost/model/enums/DeliveryConfirmation.java
@@ -1,10 +1,14 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum DeliveryConfirmation implements EasyPostEnum {
+    @SerializedName ("ADULT_SIGNATURE")
     ADULT_SIGNATURE("ADULT_SIGNATURE"),
+    @SerializedName("SIGNATURE")
     SIGNATURE("SIGNATURE"),
+    @SerializedName("NO_SIGNATURE")
     NO_SIGNATURE("NO_SIGNATURE");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/DeliveryConfirmation.java
+++ b/src/main/java/com/easypost/model/enums/DeliveryConfirmation.java
@@ -18,6 +18,6 @@ public enum DeliveryConfirmation implements EasyPostEnum {
     }
 
     public static DeliveryConfirmation getEnum(String value) throws EasyPostException {
-        return (DeliveryConfirmation) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (DeliveryConfirmation) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/DropoffType.java
+++ b/src/main/java/com/easypost/model/enums/DropoffType.java
@@ -1,18 +1,23 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum DropoffType implements EasyPostEnum {
+    @SerializedName ("REGULAR_PICKUP")
     REGULAR_PICKUP("REGULAR_PICKUP"),
+    @SerializedName("SCHEDULED_PICKUP")
     SCHEDULED_PICKUP("SCHEDULED_PICKUP"),
-    RETAIL_LOCATION("rejected"),
+    @SerializedName("RETAIL_LOCATION")
+    RETAIL_LOCATION("RETAIL_LOCATION"),
+    @SerializedName("STATION")
     STATION("STATION"),
+    @SerializedName("DROP_BOX")
     DROP_BOX("DROP_BOX"),
-    FEDEX_REGULAR_PICKUP("REGULAR_PICKUP"),
+    @SerializedName("REQUEST_COURIER")
     FEDEX_SCHEDULED_PICKUP("REQUEST_COURIER"),
-    FEDEX_RETAIL_LOCATION("BUSINESS_SERVICE_CENTER"),
-    FEDEX_STATION("STATION"),
-    FEDEX_DROP_BOX("DROP_BOX");
+    @SerializedName("BUSINESS_SERVICE_CENTER")
+    FEDEX_RETAIL_LOCATION("BUSINESS_SERVICE_CENTER");
 
     private String value;
 

--- a/src/main/java/com/easypost/model/enums/DropoffType.java
+++ b/src/main/java/com/easypost/model/enums/DropoffType.java
@@ -1,0 +1,30 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum DropoffType implements EasyPostEnum {
+    REGULAR_PICKUP("REGULAR_PICKUP"),
+    SCHEDULED_PICKUP("SCHEDULED_PICKUP"),
+    RETAIL_LOCATION("rejected"),
+    STATION("STATION"),
+    DROP_BOX("DROP_BOX"),
+    FEDEX_REGULAR_PICKUP("REGULAR_PICKUP"),
+    FEDEX_SCHEDULED_PICKUP("REQUEST_COURIER"),
+    FEDEX_RETAIL_LOCATION("BUSINESS_SERVICE_CENTER"),
+    FEDEX_STATION("STATION"),
+    FEDEX_DROP_BOX("DROP_BOX");
+
+    private String value;
+
+    DropoffType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static DropoffType getEnum(String value) throws EasyPostException {
+        return (DropoffType) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/DropoffType.java
+++ b/src/main/java/com/easypost/model/enums/DropoffType.java
@@ -25,6 +25,6 @@ public enum DropoffType implements EasyPostEnum {
     }
 
     public static DropoffType getEnum(String value) throws EasyPostException {
-        return (DropoffType) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (DropoffType) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/EasyPostEnum.java
+++ b/src/main/java/com/easypost/model/enums/EasyPostEnum.java
@@ -1,0 +1,16 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public interface EasyPostEnum {
+
+    public String getValue();
+
+    public static Enum getEnumFromValue(Class enumClazz, String value) throws EasyPostException {
+        try {
+            return Enum.valueOf(enumClazz, value);
+        } catch (IllegalArgumentException e) {
+            throw new EasyPostException("Invalid enum: " + value);
+        }
+    }
+}

--- a/src/main/java/com/easypost/model/enums/EasyPostEnum.java
+++ b/src/main/java/com/easypost/model/enums/EasyPostEnum.java
@@ -6,11 +6,12 @@ public interface EasyPostEnum {
 
     public String getValue();
 
-    public static Enum getEnumFromValue(Class enumClazz, String value) throws EasyPostException {
-        try {
-            return Enum.valueOf(enumClazz, value);
-        } catch (IllegalArgumentException e) {
-            throw new EasyPostException("Invalid enum: " + value);
+    public static EasyPostEnum getEnumFromValue(EasyPostEnum[] values, String value) throws EasyPostException {
+        for (EasyPostEnum v : values) {
+            if (v.getValue().equals(value)) {
+                return v;
+            }
         }
+        throw new EasyPostException("Invalid enum: " + value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/EventStatus.java
+++ b/src/main/java/com/easypost/model/enums/EventStatus.java
@@ -21,6 +21,6 @@ public enum EventStatus implements EasyPostEnum {
     }
 
     public static EventStatus getEnum(String value) throws EasyPostException {
-        return (EventStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (EventStatus) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/EventStatus.java
+++ b/src/main/java/com/easypost/model/enums/EventStatus.java
@@ -1,13 +1,19 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum EventStatus implements EasyPostEnum {
+    @SerializedName ("completed")
     COMPLETED("completed"),
+    @SerializedName("failed")
     FAILED("failed"),
+    @SerializedName("in_queue")
     IN_QUEUE("in_queue"),
+    @SerializedName("retrying")
     RETRYING("retrying"),
     @Deprecated
+    @SerializedName("pending")
     PENDING("pending");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/EventStatus.java
+++ b/src/main/java/com/easypost/model/enums/EventStatus.java
@@ -1,0 +1,26 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum EventStatus implements EasyPostEnum {
+    COMPLETED("completed"),
+    FAILED("failed"),
+    IN_QUEUE("in_queue"),
+    RETRYING("retrying"),
+    @Deprecated
+    PENDING("pending");
+
+    private String value;
+
+    EventStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static EventStatus getEnum(String value) throws EasyPostException {
+        return (EventStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/FeeType.java
+++ b/src/main/java/com/easypost/model/enums/FeeType.java
@@ -1,11 +1,16 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum FeeType implements EasyPostEnum {
+    @SerializedName("LabelFee")
     LABEL("LabelFee"),
+    @SerializedName("PostageFee")
     POSTAGE("PostageFee"),
+    @SerializedName("InsuranceFee")
     INSURANCE("InsuranceFee"),
+    @SerializedName("TrackerFee")
     TRACKER("TrackerFee");
 
     private String value;
@@ -19,6 +24,6 @@ public enum FeeType implements EasyPostEnum {
     }
 
     public static FeeType getEnum(String value) throws EasyPostException {
-        return (FeeType) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (FeeType) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/FeeType.java
+++ b/src/main/java/com/easypost/model/enums/FeeType.java
@@ -1,0 +1,24 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum FeeType implements EasyPostEnum {
+    LABEL("LabelFee"),
+    POSTAGE("PostageFee"),
+    INSURANCE("InsuranceFee"),
+    TRACKER("TrackerFee");
+
+    private String value;
+
+    FeeType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static FeeType getEnum(String value) throws EasyPostException {
+        return (FeeType) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/FormType.java
+++ b/src/main/java/com/easypost/model/enums/FormType.java
@@ -1,12 +1,18 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum FormType implements EasyPostEnum {
+    @SerializedName("high_value_report")
     HIGH_VALUE_REPORT("high_value_report"),
+    @SerializedName("commercial_invoice")
     COMMERCIAL_INVOICE("commercial_invoice"),
+    @SerializedName("cod_return_label")
     COD_RETURN_LABEL("cod_return_label"),
+    @SerializedName("order_summary")
     ORDER_SUMMARY("order_summary"),
+    @SerializedName("cn22")
     CN22("cn22");
 
     private String value;
@@ -20,6 +26,6 @@ public enum FormType implements EasyPostEnum {
     }
 
     public static FormType getEnum(String value) throws EasyPostException {
-        return (FormType) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (FormType) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/FormType.java
+++ b/src/main/java/com/easypost/model/enums/FormType.java
@@ -1,0 +1,25 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum FormType implements EasyPostEnum {
+    HIGH_VALUE_REPORT("high_value_report"),
+    COMMERCIAL_INVOICE("commercial_invoice"),
+    COD_RETURN_LABEL("cod_return_label"),
+    ORDER_SUMMARY("order_summary"),
+    CN22("cn22");
+
+    private String value;
+
+    FormType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static FormType getEnum(String value) throws EasyPostException {
+        return (FormType) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/HazMat.java
+++ b/src/main/java/com/easypost/model/enums/HazMat.java
@@ -24,6 +24,6 @@ public enum HazMat implements EasyPostEnum {
     }
 
     public static HazMat getEnum(String value) throws EasyPostException {
-        return (HazMat) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (HazMat) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/HazMat.java
+++ b/src/main/java/com/easypost/model/enums/HazMat.java
@@ -1,16 +1,26 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum HazMat implements EasyPostEnum {
+    @SerializedName ("PRIMARY_CONTAINED")
     PRIMARY_CONTAINED("PRIMARY_CONTAINED"),
+    @SerializedName("PRIMARY_PACKED")
     PRIMARY_PACKED("PRIMARY_PACKED"),
+    @SerializedName("PRIMARY")
     PRIMARY("PRIMARY"),
+    @SerializedName("SECONDARY_CONTAINED")
     SECONDARY_CONTAINED("SECONDARY_CONTAINED"),
+    @SerializedName("SECONDARY_PACKED")
     SECONDARY_PACKED("SECONDARY_PACKED"),
+    @SerializedName("SECONDARY")
     SECONDARY("SECONDARY"),
+    @SerializedName("ORMD")
     ORMD("ORMD"),
+    @SerializedName("LIMITED_QUANTITY")
     LIMITED_QUANTITY("LIMITED_QUANTITY"),
+    @SerializedName("LITHIUM")
     LITHIUM("LITHIUM");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/HazMat.java
+++ b/src/main/java/com/easypost/model/enums/HazMat.java
@@ -1,0 +1,29 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum HazMat implements EasyPostEnum {
+    PRIMARY_CONTAINED("PRIMARY_CONTAINED"),
+    PRIMARY_PACKED("PRIMARY_PACKED"),
+    PRIMARY("PRIMARY"),
+    SECONDARY_CONTAINED("SECONDARY_CONTAINED"),
+    SECONDARY_PACKED("SECONDARY_PACKED"),
+    SECONDARY("SECONDARY"),
+    ORMD("ORMD"),
+    LIMITED_QUANTITY("LIMITED_QUANTITY"),
+    LITHIUM("LITHIUM");
+
+    private String value;
+
+    HazMat(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static HazMat getEnum(String value) throws EasyPostException {
+        return (HazMat) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/Incoterm.java
+++ b/src/main/java/com/easypost/model/enums/Incoterm.java
@@ -1,0 +1,31 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum Incoterm implements EasyPostEnum {
+    EXW("EXW"),
+    FCA("FCA"),
+    CPT("CPT"),
+    CIP("CIP"),
+    DAT("DAT"),
+    DAP("DAP"),
+    DDP("DDP"),
+    FAS("FAS"),
+    FOB("FOB"),
+    CFR("CFR"),
+    CIF("CIF");
+
+    private String value;
+
+    Incoterm(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static Incoterm getEnum(String value) throws EasyPostException {
+        return (Incoterm) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/Incoterm.java
+++ b/src/main/java/com/easypost/model/enums/Incoterm.java
@@ -1,18 +1,30 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum Incoterm implements EasyPostEnum {
+    @SerializedName ("EXW")
     EXW("EXW"),
+    @SerializedName("FCA")
     FCA("FCA"),
+    @SerializedName("CPT")
     CPT("CPT"),
+    @SerializedName("CIP")
     CIP("CIP"),
+    @SerializedName("DAT")
     DAT("DAT"),
+    @SerializedName("DAP")
     DAP("DAP"),
+    @SerializedName("DDP")
     DDP("DDP"),
+    @SerializedName("FAS")
     FAS("FAS"),
+    @SerializedName("FOB")
     FOB("FOB"),
+    @SerializedName("CFR")
     CFR("CFR"),
+    @SerializedName("CIF")
     CIF("CIF");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/Incoterm.java
+++ b/src/main/java/com/easypost/model/enums/Incoterm.java
@@ -26,6 +26,6 @@ public enum Incoterm implements EasyPostEnum {
     }
 
     public static Incoterm getEnum(String value) throws EasyPostException {
-        return (Incoterm) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (Incoterm) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/InsuranceStatus.java
+++ b/src/main/java/com/easypost/model/enums/InsuranceStatus.java
@@ -1,12 +1,18 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum InsuranceStatus implements EasyPostEnum {
+    @SerializedName("new")
     NEW("new"),
+    @SerializedName("pending")
     PENDING("pending"),
+    @SerializedName("purchased")
     PURCHASED("purchased"),
+    @SerializedName("failed")
     FAILED("failed"),
+    @SerializedName("cancelled")
     CANCELLED("cancelled");
 
     private String value;
@@ -20,6 +26,6 @@ public enum InsuranceStatus implements EasyPostEnum {
     }
 
     public static InsuranceStatus getEnum(String value) throws EasyPostException {
-        return (InsuranceStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (InsuranceStatus) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/InsuranceStatus.java
+++ b/src/main/java/com/easypost/model/enums/InsuranceStatus.java
@@ -1,0 +1,25 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum InsuranceStatus implements EasyPostEnum {
+    NEW("new"),
+    PENDING("pending"),
+    PURCHASED("purchased"),
+    FAILED("failed"),
+    CANCELLED("cancelled");
+
+    private String value;
+
+    InsuranceStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static InsuranceStatus getEnum(String value) throws EasyPostException {
+        return (InsuranceStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/LabelFormat.java
+++ b/src/main/java/com/easypost/model/enums/LabelFormat.java
@@ -1,0 +1,28 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum LabelFormat implements EasyPostEnum {
+    PNG("PNG"),
+    PDF("PDF"),
+    ZPL("ZPL"),
+    EPL2("EPL2");
+
+    private String value;
+
+    LabelFormat(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static LabelFormat getEnum(String value) throws EasyPostException {
+        return (LabelFormat) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+
+    public static LabelFormat getDefault() {
+        return PNG;
+    }
+}

--- a/src/main/java/com/easypost/model/enums/LabelFormat.java
+++ b/src/main/java/com/easypost/model/enums/LabelFormat.java
@@ -1,11 +1,16 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum LabelFormat implements EasyPostEnum {
+    @SerializedName ("PNG")
     PNG("PNG"),
+    @SerializedName("PDF")
     PDF("PDF"),
+    @SerializedName("ZPL")
     ZPL("ZPL"),
+    @SerializedName("EPL2")
     EPL2("EPL2");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/LabelFormat.java
+++ b/src/main/java/com/easypost/model/enums/LabelFormat.java
@@ -19,7 +19,7 @@ public enum LabelFormat implements EasyPostEnum {
     }
 
     public static LabelFormat getEnum(String value) throws EasyPostException {
-        return (LabelFormat) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (LabelFormat) EasyPostEnum.getEnumFromValue(values(), value);
     }
 
     public static LabelFormat getDefault() {

--- a/src/main/java/com/easypost/model/enums/Mode.java
+++ b/src/main/java/com/easypost/model/enums/Mode.java
@@ -1,0 +1,22 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum Mode implements EasyPostEnum {
+    TEST("test"),
+    PRODUCTION("production");
+
+    private String value;
+
+    Mode(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static Mode getEnum(String value) throws EasyPostException {
+        return (Mode) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/Mode.java
+++ b/src/main/java/com/easypost/model/enums/Mode.java
@@ -1,9 +1,13 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum Mode implements EasyPostEnum {
+    // https://stackoverflow.com/a/18851314
+    @SerializedName ("test")
     TEST("test"),
+    @SerializedName ("production")
     PRODUCTION("production");
 
     private String value;
@@ -17,6 +21,7 @@ public enum Mode implements EasyPostEnum {
     }
 
     public static Mode getEnum(String value) throws EasyPostException {
-        return (Mode) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        
+        return (Mode) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/Payment.java
+++ b/src/main/java/com/easypost/model/enums/Payment.java
@@ -1,0 +1,28 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum Payment implements EasyPostEnum {
+    SENDER("SENDER"),
+    THIRD_PARTY("THIRD_PARTY"),
+    RECEIVER("RECEIVER"),
+    COLLECT("COLLECT");
+
+    private String value;
+
+    Payment(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static Payment getEnum(String value) throws EasyPostException {
+        return (Payment) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+
+    public static Payment getDefault() {
+        return SENDER;
+    }
+}

--- a/src/main/java/com/easypost/model/enums/Payment.java
+++ b/src/main/java/com/easypost/model/enums/Payment.java
@@ -1,11 +1,16 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum Payment implements EasyPostEnum {
+    @SerializedName ("SENDER")
     SENDER("SENDER"),
+    @SerializedName("THIRD_PARTY")
     THIRD_PARTY("THIRD_PARTY"),
+    @SerializedName("RECEIVER")
     RECEIVER("RECEIVER"),
+    @SerializedName("COLLECT")
     COLLECT("COLLECT");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/Payment.java
+++ b/src/main/java/com/easypost/model/enums/Payment.java
@@ -19,7 +19,7 @@ public enum Payment implements EasyPostEnum {
     }
 
     public static Payment getEnum(String value) throws EasyPostException {
-        return (Payment) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (Payment) EasyPostEnum.getEnumFromValue(values(), value);
     }
 
     public static Payment getDefault() {

--- a/src/main/java/com/easypost/model/enums/PickupStatus.java
+++ b/src/main/java/com/easypost/model/enums/PickupStatus.java
@@ -1,10 +1,14 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum PickupStatus implements EasyPostEnum {
+    @SerializedName("unknown")
     UNKNOWN("unknown"),
+    @SerializedName("scheduled")
     SCHEDULED("scheduled"),
+    @SerializedName("canceled")
     CANCELLED("canceled"); // handles single to double L confusion, the catalyst for using enums
 
     private String value;
@@ -18,6 +22,6 @@ public enum PickupStatus implements EasyPostEnum {
     }
 
     public static PickupStatus getEnum(String value) throws EasyPostException {
-        return (PickupStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (PickupStatus) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/PickupStatus.java
+++ b/src/main/java/com/easypost/model/enums/PickupStatus.java
@@ -1,0 +1,23 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum PickupStatus implements EasyPostEnum {
+    UNKNOWN("unknown"),
+    SCHEDULED("scheduled"),
+    CANCELLED("canceled"); // handles single to double L confusion, the catalyst for using enums
+
+    private String value;
+
+    PickupStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static PickupStatus getEnum(String value) throws EasyPostException {
+        return (PickupStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/PrintCustomCode.java
+++ b/src/main/java/com/easypost/model/enums/PrintCustomCode.java
@@ -1,29 +1,52 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum PrintCustomCode implements EasyPostEnum {
+    @SerializedName ("PO")
     PO("PO"),
+    @SerializedName("DP")
     DP("DP"),
+    @SerializedName("RMA")
     RMA("RMA"),
+    @SerializedName("AJ")
     AJ("AJ"),
+    @SerializedName("AT")
     AT("AT"),
+    @SerializedName("DM")
     BM("BM"),
+    @SerializedName("9V")
     NINEV("9V"),
+    @SerializedName("ON")
     ON("ON"),
+    @SerializedName("3Q")
     THREEQ("3Q"),
+    @SerializedName("IK")
     IK("IK"),
+    @SerializedName("MK")
     MK("MK"),
+    @SerializedName("MJ")
     MJ("MJ"),
+    @SerializedName("PM")
     PM("PM"),
+    @SerializedName("PC")
     PC("PC"),
+    @SerializedName("RQ")
     RQ("RQ"),
+    @SerializedName("RZ")
     RZ("RZ"),
+    @SerializedName("SA")
     SA("SA"),
+    @SerializedName("SE")
     SE("SE"),
+    @SerializedName("ST")
     ST("ST"),
+    @SerializedName("TN")
     TN("TN"),
+    @SerializedName("EI")
     EI("EI"),
+    @SerializedName("TJ")
     TJ("TJ");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/PrintCustomCode.java
+++ b/src/main/java/com/easypost/model/enums/PrintCustomCode.java
@@ -1,0 +1,46 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum PrintCustomCode implements EasyPostEnum {
+    PO("PO"),
+    DP("DP"),
+    RMA("RMA"),
+    AJ("AJ"),
+    AT("AT"),
+    BM("BM"),
+    NINEV("9V"),
+    ON("ON"),
+    THREEQ("3Q"),
+    IK("IK"),
+    MK("MK"),
+    MJ("MJ"),
+    PM("PM"),
+    PC("PC"),
+    RQ("RQ"),
+    RZ("RZ"),
+    SA("SA"),
+    SE("SE"),
+    ST("ST"),
+    TN("TN"),
+    EI("EI"),
+    TJ("TJ");
+
+    private String value;
+
+    PrintCustomCode(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static PrintCustomCode getEnum(String value) throws EasyPostException {
+        return (PrintCustomCode) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+
+    public static PrintCustomCode getFedexDefault() {
+        return null;
+    }
+}

--- a/src/main/java/com/easypost/model/enums/PrintCustomCode.java
+++ b/src/main/java/com/easypost/model/enums/PrintCustomCode.java
@@ -37,7 +37,7 @@ public enum PrintCustomCode implements EasyPostEnum {
     }
 
     public static PrintCustomCode getEnum(String value) throws EasyPostException {
-        return (PrintCustomCode) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (PrintCustomCode) EasyPostEnum.getEnumFromValue(values(), value);
     }
 
     public static PrintCustomCode getFedexDefault() {

--- a/src/main/java/com/easypost/model/enums/RefundStatus.java
+++ b/src/main/java/com/easypost/model/enums/RefundStatus.java
@@ -1,0 +1,23 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum RefundStatus implements EasyPostEnum {
+    SUBMITTED("submitted"),
+    REFUNDED("refunded"),
+    REJECTED("rejected");
+
+    private String value;
+
+    RefundStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static RefundStatus getEnum(String value) throws EasyPostException {
+        return (RefundStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/RefundStatus.java
+++ b/src/main/java/com/easypost/model/enums/RefundStatus.java
@@ -1,10 +1,14 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum RefundStatus implements EasyPostEnum {
+    @SerializedName("submitted")
     SUBMITTED("submitted"),
+    @SerializedName("refunded")
     REFUNDED("refunded"),
+    @SerializedName("rejected")
     REJECTED("rejected");
 
     private String value;
@@ -18,6 +22,6 @@ public enum RefundStatus implements EasyPostEnum {
     }
 
     public static RefundStatus getEnum(String value) throws EasyPostException {
-        return (RefundStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (RefundStatus) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/ReportStatus.java
+++ b/src/main/java/com/easypost/model/enums/ReportStatus.java
@@ -1,0 +1,27 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum ReportStatus implements EasyPostEnum {
+    NEW("new"),
+    AVAILABLE("available"),
+    FAILED("failed"),
+    NULL(null);
+
+    private String value;
+
+    ReportStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static ReportStatus getEnum(String value) throws EasyPostException {
+        if (value == null) {
+            return NULL;
+        }
+        return (ReportStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/ReportStatus.java
+++ b/src/main/java/com/easypost/model/enums/ReportStatus.java
@@ -1,10 +1,14 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum ReportStatus implements EasyPostEnum {
+    @SerializedName("new")
     NEW("new"),
+    @SerializedName("available")
     AVAILABLE("available"),
+    @SerializedName("failed")
     FAILED("failed"),
     NULL(null);
 
@@ -22,6 +26,6 @@ public enum ReportStatus implements EasyPostEnum {
         if (value == null) {
             return NULL;
         }
-        return (ReportStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (ReportStatus) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/ReportType.java
+++ b/src/main/java/com/easypost/model/enums/ReportType.java
@@ -21,6 +21,6 @@ public enum ReportType implements EasyPostEnum {
     }
 
     public static ReportType getEnum(String value) throws EasyPostException {
-        return (ReportType) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (ReportType) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/ReportType.java
+++ b/src/main/java/com/easypost/model/enums/ReportType.java
@@ -1,13 +1,20 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum ReportType implements EasyPostEnum {
+    @SerializedName ("CashFlowReport")
     CASH_FLOW("CashFlowReport"),
+    @SerializedName("PaymentLogReport")
     PAYMENT_LOG("PaymentLogReport"),
+    @SerializedName("RefundReport")
     REFUND("RefundReport"),
+    @SerializedName("ShipmentReport")
     SHIPMENT("ShipmentReport"),
+    @SerializedName("ShipmentInvoiceReport")
     SHIPMENT_INVOICE("ShipmentInvoiceReport"),
+    @SerializedName("TrackerReport")
     TRACKER("TrackerReport");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/ReportType.java
+++ b/src/main/java/com/easypost/model/enums/ReportType.java
@@ -1,0 +1,26 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum ReportType implements EasyPostEnum {
+    CASH_FLOW("CashFlowReport"),
+    PAYMENT_LOG("PaymentLogReport"),
+    REFUND("RefundReport"),
+    SHIPMENT("ShipmentReport"),
+    SHIPMENT_INVOICE("ShipmentInvoiceReport"),
+    TRACKER("TrackerReport");
+
+    private String value;
+
+    ReportType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static ReportType getEnum(String value) throws EasyPostException {
+        return (ReportType) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/ScanFormStatus.java
+++ b/src/main/java/com/easypost/model/enums/ScanFormStatus.java
@@ -1,10 +1,14 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum ScanFormStatus implements EasyPostEnum {
+    @SerializedName("creating")
     CREATING("creating"),
+    @SerializedName("created")
     CREATED("created"),
+    @SerializedName("failed")
     FAILED("failed");
 
     private String value;
@@ -18,6 +22,6 @@ public enum ScanFormStatus implements EasyPostEnum {
     }
 
     public static ScanFormStatus getEnum(String value) throws EasyPostException {
-        return (ScanFormStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (ScanFormStatus) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/ScanFormStatus.java
+++ b/src/main/java/com/easypost/model/enums/ScanFormStatus.java
@@ -1,0 +1,23 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum ScanFormStatus implements EasyPostEnum {
+    CREATING("creating"),
+    CREATED("created"),
+    FAILED("failed");
+
+    private String value;
+
+    ScanFormStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static ScanFormStatus getEnum(String value) throws EasyPostException {
+        return (ScanFormStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/TaxEntity.java
+++ b/src/main/java/com/easypost/model/enums/TaxEntity.java
@@ -17,6 +17,6 @@ public enum TaxEntity implements EasyPostEnum {
     }
 
     public static TaxEntity getEnum(String value) throws EasyPostException {
-        return (TaxEntity) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxEntity) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/TaxEntity.java
+++ b/src/main/java/com/easypost/model/enums/TaxEntity.java
@@ -1,0 +1,22 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum TaxEntity implements EasyPostEnum {
+    SENDER("SENDER"),
+    RECEIVER("RECEIVER");
+
+    private String value;
+
+    TaxEntity(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxEntity getEnum(String value) throws EasyPostException {
+        return (TaxEntity) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/TaxEntity.java
+++ b/src/main/java/com/easypost/model/enums/TaxEntity.java
@@ -1,9 +1,12 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxEntity implements EasyPostEnum {
+    @SerializedName ("SENDER")
     SENDER("SENDER"),
+    @SerializedName("RECEIVER")
     RECEIVER("RECEIVER");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/TrackerStatus.java
+++ b/src/main/java/com/easypost/model/enums/TrackerStatus.java
@@ -1,0 +1,30 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum TrackerStatus implements EasyPostEnum {
+    UNKNOWN("unknown"),
+    PRE_TRANSIT("pre_transit"),
+    IN_TRANSIT("in_transit"),
+    OUT_FOR_DELIVERY("out_for_delivery"),
+    DELIVERED("delivered"),
+    AVAILABLE_FOR_PICKUP("available_for_pickup"),
+    RETURN_TO_SENDER("return_to_sender"),
+    FAILURE("failure"),
+    CANCELLED("cancelled"),
+    ERROR("error");
+
+    private String value;
+
+    TrackerStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TrackerStatus getEnum(String value) throws EasyPostException {
+        return (TrackerStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/TrackerStatus.java
+++ b/src/main/java/com/easypost/model/enums/TrackerStatus.java
@@ -1,17 +1,28 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum TrackerStatus implements EasyPostEnum {
+    @SerializedName("unknown")
     UNKNOWN("unknown"),
+    @SerializedName("pre_transit")
     PRE_TRANSIT("pre_transit"),
+    @SerializedName("in_transit")
     IN_TRANSIT("in_transit"),
+    @SerializedName("out_for_delivery")
     OUT_FOR_DELIVERY("out_for_delivery"),
+    @SerializedName("delivered")
     DELIVERED("delivered"),
+    @SerializedName("available_for_pickup")
     AVAILABLE_FOR_PICKUP("available_for_pickup"),
+    @SerializedName("return_to_sender")
     RETURN_TO_SENDER("return_to_sender"),
+    @SerializedName("failure")
     FAILURE("failure"),
+    @SerializedName("cancelled")
     CANCELLED("cancelled"),
+    @SerializedName("error")
     ERROR("error");
 
     private String value;
@@ -25,6 +36,6 @@ public enum TrackerStatus implements EasyPostEnum {
     }
 
     public static TrackerStatus getEnum(String value) throws EasyPostException {
-        return (TrackerStatus) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TrackerStatus) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/USPSSpecialRatesEligibility.java
+++ b/src/main/java/com/easypost/model/enums/USPSSpecialRatesEligibility.java
@@ -17,6 +17,6 @@ public enum USPSSpecialRatesEligibility implements EasyPostEnum {
     }
 
     public static USPSSpecialRatesEligibility getEnum(String value) throws EasyPostException {
-        return (USPSSpecialRatesEligibility) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (USPSSpecialRatesEligibility) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/USPSSpecialRatesEligibility.java
+++ b/src/main/java/com/easypost/model/enums/USPSSpecialRatesEligibility.java
@@ -1,0 +1,22 @@
+package com.easypost.model.enums;
+
+import com.easypost.exception.EasyPostException;
+
+public enum USPSSpecialRatesEligibility implements EasyPostEnum {
+    MEDIA_MAIL("USPS.MEDIAMAIL"),
+    LIBRARY_MAIL("USPS.LIBRARYMAIL");
+
+    private String value;
+
+    USPSSpecialRatesEligibility(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static USPSSpecialRatesEligibility getEnum(String value) throws EasyPostException {
+        return (USPSSpecialRatesEligibility) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/USPSSpecialRatesEligibility.java
+++ b/src/main/java/com/easypost/model/enums/USPSSpecialRatesEligibility.java
@@ -1,9 +1,12 @@
 package com.easypost.model.enums;
 
 import com.easypost.exception.EasyPostException;
+import com.google.gson.annotations.SerializedName;
 
 public enum USPSSpecialRatesEligibility implements EasyPostEnum {
+    @SerializedName ("USPS.MEDIAMAIL")
     MEDIA_MAIL("USPS.MEDIAMAIL"),
+    @SerializedName("USPS.LIBRARYMAIL")
     LIBRARY_MAIL("USPS.LIBRARYMAIL");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_APC.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_APC.java
@@ -1,0 +1,23 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_APC implements EasyPostEnum {
+    VAT("VAT");
+
+    private String value;
+
+    TaxIDType_APC(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_APC getEnum(String value) throws EasyPostException {
+        return (TaxIDType_APC) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_APC.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_APC.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_APC implements EasyPostEnum {
     VAT("VAT");
@@ -18,6 +17,6 @@ public enum TaxIDType_APC implements EasyPostEnum {
     }
 
     public static TaxIDType_APC getEnum(String value) throws EasyPostException {
-        return (TaxIDType_APC) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_APC) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_APC.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_APC.java
@@ -2,8 +2,10 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_APC implements EasyPostEnum {
+    @SerializedName ("VAT")
     VAT("VAT");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_Asendia.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_Asendia.java
@@ -2,8 +2,10 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_Asendia implements EasyPostEnum {
+    @SerializedName ("VAT")
     VAT("VAT");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_Asendia.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_Asendia.java
@@ -1,0 +1,23 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_Asendia implements EasyPostEnum {
+    VAT("VAT");
+
+    private String value;
+
+    TaxIDType_Asendia(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_Asendia getEnum(String value) throws EasyPostException {
+        return (TaxIDType_Asendia) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_Asendia.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_Asendia.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_Asendia implements EasyPostEnum {
     VAT("VAT");
@@ -18,6 +17,6 @@ public enum TaxIDType_Asendia implements EasyPostEnum {
     }
 
     public static TaxIDType_Asendia getEnum(String value) throws EasyPostException {
-        return (TaxIDType_Asendia) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_Asendia) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_AsendiaUSA.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_AsendiaUSA.java
@@ -1,0 +1,23 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_AsendiaUSA implements EasyPostEnum {
+    VAT("VAT");
+
+    private String value;
+
+    TaxIDType_AsendiaUSA(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_AsendiaUSA getEnum(String value) throws EasyPostException {
+        return (TaxIDType_AsendiaUSA) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_AsendiaUSA.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_AsendiaUSA.java
@@ -2,8 +2,10 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_AsendiaUSA implements EasyPostEnum {
+    @SerializedName ("VAT")
     VAT("VAT");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_AsendiaUSA.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_AsendiaUSA.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_AsendiaUSA implements EasyPostEnum {
     VAT("VAT");
@@ -18,6 +17,6 @@ public enum TaxIDType_AsendiaUSA implements EasyPostEnum {
     }
 
     public static TaxIDType_AsendiaUSA getEnum(String value) throws EasyPostException {
-        return (TaxIDType_AsendiaUSA) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_AsendiaUSA) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_AustraliaPost.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_AustraliaPost.java
@@ -1,0 +1,24 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_AustraliaPost implements EasyPostEnum {
+    VAT("VAT"),
+    IOSS("IOSS");
+
+    private String value;
+
+    TaxIDType_AustraliaPost(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_AustraliaPost getEnum(String value) throws EasyPostException {
+        return (TaxIDType_AustraliaPost) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_AustraliaPost.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_AustraliaPost.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_AustraliaPost implements EasyPostEnum {
     VAT("VAT"),
@@ -19,6 +18,6 @@ public enum TaxIDType_AustraliaPost implements EasyPostEnum {
     }
 
     public static TaxIDType_AustraliaPost getEnum(String value) throws EasyPostException {
-        return (TaxIDType_AustraliaPost) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_AustraliaPost) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_AustraliaPost.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_AustraliaPost.java
@@ -2,9 +2,12 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_AustraliaPost implements EasyPostEnum {
+    @SerializedName ("VAT")
     VAT("VAT"),
+    @SerializedName("IOSS")
     IOSS("IOSS");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLAsia.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLAsia.java
@@ -2,12 +2,18 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_DHLAsia implements EasyPostEnum {
+    @SerializedName ("VAT")
     VAT("VAT"),
+    @SerializedName("GST")
     GST("GST"),
+    @SerializedName("EORI")
     EORI("EORI"),
+    @SerializedName("IOSS")
     IOSS("IOSS"),
+    @SerializedName("PAN")
     PAN("PAN");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLAsia.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLAsia.java
@@ -1,0 +1,27 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_DHLAsia implements EasyPostEnum {
+    VAT("VAT"),
+    GST("GST"),
+    EORI("EORI"),
+    IOSS("IOSS"),
+    PAN("PAN");
+
+    private String value;
+
+    TaxIDType_DHLAsia(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_DHLAsia getEnum(String value) throws EasyPostException {
+        return (TaxIDType_DHLAsia) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLAsia.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLAsia.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_DHLAsia implements EasyPostEnum {
     VAT("VAT"),
@@ -22,6 +21,6 @@ public enum TaxIDType_DHLAsia implements EasyPostEnum {
     }
 
     public static TaxIDType_DHLAsia getEnum(String value) throws EasyPostException {
-        return (TaxIDType_DHLAsia) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_DHLAsia) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLECS.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLECS.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_DHLECS implements EasyPostEnum {
     VAT("VAT"),
@@ -23,6 +22,6 @@ public enum TaxIDType_DHLECS implements EasyPostEnum {
     }
 
     public static TaxIDType_DHLECS getEnum(String value) throws EasyPostException {
-        return (TaxIDType_DHLECS) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_DHLECS) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLECS.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLECS.java
@@ -1,0 +1,28 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_DHLECS implements EasyPostEnum {
+    VAT("VAT"),
+    GST("GST"),
+    EORI("EORI"),
+    IOSS("IOSS"),
+    PAN("PAN"),
+    OTHER("OTHER");
+
+    private String value;
+
+    TaxIDType_DHLECS(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_DHLECS getEnum(String value) throws EasyPostException {
+        return (TaxIDType_DHLECS) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLECS.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLECS.java
@@ -2,13 +2,20 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_DHLECS implements EasyPostEnum {
+    @SerializedName ("VAT")
     VAT("VAT"),
+    @SerializedName("GST")
     GST("GST"),
+    @SerializedName("EORI")
     EORI("EORI"),
+    @SerializedName("IOSS")
     IOSS("IOSS"),
+    @SerializedName("PAN")
     PAN("PAN"),
+    @SerializedName("OTHER")
     OTHER("OTHER");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLExpress.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLExpress.java
@@ -2,21 +2,36 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_DHLExpress implements EasyPostEnum {
+    @SerializedName ("VAT")
     VAT("VAT"),
+    @SerializedName("SDT")
     SDT("SDT"),
+    @SerializedName("IOSS")
     IOSS("IOSS"),
+    @SerializedName("FTZ")
     FTZ("FTZ"),
+    @SerializedName("DAN")
     DAN("DAN"),
+    @SerializedName("TAN")
     TAN("TAN"),
+    @SerializedName("DIF")
     DTF("DTF"),
+    @SerializedName("CNP")
     CNP("CNP"),
+    @SerializedName("DUN")
     DUN("DUN"),
+    @SerializedName("EIN")
     EIN("EIN"),
+    @SerializedName("EOR")
     EOR("EOR"),
+    @SerializedName("SSN")
     SSN("SSN"),
+    @SerializedName("FED")
     FED("FED"),
+    @SerializedName("STA")
     STA("STA");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLExpress.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLExpress.java
@@ -1,0 +1,36 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_DHLExpress implements EasyPostEnum {
+    VAT("VAT"),
+    SDT("SDT"),
+    IOSS("IOSS"),
+    FTZ("FTZ"),
+    DAN("DAN"),
+    TAN("TAN"),
+    DTF("DTF"),
+    CNP("CNP"),
+    DUN("DUN"),
+    EIN("EIN"),
+    EOR("EOR"),
+    SSN("SSN"),
+    FED("FED"),
+    STA("STA");
+
+    private String value;
+
+    TaxIDType_DHLExpress(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_DHLExpress getEnum(String value) throws EasyPostException {
+        return (TaxIDType_DHLExpress) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLExpress.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DHLExpress.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_DHLExpress implements EasyPostEnum {
     VAT("VAT"),
@@ -31,6 +30,6 @@ public enum TaxIDType_DHLExpress implements EasyPostEnum {
     }
 
     public static TaxIDType_DHLExpress getEnum(String value) throws EasyPostException {
-        return (TaxIDType_DHLExpress) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_DHLExpress) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DPDUK.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DPDUK.java
@@ -2,11 +2,16 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_DPDUK implements EasyPostEnum {
+    @SerializedName ("VAT")
     VAT("VAT"),
+    @SerializedName("EORI")
     EORI("EORI"),
+    @SerializedName("PID")
     PID("PID"),
+    @SerializedName("IOSS")
     IOSS("IOSS");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DPDUK.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DPDUK.java
@@ -1,0 +1,26 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_DPDUK implements EasyPostEnum {
+    VAT("VAT"),
+    EORI("EORI"),
+    PID("PID"),
+    IOSS("IOSS");
+
+    private String value;
+
+    TaxIDType_DPDUK(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_DPDUK getEnum(String value) throws EasyPostException {
+        return (TaxIDType_DPDUK) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DPDUK.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DPDUK.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_DPDUK implements EasyPostEnum {
     VAT("VAT"),
@@ -21,6 +20,6 @@ public enum TaxIDType_DPDUK implements EasyPostEnum {
     }
 
     public static TaxIDType_DPDUK getEnum(String value) throws EasyPostException {
-        return (TaxIDType_DPDUK) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_DPDUK) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DiaPost.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DiaPost.java
@@ -2,9 +2,12 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_DiaPost implements EasyPostEnum {
+    @SerializedName ("VAT")
     VAT("VAT"),
+    @SerializedName("IOSS")
     IOSS("IOSS");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DiaPost.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DiaPost.java
@@ -1,0 +1,24 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_DiaPost implements EasyPostEnum {
+    VAT("VAT"),
+    IOSS("IOSS");
+
+    private String value;
+
+    TaxIDType_DiaPost(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_DiaPost getEnum(String value) throws EasyPostException {
+        return (TaxIDType_DiaPost) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DiaPost.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_DiaPost.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_DiaPost implements EasyPostEnum {
     VAT("VAT"),
@@ -19,6 +18,6 @@ public enum TaxIDType_DiaPost implements EasyPostEnum {
     }
 
     public static TaxIDType_DiaPost getEnum(String value) throws EasyPostException {
-        return (TaxIDType_DiaPost) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_DiaPost) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedEx.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedEx.java
@@ -1,0 +1,23 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_FedEx implements EasyPostEnum {
+    TIN("TIN");
+
+    private String value;
+
+    TaxIDType_FedEx(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_FedEx getEnum(String value) throws EasyPostException {
+        return (TaxIDType_FedEx) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedEx.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedEx.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_FedEx implements EasyPostEnum {
     TIN("TIN");
@@ -18,6 +17,6 @@ public enum TaxIDType_FedEx implements EasyPostEnum {
     }
 
     public static TaxIDType_FedEx getEnum(String value) throws EasyPostException {
-        return (TaxIDType_FedEx) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_FedEx) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedEx.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedEx.java
@@ -2,8 +2,10 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_FedEx implements EasyPostEnum {
+    @SerializedName ("TIN")
     TIN("TIN");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedExCrossBorder.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedExCrossBorder.java
@@ -1,0 +1,26 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_FedExCrossBorder implements EasyPostEnum {
+    VAT("VAT"),
+    EORI("EORI"),
+    IOSS("IOSS"),
+    TIN("TIN");
+
+    private String value;
+
+    TaxIDType_FedExCrossBorder(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_FedExCrossBorder getEnum(String value) throws EasyPostException {
+        return (TaxIDType_FedExCrossBorder) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedExCrossBorder.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedExCrossBorder.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_FedExCrossBorder implements EasyPostEnum {
     VAT("VAT"),
@@ -21,6 +20,6 @@ public enum TaxIDType_FedExCrossBorder implements EasyPostEnum {
     }
 
     public static TaxIDType_FedExCrossBorder getEnum(String value) throws EasyPostException {
-        return (TaxIDType_FedExCrossBorder) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_FedExCrossBorder) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedExCrossBorder.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedExCrossBorder.java
@@ -2,11 +2,16 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_FedExCrossBorder implements EasyPostEnum {
+    @SerializedName ("VAT")
     VAT("VAT"),
+    @SerializedName("EORI")
     EORI("EORI"),
+    @SerializedName("IOSS")
     IOSS("IOSS"),
+    @SerializedName("TIN")
     TIN("TIN");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedExMailview.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedExMailview.java
@@ -1,0 +1,23 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_FedExMailview implements EasyPostEnum {
+    TIN("TIN");
+
+    private String value;
+
+    TaxIDType_FedExMailview(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_FedExMailview getEnum(String value) throws EasyPostException {
+        return (TaxIDType_FedExMailview) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedExMailview.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedExMailview.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_FedExMailview implements EasyPostEnum {
     TIN("TIN");
@@ -18,6 +17,6 @@ public enum TaxIDType_FedExMailview implements EasyPostEnum {
     }
 
     public static TaxIDType_FedExMailview getEnum(String value) throws EasyPostException {
-        return (TaxIDType_FedExMailview) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_FedExMailview) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedExMailview.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_FedExMailview.java
@@ -2,8 +2,10 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_FedExMailview implements EasyPostEnum {
+    @SerializedName ("TIN")
     TIN("TIN");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_Globegistics.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_Globegistics.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_Globegistics implements EasyPostEnum {
     VAT("VAT");
@@ -18,6 +17,6 @@ public enum TaxIDType_Globegistics implements EasyPostEnum {
     }
 
     public static TaxIDType_Globegistics getEnum(String value) throws EasyPostException {
-        return (TaxIDType_Globegistics) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_Globegistics) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_Globegistics.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_Globegistics.java
@@ -2,8 +2,10 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_Globegistics implements EasyPostEnum {
+    @SerializedName ("VAT")
     VAT("VAT");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_Globegistics.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_Globegistics.java
@@ -1,0 +1,23 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_Globegistics implements EasyPostEnum {
+    VAT("VAT");
+
+    private String value;
+
+    TaxIDType_Globegistics(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_Globegistics getEnum(String value) throws EasyPostException {
+        return (TaxIDType_Globegistics) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_RoyalMail.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_RoyalMail.java
@@ -1,0 +1,25 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_RoyalMail implements EasyPostEnum {
+    VAT("VAT"),
+    EORI("EORI"),
+    IOSS("IOSS");
+
+    private String value;
+
+    TaxIDType_RoyalMail(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_RoyalMail getEnum(String value) throws EasyPostException {
+        return (TaxIDType_RoyalMail) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_RoyalMail.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_RoyalMail.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_RoyalMail implements EasyPostEnum {
     VAT("VAT"),
@@ -20,6 +19,6 @@ public enum TaxIDType_RoyalMail implements EasyPostEnum {
     }
 
     public static TaxIDType_RoyalMail getEnum(String value) throws EasyPostException {
-        return (TaxIDType_RoyalMail) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_RoyalMail) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_RoyalMail.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_RoyalMail.java
@@ -2,10 +2,14 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_RoyalMail implements EasyPostEnum {
+    @SerializedName ("VAT")
     VAT("VAT"),
+    @SerializedName("EORI")
     EORI("EORI"),
+    @SerializedName("IOSS")
     IOSS("IOSS");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_UPS.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_UPS.java
@@ -2,11 +2,16 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_UPS implements EasyPostEnum {
+    @SerializedName ("VAT")
     VAT("VAT"),
+    @SerializedName("IOSS")
     IOSS("IOSS"),
+    @SerializedName("VOEC")
     VOEC("VOEC"),
+    @SerializedName("HMRC")
     HMRC("HMRC");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_UPS.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_UPS.java
@@ -1,0 +1,26 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_UPS implements EasyPostEnum {
+    VAT("VAT"),
+    IOSS("IOSS"),
+    VOEC("VOEC"),
+    HMRC("HMRC");
+
+    private String value;
+
+    TaxIDType_UPS(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_UPS getEnum(String value) throws EasyPostException {
+        return (TaxIDType_UPS) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_UPS.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_UPS.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_UPS implements EasyPostEnum {
     VAT("VAT"),
@@ -21,6 +20,6 @@ public enum TaxIDType_UPS implements EasyPostEnum {
     }
 
     public static TaxIDType_UPS getEnum(String value) throws EasyPostException {
-        return (TaxIDType_UPS) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_UPS) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_UPSMI.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_UPSMI.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_UPSMI implements EasyPostEnum {
     VAT("VAT");
@@ -18,6 +17,6 @@ public enum TaxIDType_UPSMI implements EasyPostEnum {
     }
 
     public static TaxIDType_UPSMI getEnum(String value) throws EasyPostException {
-        return (TaxIDType_UPSMI) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_UPSMI) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_UPSMI.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_UPSMI.java
@@ -2,8 +2,10 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_UPSMI implements EasyPostEnum {
+    @SerializedName ("VAT")
     VAT("VAT");
 
     private String value;

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_UPSMI.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_UPSMI.java
@@ -1,0 +1,23 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_UPSMI implements EasyPostEnum {
+    VAT("VAT");
+
+    private String value;
+
+    TaxIDType_UPSMI(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_UPSMI getEnum(String value) throws EasyPostException {
+        return (TaxIDType_UPSMI) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_USPS.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_USPS.java
@@ -2,7 +2,6 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
-import com.easypost.model.enums.Mode;
 
 public enum TaxIDType_USPS implements EasyPostEnum {
     VAT("VAT");
@@ -18,6 +17,6 @@ public enum TaxIDType_USPS implements EasyPostEnum {
     }
 
     public static TaxIDType_USPS getEnum(String value) throws EasyPostException {
-        return (TaxIDType_USPS) EasyPostEnum.getEnumFromValue(Mode.class, value);
+        return (TaxIDType_USPS) EasyPostEnum.getEnumFromValue(values(), value);
     }
 }

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_USPS.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_USPS.java
@@ -1,0 +1,23 @@
+package com.easypost.model.enums.taxidentifiers;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
+
+public enum TaxIDType_USPS implements EasyPostEnum {
+    VAT("VAT");
+
+    private String value;
+
+    TaxIDType_USPS(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TaxIDType_USPS getEnum(String value) throws EasyPostException {
+        return (TaxIDType_USPS) EasyPostEnum.getEnumFromValue(Mode.class, value);
+    }
+}

--- a/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_USPS.java
+++ b/src/main/java/com/easypost/model/enums/taxidentifiers/TaxIDType_USPS.java
@@ -2,8 +2,10 @@ package com.easypost.model.enums.taxidentifiers;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.enums.EasyPostEnum;
+import com.google.gson.annotations.SerializedName;
 
 public enum TaxIDType_USPS implements EasyPostEnum {
+    @SerializedName ("VAT")
     VAT("VAT");
 
     private String value;

--- a/src/main/java/com/easypost/net/EasyPostResource.java
+++ b/src/main/java/com/easypost/net/EasyPostResource.java
@@ -11,6 +11,8 @@ import com.easypost.model.Shipment;
 import com.easypost.model.SmartrateCollection;
 import com.easypost.model.SmartrateCollectionDeserializer;
 import com.easypost.model.TrackingDetail;
+import com.easypost.model.enums.EasyPostEnum;
+import com.easypost.model.enums.Mode;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -47,11 +49,11 @@ public abstract class EasyPostResource {
 		.create();
 
 	public static final Gson prettyPrintGson = new GsonBuilder().
-		setPrettyPrinting().
-		serializeNulls().
-		setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).
-		registerTypeAdapter(Event.class, new EventDeserializer()).
-		create();
+		setPrettyPrinting()
+		.serializeNulls()
+		.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+		.registerTypeAdapter(Event.class, new EventDeserializer())
+		.create();
 
 	@Override public String toString() {
 
@@ -581,8 +583,8 @@ public abstract class EasyPostResource {
 	public String getId() {
 		return "";
 	}
-	public String getMode() {
-		return "";
+	public Mode getMode() {
+		return Mode.TEST;
 	}
 	// Batch
 	public List<Shipment> getShipments() {
@@ -601,8 +603,8 @@ public abstract class EasyPostResource {
 	public String getTrackingCode() {
 		return "";
 	}
-	public String getStatus() {
-		return "";
+	public EasyPostEnum getStatus() {
+		return null;
 	}
 	public List<TrackingDetail> getTrackingDetails() {
 		return new ArrayList<TrackingDetail>();

--- a/src/test/java/com/easypost/EasyPostTest.java
+++ b/src/test/java/com/easypost/EasyPostTest.java
@@ -24,7 +24,10 @@ import com.easypost.model.TrackingDetail;
 import com.easypost.model.TrackingLocation;
 import com.easypost.model.Webhook;
 import com.easypost.model.WebhookCollection;
+import com.easypost.model.enums.BatchState;
 import com.easypost.model.enums.FeeType;
+import com.easypost.model.enums.Mode;
+import com.easypost.model.enums.PickupStatus;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -652,7 +655,7 @@ public class EasyPostTest {
     Batch batch = Batch.create(batchMap);
     while (true) {
       batch = batch.refresh();
-      if ("created".equals(batch.getState())) {
+      if (batch.getState() == BatchState.CREATED) {
         break;
       }
       Thread.sleep(3000);
@@ -661,13 +664,13 @@ public class EasyPostTest {
     batch.buy();
     while (true) {
       batch = batch.refresh();
-      if ("purchased".equals(batch.getState())) {
+      if (batch.getState() == BatchState.PURCHASED) {
         break;
       }
       Thread.sleep(3000);
     }
 
-    assertEquals("Batch state is not purchased.", "purchased", batch.getState());
+    assertEquals("Batch state is not purchased.", BatchState.PURCHASED, batch.getState());
   }
 
   @Test
@@ -684,7 +687,7 @@ public class EasyPostTest {
     Batch batch = Batch.create();
     while (true) {
       batch = batch.refresh();
-      if ("created".equals(batch.getState())) {
+      if (batch.getState() == BatchState.CREATED) {
         break;
       }
       Thread.sleep(3000);
@@ -763,7 +766,7 @@ public class EasyPostTest {
 
     assertNotNull(pickup);
     assertEquals(0, pickup.getMessages().size());
-    assertEquals("scheduled", pickup.getStatus());
+    assertEquals(PickupStatus.SCHEDULED, pickup.getStatus());
 
     Map<String, Object> cancelMap = new HashMap<String, Object>();
     cancelMap.put("id", pickup.getId());
@@ -771,7 +774,7 @@ public class EasyPostTest {
 
     assertNotNull(pickup);
     assertEquals(0, pickup.getMessages().size());
-    assertEquals("canceled", pickup.getStatus());
+    assertEquals(PickupStatus.CANCELLED, pickup.getStatus());
 
     Pickup retrieved = Pickup.retrieve(pickup.getId());
     pickup = pickup.refresh();
@@ -1017,7 +1020,7 @@ public class EasyPostTest {
     // Create a webhook
     Webhook webhook = Webhook.create(paramMap);
     assertNotNull("ID is null", webhook.getId());
-    assertEquals("mode is not test",  "test", webhook.getMode());
+    assertEquals("mode is not test", Mode.TEST, webhook.getMode());
     assertEquals("URL is not correctly ser", webhook.getUrl(), url);
     assertNull("disabledAt is not null", webhook.getDisabledAt());
     assertEquals("Class is not Webhook", Webhook.class, webhook.getClass());

--- a/src/test/java/com/easypost/EasyPostTest.java
+++ b/src/test/java/com/easypost/EasyPostTest.java
@@ -24,6 +24,7 @@ import com.easypost.model.TrackingDetail;
 import com.easypost.model.TrackingLocation;
 import com.easypost.model.Webhook;
 import com.easypost.model.WebhookCollection;
+import com.easypost.model.enums.FeeType;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -195,13 +196,13 @@ public class EasyPostTest {
     assertEquals(0.01, fee1.getAmount(), 0.001);
     assertEquals(true, fee1.getCharged());
     assertEquals(false, fee1.getRefunded());
-    assertEquals("LabelFee", fee1.getType());
+    assertEquals(FeeType.LABEL, fee1.getType());
 
     Fee fee2 = fees.get(1);
     assertEquals(4.83, fee2.getAmount(), 0.001);
     assertEquals(true, fee2.getCharged());
     assertEquals(false, fee2.getRefunded());
-    assertEquals("PostageFee", fee2.getType());
+    assertEquals(FeeType.POSTAGE, fee2.getType());
   }
 
   @Test


### PR DESCRIPTION
Provide enums for fields that have only a specific set of choices for values (i.e. "pickup status" can only be one of four or five different strings).
This makes it easier to set values, since it requires the user to use only "approved" values, rather than any potential string.
This makes it easier to get and use values, since it will ensure that the user received one of an "approved" or expected value.  This naturally makes it easier to compare/check results by avoiding string-to-string comparisons, which are prone to spelling errors.
This also helps expose if an error does occur (i.e. the API returned unexpected data and subsequently throws a deserialization error).
Enums can also be marked as "deprecated" when old values are being phased out.
Conversely, anything not explicitly included as an enum choice will fail (programmatically produces null) if the API returns the data. This would require us to update the Java library often to include the new options, i.e. whenever a new carrier is added.