### PR TITLE
use stream() instead of loop in unit tests.

### DIFF
--- a/src/test/java/com/easypost/AddressTest.java
+++ b/src/test/java/com/easypost/AddressTest.java
@@ -90,13 +90,11 @@ public class AddressTest {
 
         AddressCollection addresses = Address.all(params);
 
-        List<Address> addressesArray = addresses.getAddresses();
+        List<Address> addressesList = addresses.getAddresses();
 
-        assertTrue(addressesArray.size() <= Fixture.pageSize());
+        assertTrue(addressesList.size() <= Fixture.pageSize());
         assertNotNull(addresses.getHasMore());
-        for(Address address: addressesArray) {
-            assertTrue(address instanceof Address);
-        }
+        assertTrue(addressesList.stream().allMatch(address -> address instanceof Address));
     }
 
     /**

--- a/src/test/java/com/easypost/BatchTest.java
+++ b/src/test/java/com/easypost/BatchTest.java
@@ -76,11 +76,11 @@ public class BatchTest {
 
         BatchCollection batches = Batch.all(params);
 
-        assertTrue(batches.getBatches().size() <= Fixture.pageSize());
+        List<Batch> batchesList = batches.getBatches();
+
+        assertTrue(batchesList.size() <= Fixture.pageSize());
         assertNotNull(batches.getHasMore());
-        for(Batch batch: batches.getBatches()) {
-            assertTrue(batch instanceof Batch);
-        }
+        assertTrue(batchesList.stream().allMatch(batch -> batch instanceof Batch));
     }
 
     /**

--- a/src/test/java/com/easypost/CarrierAccountTest.java
+++ b/src/test/java/com/easypost/CarrierAccountTest.java
@@ -83,9 +83,7 @@ public class CarrierAccountTest {
     public void testAll() throws EasyPostException {
         List<CarrierAccount> carrierAccounts = CarrierAccount.all(null);
 
-        for(CarrierAccount carrierAccount: carrierAccounts) {
-            assertTrue(carrierAccount instanceof CarrierAccount);
-        }
+        assertTrue(carrierAccounts.stream().allMatch(carrier -> carrier instanceof CarrierAccount));
     }
 
     /**

--- a/src/test/java/com/easypost/EventTest.java
+++ b/src/test/java/com/easypost/EventTest.java
@@ -2,6 +2,7 @@ package com.easypost;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.Event;
@@ -38,11 +39,11 @@ public class EventTest {
     public void testAll() throws EasyPostException {
         EventCollection events = Event.all(params);
 
-        assertTrue(events.getEvents().size() <= Fixture.pageSize());
+        List<Event> eventsList = events.getEvents();
+
+        assertTrue(eventsList.size() <= Fixture.pageSize());
         assertNotNull(events.getHasMore());
-        for(Event event: events.getEvents()) {
-            assertTrue(event instanceof Event);
-        }
+        assertTrue(eventsList.stream().allMatch(event -> event instanceof Event));
     }
 
     /**

--- a/src/test/java/com/easypost/InsuranceTest.java
+++ b/src/test/java/com/easypost/InsuranceTest.java
@@ -2,6 +2,7 @@ package com.easypost;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.Insurance;
@@ -77,11 +78,10 @@ public class InsuranceTest {
 
         InsuranceCollection insurances = Insurance.all(params);
 
-        assertTrue(insurances instanceof InsuranceCollection);
+        List<Insurance> insurancesList = insurances.getInsurances();
+
+        assertTrue(insurancesList.size() <= Fixture.pageSize());
         assertNotNull(insurances.getHasMore());
-        assertTrue(insurances.getInsurances().size() <= Fixture.pageSize());
-        for(Insurance insurance: insurances.getInsurances()) {
-            assertTrue(insurance instanceof Insurance);
-        }
+        assertTrue(insurancesList.stream().allMatch(insurance -> insurance instanceof Insurance));
     }
 }

--- a/src/test/java/com/easypost/RefundTest.java
+++ b/src/test/java/com/easypost/RefundTest.java
@@ -67,11 +67,11 @@ public class RefundTest {
 
         RefundCollection refunds = Refund.all(params);
 
-        assertTrue(refunds.getRefunds().size() <= Fixture.pageSize());
+        List<Refund> refundsList = refunds.getRefunds();
+
+        assertTrue(refundsList.size() <= Fixture.pageSize());
         assertNotNull(refunds.getHasMore());
-        for(Refund refund: refunds.getRefunds()) {
-            assertTrue(refund instanceof Refund);
-        }
+        assertTrue(refundsList.stream().allMatch(refund -> refund instanceof Refund));
     }
 
     /**

--- a/src/test/java/com/easypost/ReportTest.java
+++ b/src/test/java/com/easypost/ReportTest.java
@@ -2,6 +2,7 @@ package com.easypost;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.Report;
@@ -217,11 +218,11 @@ public class ReportTest {
 
         ReportCollection reports = Report.all(params);
 
-        assertTrue(reports.getReports().size() <= Fixture.pageSize());
+        List<Report> reportsList = reports.getReports();
+
+        assertTrue(reportsList.size() <= Fixture.pageSize());
         assertNotNull(reports.getHasMore());
-        for(Report report: reports.getReports()) {
-            assertTrue(report instanceof Report);
-        }
+        assertTrue(reportsList.stream().allMatch(report -> report instanceof Report));
     }
 
     /**

--- a/src/test/java/com/easypost/ScanFormTest.java
+++ b/src/test/java/com/easypost/ScanFormTest.java
@@ -87,10 +87,9 @@ public class ScanFormTest {
 
         ScanFormCollection scanForms = ScanForm.all(params);
 
+        List<ScanForm> scanFormsList = scanForms.getScanForms();
+        assertTrue(scanFormsList.size() <= Fixture.pageSize());
         assertNotNull(scanForms.getHasMore());
-        assertTrue(scanForms.getScanForms().size() <= Fixture.pageSize());
-        for(ScanForm scanForm: scanForms.getScanForms()) {
-            assertTrue(scanForm instanceof ScanForm);
-        }
+        assertTrue(scanFormsList.stream().allMatch(scanForm -> scanForm instanceof ScanForm));
     }
 }

--- a/src/test/java/com/easypost/ShipmentTest.java
+++ b/src/test/java/com/easypost/ShipmentTest.java
@@ -73,11 +73,11 @@ public class ShipmentTest {
 
         ShipmentCollection shipments = Shipment.all(params);
 
+        List<Shipment> shipmentsList = shipments.getShipments();
+
+        assertTrue(shipmentsList.size() <= Fixture.pageSize());
         assertNotNull(shipments.getHasMore());
-        assertTrue(shipments.getShipments().size() <= Fixture.pageSize());
-        for(Shipment shipment: shipments.getShipments()) {
-            assertTrue(shipment instanceof Shipment);
-        }
+        assertTrue(shipmentsList.stream().allMatch(shipment -> shipment instanceof Shipment));
     }
 
     /**

--- a/src/test/java/com/easypost/TrackerTest.java
+++ b/src/test/java/com/easypost/TrackerTest.java
@@ -2,6 +2,7 @@ package com.easypost;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.Tracker;
@@ -70,11 +71,11 @@ public class TrackerTest {
 
         TrackerCollection trackers = globalTracker.all(params);
 
+        List<Tracker> trackersList = trackers.getTrackers();
+
+        assertTrue(trackersList.size() <= Fixture.pageSize());
         assertNotNull(trackers.getHasMore());
-        assertTrue(trackers.getTrackers().size() <= Fixture.pageSize());
-        for (Tracker tracker: trackers.getTrackers()) {
-            assertTrue(tracker instanceof Tracker);
-        }
+        assertTrue(trackersList.stream().allMatch(tracker -> tracker instanceof Tracker));
     }
 
     /**

--- a/src/test/java/com/easypost/WebhookTest.java
+++ b/src/test/java/com/easypost/WebhookTest.java
@@ -2,6 +2,7 @@ package com.easypost;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.Webhook;
@@ -86,10 +87,10 @@ public class WebhookTest {
 
         WebhookCollection webhooks = Webhook.all(params);
 
-        assertTrue(webhooks.getWebhooks().size() <= Fixture.pageSize());
-        for (Webhook webhook: webhooks.getWebhooks()) {
-            assertTrue(webhook instanceof Webhook);
-        }
+        List<Webhook> webhooksList = webhooks.getWebhooks();
+
+        assertTrue(webhooksList.size() <= Fixture.pageSize());
+        assertTrue(webhooksList.stream().allMatch(webhook -> webhook instanceof Webhook));
     }
 
     /**


### PR DESCRIPTION
This PR converts a loop of assertion to **stream()** for **testAll()** in all unit tests.