### PR TITLE
Migration to eventually fix spelling error

### DIFF
--- a/src/main/java/com/easypost/model/Tracker.java
+++ b/src/main/java/com/easypost/model/Tracker.java
@@ -229,26 +229,6 @@ public final class Tracker extends EasyPostResource {
         this.carrierDetail = carrierDetail;
     }
 
-    // This method is a misspelling, but it persists to avoid breaking backwards compatibility
-
-    /**
-     * Get when the tracker was updated.
-     *
-     * @return when the tracker was updated.
-     */
-    public Date getUpdateAt() {
-        return getUpdatedAt();
-    }
-
-    /**
-     * Set when the tracker was updated.
-     *
-     * @param updatedAt when the tracker was updated.
-     */
-    public void setUpdateAt(final Date updatedAt) {
-        setUpdatedAt(updatedAt);
-    }
-
     /**
      * Get the public URL of the Tracker.
      *

--- a/src/test/java/com/easypost/EasyPostTest.java
+++ b/src/test/java/com/easypost/EasyPostTest.java
@@ -322,7 +322,7 @@ public class EasyPostTest {
         assertNotNull("Est delivery Date local is null", tracker.getCarrierDetail().getEstDeliveryDateLocal());
         assertNotNull("Est delivery Time local is null", tracker.getCarrierDetail().getEstDeliveryTimeLocal());
         assertNotNull("Created at is null", tracker.getCreatedAt());
-        assertNotNull("Updated at is null", tracker.getUpdateAt());
+        assertNotNull("Updated at is null", tracker.getUpdatedAt());
         assertNotNull("PublicURL is not null", tracker.getPublicUrl());
 
         Tracker retrieved = Tracker.retrieve(tracker.getId());


### PR DESCRIPTION
Addresses #78 

- Remove misspelled `get/setUpdateAt()`, defer to internal `get/setUpdatedAt()`
- Fixed test