### PR TITLE
Fix timeout values in test

### DIFF
--- a/src/main/java/com/easypost/net/EasyPostResource.java
+++ b/src/main/java/com/easypost/net/EasyPostResource.java
@@ -546,13 +546,6 @@ public abstract class EasyPostResource {
     }
 
     /**
-     * Reset the API connection timeout to the default value.
-     */
-    public static void resetConnectTimeoutMilliseconds() {
-        setConnectTimeoutMilliseconds(DEFAULT_CONNECT_TIMEOUT_MILLISECONDS);
-    }
-
-    /**
      * Get the timeout in milliseconds for reading API responses.
      *
      * @return the timeout in milliseconds
@@ -571,13 +564,6 @@ public abstract class EasyPostResource {
     }
 
     /**
-     * Reset the API response reading timeout to the default value.
-     */
-    public static void resetReadTimeoutMilliseconds() {
-        setReadTimeoutMilliseconds(DEFAULT_READ_TIMEOUT_MILLISECONDS);
-    }
-
-    /**
      * Get the timeout in milliseconds for App Engine API requests.
      *
      * @return the timeout in milliseconds
@@ -593,13 +579,6 @@ public abstract class EasyPostResource {
      */
     public static void setAppEngineTimeoutSeconds(double seconds) {
         appEngineTimeoutSeconds = seconds;
-    }
-
-    /**
-     * Reset the App Engine API request timeout to the default value.
-     */
-    public static void resetAppEngineTimeoutSeconds() {
-        setAppEngineTimeoutSeconds(DEFAULT_APP_ENGINE_TIMEOUT_SECONDS);
     }
 
     /**

--- a/src/main/java/com/easypost/net/EasyPostResource.java
+++ b/src/main/java/com/easypost/net/EasyPostResource.java
@@ -546,6 +546,13 @@ public abstract class EasyPostResource {
     }
 
     /**
+     * Reset the API connection timeout to the default value.
+     */
+    public static void resetConnectTimeoutMilliseconds() {
+        setConnectTimeoutMilliseconds(DEFAULT_CONNECT_TIMEOUT_MILLISECONDS);
+    }
+
+    /**
      * Get the timeout in milliseconds for reading API responses.
      *
      * @return the timeout in milliseconds
@@ -564,6 +571,13 @@ public abstract class EasyPostResource {
     }
 
     /**
+     * Reset the API response reading timeout to the default value.
+     */
+    public static void resetReadTimeoutMilliseconds() {
+        setReadTimeoutMilliseconds(DEFAULT_READ_TIMEOUT_MILLISECONDS);
+    }
+
+    /**
      * Get the timeout in milliseconds for App Engine API requests.
      *
      * @return the timeout in milliseconds
@@ -579,6 +593,13 @@ public abstract class EasyPostResource {
      */
     public static void setAppEngineTimeoutSeconds(double seconds) {
         appEngineTimeoutSeconds = seconds;
+    }
+
+    /**
+     * Reset the App Engine API request timeout to the default value.
+     */
+    public static void resetAppEngineTimeoutSeconds() {
+        setAppEngineTimeoutSeconds(DEFAULT_APP_ENGINE_TIMEOUT_SECONDS);
     }
 
     /**

--- a/src/main/java/com/easypost/net/EasyPostResource.java
+++ b/src/main/java/com/easypost/net/EasyPostResource.java
@@ -57,9 +57,9 @@ public abstract class EasyPostResource {
     public static final String CHARSET = "UTF-8";
     public static final ArrayList<String> GLOBAL_FIELD_ACCESSORS =
             new ArrayList<>(Arrays.asList("getCreatedAt", "getUpdatedAt", "getFees"));
-    private static final int DEFAULT_CONNECT_TIMEOUT_MILLISECONDS = 30000;
-    private static final int DEFAULT_READ_TIMEOUT_MILLISECONDS = 60000;
-    private static final double DEFAULT_APP_ENGINE_TIMEOUT_SECONDS = 20.0;
+    public static final int DEFAULT_CONNECT_TIMEOUT_MILLISECONDS = 30000;
+    public static final int DEFAULT_READ_TIMEOUT_MILLISECONDS = 60000;
+    public static final double DEFAULT_APP_ENGINE_TIMEOUT_SECONDS = 20.0;
     private static final String DNS_CACHE_TTL_PROPERTY_NAME = "networkaddress.cache.ttl";
     private static final String CUSTOM_URL_STREAM_HANDLER_PROPERTY_NAME = "com.easypost.net.customURLStreamHandler";
     private static int connectTimeoutMilliseconds = DEFAULT_CONNECT_TIMEOUT_MILLISECONDS;

--- a/src/test/java/com/easypost/EasyPostTest.java
+++ b/src/test/java/com/easypost/EasyPostTest.java
@@ -25,6 +25,7 @@ import com.easypost.model.TrackingDetail;
 import com.easypost.model.TrackingLocation;
 import com.easypost.model.Webhook;
 import com.easypost.model.WebhookCollection;
+import com.easypost.net.EasyPostResource;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -355,7 +356,7 @@ public class EasyPostTest {
     @Test
     public void testBatchTrackerCreate() throws EasyPostException {
 
-        String[] trackingCodes = new String[]{"EZ1000000001", "EZ1000000002", "EZ1000000003"};
+        String[] trackingCodes = new String[] { "EZ1000000001", "EZ1000000002", "EZ1000000003" };
         HashMap<String, Object> trackingCodeParams = new HashMap<String, Object>();
 
         for (int i = 0; i < trackingCodes.length; i++) {
@@ -1072,6 +1073,10 @@ public class EasyPostTest {
         assertEquals(Order.getConnectTimeoutMilliseconds(), timeout);
         assertEquals(Order.getReadTimeoutMilliseconds(), timeout);
         assertEquals(Order.getAppEngineTimeoutSeconds(), timeout, 0.001);
+        // Need to reset these timeouts to default values for other tests to run correctly
+        Order.setConnectTimeoutMilliseconds(EasyPostResource.DEFAULT_CONNECT_TIMEOUT_MILLISECONDS);
+        Order.setReadTimeoutMilliseconds(EasyPostResource.DEFAULT_READ_TIMEOUT_MILLISECONDS);
+        Order.setAppEngineTimeoutSeconds(EasyPostResource.DEFAULT_APP_ENGINE_TIMEOUT_SECONDS);
     }
 
 

--- a/src/test/java/com/easypost/EasyPostTest.java
+++ b/src/test/java/com/easypost/EasyPostTest.java
@@ -1072,6 +1072,9 @@ public class EasyPostTest {
         assertEquals(Order.getConnectTimeoutMilliseconds(), timeout);
         assertEquals(Order.getReadTimeoutMilliseconds(), timeout);
         assertEquals(Order.getAppEngineTimeoutSeconds(), timeout, 0.001);
+        Order.resetConnectTimeoutMilliseconds();
+        Order.resetReadTimeoutMilliseconds();
+        Order.resetAppEngineTimeoutSeconds();
     }
 
 

--- a/src/test/java/com/easypost/EasyPostTest.java
+++ b/src/test/java/com/easypost/EasyPostTest.java
@@ -1072,9 +1072,6 @@ public class EasyPostTest {
         assertEquals(Order.getConnectTimeoutMilliseconds(), timeout);
         assertEquals(Order.getReadTimeoutMilliseconds(), timeout);
         assertEquals(Order.getAppEngineTimeoutSeconds(), timeout, 0.001);
-        Order.resetConnectTimeoutMilliseconds();
-        Order.resetReadTimeoutMilliseconds();
-        Order.resetAppEngineTimeoutSeconds();
     }
 
 


### PR DESCRIPTION
We had a bad testing setup, where the test for changing the API timeouts was running before other tests. Without resetting the timeouts, they were too aggressive and were causing other tests to fail.

This PR includes:
- Public (but immutable) default timeout values, so can be accessed if needed (i.e. to reset values)
- Corrected timeout test that resets what it changed after executing, so other tests can run correctly.