### PR TITLE
chore: bump plugins, remove bad Java README version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 EasyPost is a simple shipping API. You can sign up for an account at https://easypost.com
 
-## Requirements
-
-* Java 1.5 and later.
-* [Google Gson](http://code.google.com/p/google-gson/)
-
 ## Installation
 
 ```sh
@@ -15,10 +10,11 @@ mvn package
 
 or build the jar from src!
 
+NOTE: [Google Gson](http://code.google.com/p/google-gson/) is required.
+
 ## Example
 
 ```java
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
@@ -126,7 +122,6 @@ public class Readme {
         }
     }
 }
-
 ```
 
 ## Documentation

--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,6 @@
         <url>https://easypost.com</url>
     </organization>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
-
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
@@ -90,7 +84,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -106,7 +100,7 @@
                 <configuration>
                     <source>8</source>
                 </configuration>
-                <version>2.9.1</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -119,7 +113,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -133,7 +127,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.9.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -142,7 +136,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>


### PR DESCRIPTION
Bumps the plugins we use during development, has no impact on the library itself. Also removes the now incorrect `Java 1.5` requirement from the README