### PR TITLE
Improve create list tracker

### DIFF
--- a/src/main/java/com/easypost/model/Tracker.java
+++ b/src/main/java/com/easypost/model/Tracker.java
@@ -3,7 +3,6 @@ package com.easypost.model;
 import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -119,16 +118,11 @@ public final class Tracker extends EasyPostResource {
     public static boolean createList(final Map<String, Object> params, final String apiKey) throws EasyPostException {
         String createListUrl = String.format("%s/create_list", classURL(Tracker.class));
 
-        int count = 0;
         Map<String, Object> newParams = new HashMap<String, Object>();
-        Map<String, Object> trackers = new HashMap<String, Object>();
-        for (Object tracker : (ArrayList) params.get("trackers")) {
-            trackers.put(String.valueOf(count), tracker);
-            count++;
-        }
-        newParams.put("trackers", trackers);
+        newParams.put("trackers", params);
 
         request(RequestMethod.POST, createListUrl, newParams, Object.class, apiKey);
+        // This endpoint does not return a response so we return true here
         return true;
     }
 

--- a/src/test/java/com/easypost/EasyPostTest.java
+++ b/src/test/java/com/easypost/EasyPostTest.java
@@ -359,10 +359,10 @@ public class EasyPostTest {
         HashMap<String, Object> trackingCodeParams = new HashMap<String, Object>();
 
         for (int i = 0; i < trackingCodes.length; i++) {
-            HashMap<String, Object> tracker = new HashMap<String, Object>();
-            tracker.put("tracking_code", trackingCodes[i]);
-            tracker.put("carrier", "USPS");
-            trackingCodeParams.put(String.valueOf(i), tracker);
+            HashMap<String, Object> code = new HashMap<String, Object>();
+            code.put("tracking_code", trackingCodes[i]);
+            code.put("carrier", "USPS");
+            trackingCodeParams.put(String.valueOf(i), code);
         }
 
         Tracker.createList(trackingCodeParams);

--- a/src/test/java/com/easypost/EasyPostTest.java
+++ b/src/test/java/com/easypost/EasyPostTest.java
@@ -354,25 +354,18 @@ public class EasyPostTest {
 
     @Test
     public void testBatchTrackerCreate() throws EasyPostException {
-        List<String> trackingCodes = new ArrayList<String>();
-        trackingCodes.add("EZ1000000001");
-        trackingCodes.add("EZ2000000002");
-        trackingCodes.add("EZ3000000003");
 
-        List<HashMap<String, Object>> trackingCodeParams = new ArrayList<HashMap<String, Object>>();
-        HashMap<String, Object> code;
+        String[] trackingCodes = new String[]{"EZ1000000001", "EZ1000000002", "EZ1000000003"};
+        HashMap<String, Object> trackingCodeParams = new HashMap<String, Object>();
 
-        for (int i = 0; i < trackingCodes.size(); i++) {
-            code = new HashMap<String, Object>();
-            code.put("tracking_code", trackingCodes.get(i));
-            code.put("carrier", "USPS");
-            trackingCodeParams.add(code);
+        for (int i = 0; i < trackingCodes.length; i++) {
+            HashMap<String, Object> tracker = new HashMap<String, Object>();
+            tracker.put("tracking_code", trackingCodes[i]);
+            tracker.put("carrier", "USPS");
+            trackingCodeParams.put(String.valueOf(i), tracker);
         }
 
-        Map createListParams = new HashMap<String, Object>();
-        createListParams.put("trackers", trackingCodeParams);
-
-        Tracker.createList(createListParams);
+        Tracker.createList(trackingCodeParams);
     }
 
     @Test
@@ -1098,7 +1091,7 @@ public class EasyPostTest {
     assertEquals("Incorrect ShipmentReport start_date", "Sun Oct 01 00:00:00 PDT 2017", shipmentReport2.getStartDate().toString());
     assertEquals("Incorrect ShipmentReport end_date", "Mon Oct 30 00:00:00 PDT 2017", shipmentReport2.getEndDate().toString());
   }*/
-  
+
 
   /*
    // This test requires a FedExSameDayCity account


### PR DESCRIPTION
## What?
Improve the **createList** method in the Tracker class
## Why?
Currently, our **createList** method in the Tracker class is doing extra work which refactors the user input. The user is also creating an extra list and map. Overall, this extra work would downgrade the runtime performance which takes O(n) time complexity for **createList** method, and when the user mistypes "trackers" as the key for input map, a NullPointerException could be thrown.
## How?
Instead of asking the user to input a map that **must** have "**trackers**" as the key and a list of maps as value, we now just need the user to enter a map of maps where the key is the number of trackers and value is a map of **tracking_code** and **carrier**.
## Testing?
Modify the unit test to accommodate the code change.