### PR TITLE
Update changelog for new feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added support for `One Call Buy a Shipment`
 * Added support for `Retrieve Carrier Types`
 * Added support for `One Call Buy an Order`
+* Allow user to override default API timeouts
 
 ## 5.0.0 2022-01-14
 


### PR DESCRIPTION
RE: https://github.com/EasyPost/easypost-java/pull/93

- Update CHANGELOG.md: Allow users to override default API timeouts