### PR TITLE
Get shipment rates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,7 @@ Icon
 target
 
 .idea/
-src/main/main.iml
-src/test/test.iml
-easypost-api-client.iml
+*.iml
 
 *.class
 settings.xml

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ target
 .idea/
 src/main/main.iml
 src/test/test.iml
+easypost-api-client.iml
 
 *.class
 settings.xml

--- a/src/main/java/com/easypost/model/Shipment.java
+++ b/src/main/java/com/easypost/model/Shipment.java
@@ -1064,23 +1064,24 @@ public final class Shipment extends EasyPostResource {
     }
 
     /**
-     * Update the rates of a shipment.
+     * Get the rates of a shipment.
      *
+     * @return Rate object
      * @throws EasyPostException
      */
-    public void retrieveRates() throws EasyPostException {
-        this.retrieveRates(null);
+    public Shipment retrieveRates() throws EasyPostException {
+        return retrieveRates(null);
     }
 
     /**
-     * Update the rates of a shipment.
+     * Get the rates of a shipment.
      *
+     * @return Rate object
      * @param apiKey API key to use in request (overrides default API key).
      * @throws EasyPostException
      */
-    public void retrieveRates(String apiKey) throws EasyPostException {
-        Shipment response = request(RequestMethod.GET, String.format("%s/rates",
+    public Shipment retrieveRates(String apiKey) throws EasyPostException {
+        return request(RequestMethod.GET, String.format("%s/rates",
                         instanceURL(Shipment.class, this.getId())), null, Shipment.class, apiKey);
-        this.setRates(response.getRates());
     }
 }

--- a/src/main/java/com/easypost/model/Shipment.java
+++ b/src/main/java/com/easypost/model/Shipment.java
@@ -1062,4 +1062,29 @@ public final class Shipment extends EasyPostResource {
 
         return lowestRate;
     }
+
+    /**
+     * Get rate for a shipment.
+     *
+     * @return Shipment object
+     * @throws EasyPostException
+     */
+    public Shipment getShipmentRate() throws EasyPostException {
+        return getShipmentRate(null);
+    }
+
+    /**
+     * Get rate for a shipment.
+     *
+     * @param apiKey API key to use in request (overrides default API key).
+     * @return Shipment object
+     * @throws EasyPostException
+     */
+    public Shipment getShipmentRate(String apiKey) throws EasyPostException {
+        Shipment response = request(RequestMethod.GET, String.format("%s/rates",
+                        instanceURL(Shipment.class, this.getId())),
+        null, Shipment.class, apiKey);
+        this.setRates(response.getRates());
+        return response;
+    }
 }

--- a/src/main/java/com/easypost/model/Shipment.java
+++ b/src/main/java/com/easypost/model/Shipment.java
@@ -1069,8 +1069,8 @@ public final class Shipment extends EasyPostResource {
      * @return Shipment object
      * @throws EasyPostException
      */
-    public Shipment getShipmentRate() throws EasyPostException {
-        return getShipmentRate(null);
+    public Shipment retrieveRates() throws EasyPostException {
+        return retrieveRates(null);
     }
 
     /**
@@ -1080,7 +1080,7 @@ public final class Shipment extends EasyPostResource {
      * @return Shipment object
      * @throws EasyPostException
      */
-    public Shipment getShipmentRate(String apiKey) throws EasyPostException {
+    public Shipment retrieveRates(String apiKey) throws EasyPostException {
         Shipment response = request(RequestMethod.GET, String.format("%s/rates",
                         instanceURL(Shipment.class, this.getId())), null, Shipment.class, apiKey);
         this.setRates(response.getRates());

--- a/src/main/java/com/easypost/model/Shipment.java
+++ b/src/main/java/com/easypost/model/Shipment.java
@@ -1082,8 +1082,7 @@ public final class Shipment extends EasyPostResource {
      */
     public Shipment getShipmentRate(String apiKey) throws EasyPostException {
         Shipment response = request(RequestMethod.GET, String.format("%s/rates",
-                        instanceURL(Shipment.class, this.getId())),
-        null, Shipment.class, apiKey);
+                        instanceURL(Shipment.class, this.getId())), null, Shipment.class, apiKey);
         this.setRates(response.getRates());
         return response;
     }

--- a/src/main/java/com/easypost/model/Shipment.java
+++ b/src/main/java/com/easypost/model/Shipment.java
@@ -1064,26 +1064,23 @@ public final class Shipment extends EasyPostResource {
     }
 
     /**
-     * Get rate for a shipment.
+     * Update the rates of a shipment.
      *
-     * @return Shipment object
      * @throws EasyPostException
      */
-    public Shipment retrieveRates() throws EasyPostException {
-        return retrieveRates(null);
+    public void retrieveRates() throws EasyPostException {
+        this.retrieveRates(null);
     }
 
     /**
-     * Get rate for a shipment.
+     * Update the rates of a shipment.
      *
      * @param apiKey API key to use in request (overrides default API key).
-     * @return Shipment object
      * @throws EasyPostException
      */
-    public Shipment retrieveRates(String apiKey) throws EasyPostException {
+    public void retrieveRates(String apiKey) throws EasyPostException {
         Shipment response = request(RequestMethod.GET, String.format("%s/rates",
                         instanceURL(Shipment.class, this.getId())), null, Shipment.class, apiKey);
         this.setRates(response.getRates());
-        return response;
     }
 }

--- a/src/test/java/com/easypost/EasyPostTest.java
+++ b/src/test/java/com/easypost/EasyPostTest.java
@@ -1082,10 +1082,10 @@ public class EasyPostTest {
     @Test
     public void testRetrieveRates() throws EasyPostException {
         Shipment shipment = createDefaultShipmentDomestic();
-        shipment.retrieveRates();
+        Shipment shipmentRate = shipment.retrieveRates();
         
-        assertNotNull(shipment);
-        assertTrue(shipment.getRates().size() > 0);
+        assertNotNull(shipmentRate);
+        assertTrue(shipmentRate.getRates().size() > 0);
     }
 
 

--- a/src/test/java/com/easypost/EasyPostTest.java
+++ b/src/test/java/com/easypost/EasyPostTest.java
@@ -1079,6 +1079,15 @@ public class EasyPostTest {
         Order.setAppEngineTimeoutSeconds(EasyPostResource.DEFAULT_APP_ENGINE_TIMEOUT_SECONDS);
     }
 
+    @Test
+    public void testGetShipmentRate() throws EasyPostException {
+        Shipment shipment = createDefaultShipmentDomestic();
+        Shipment shipmentRates = shipment.getShipmentRate();
+
+        assertNotNull(shipmentRates);
+        assertTrue(shipmentRates.getRates().size() > 0);
+    }
+
 
     //This test needs to have new set of dates to avoid "report already exists" error
   /*

--- a/src/test/java/com/easypost/EasyPostTest.java
+++ b/src/test/java/com/easypost/EasyPostTest.java
@@ -1082,10 +1082,10 @@ public class EasyPostTest {
     @Test
     public void testRetrieveRates() throws EasyPostException {
         Shipment shipment = createDefaultShipmentDomestic();
-        Shipment shipmentRates = shipment.retrieveRates();
-
-        assertNotNull(shipmentRates);
-        assertTrue(shipmentRates.getRates().size() > 0);
+        shipment.retrieveRates();
+        
+        assertNotNull(shipment);
+        assertTrue(shipment.getRates().size() > 0);
     }
 
 

--- a/src/test/java/com/easypost/EasyPostTest.java
+++ b/src/test/java/com/easypost/EasyPostTest.java
@@ -1080,9 +1080,9 @@ public class EasyPostTest {
     }
 
     @Test
-    public void testGetShipmentRate() throws EasyPostException {
+    public void testRetrieveRates() throws EasyPostException {
         Shipment shipment = createDefaultShipmentDomestic();
-        Shipment shipmentRates = shipment.getShipmentRate();
+        Shipment shipmentRates = shipment.retrieveRates();
 
         assertNotNull(shipmentRates);
         assertTrue(shipmentRates.getRates().size() > 0);


### PR DESCRIPTION
Currently, our Java library has a getter method **getRate()** but does not have a method to allow users to get rates if they create a shipment but don't buy it immediately. 

Add an additional method **retrieveRates()** that allows the user to get the latest rate of a specific shipment. Add unit test to ensure the code works.