### PR TITLE
Support `columns` and `additional_columns` for reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Next release
+* Add support for `columns` and `additional_columns` on Report creation
+
 ## v5.2.0 (2022-02-25)
 
 * Adds a getter and setter for `eel_pfc` on the `CustomsInfo` object

--- a/src/main/java/com/easypost/model/Report.java
+++ b/src/main/java/com/easypost/model/Report.java
@@ -8,6 +8,8 @@ import java.net.URLEncoder;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
 
 public final class Report extends EasyPostResource {
     private String id;
@@ -39,13 +41,33 @@ public final class Report extends EasyPostResource {
      * @throws EasyPostException when the request fails.
      */
     public static Report create(final Map<String, Object> params, final String apiKey) throws EasyPostException {
+        String type = (String) params.get("type");
+        String url = reportURL(type) + "?";
+
+        if (params.containsKey("columns")) {
+            List<String> columns = (ArrayList<String>) params.get("columns");
+            for (int i = 0; i < columns.size(); i++) {
+                url += "columns[]=" + columns.get(i) + "&";
+            }
+            // Delete the columns from the param since it's added to the url query.
+            params.remove("columns");
+        }
+
+        if (params.containsKey("additional_columns")) {
+            List<String> additionalColumns = (ArrayList<String>) params.get("additional_columns");
+            for (int i = 0; i < additionalColumns.size(); i++) {
+                url += "additional_columns[]=" + additionalColumns.get(i) + "&";
+            }
+            // Delete the additional columns from the param since it's added to the url query.
+            params.remove("additional_columns");
+        }
+
         Map<String, Object> wrappedParams = new HashMap<String, Object>();
         wrappedParams.put("report", params);
         wrappedParams.put("start_date", params.get("start_date"));
         wrappedParams.put("end_date", params.get("end_date"));
 
-        String type = (String) params.get("type");
-        return request(RequestMethod.POST, reportURL(type), wrappedParams, Report.class, apiKey);
+        return request(RequestMethod.POST, url, wrappedParams, Report.class, apiKey);
     }
 
     /**

--- a/src/test/java/com/easypost/ReportTest.java
+++ b/src/test/java/com/easypost/ReportTest.java
@@ -1,5 +1,7 @@
 package com.easypost;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
@@ -65,15 +67,58 @@ public class ReportTest {
     }
 
     /**
+     * Test creating a report with additional columns.
+     *
+     * @throws EasyPostException when the request fails.
+     */
+    @Test
+    public void testCreateReportWithAdditionalColumns() throws EasyPostException {
+        Map<String, Object> reportWithAdditionalColumnsParam = new HashMap<>();
+
+        List<String> additionalColumns = new ArrayList<>(Arrays.asList("from_name", "from_company"));
+
+        reportWithAdditionalColumnsParam.put("start_date", Fixture.reportStartDate());
+        reportWithAdditionalColumnsParam.put("end_date", Fixture.reportEndDate());
+        reportWithAdditionalColumnsParam.put("type", "shipment");
+        reportWithAdditionalColumnsParam.put("additional_columns", additionalColumns);
+
+        Report reportWithAdditionalColumns = Report.create(reportWithAdditionalColumnsParam);
+
+        // Reports are queued, so we can't wait for completion. Verifying columns would require parsing CSV.
+        assertTrue(reportWithAdditionalColumns instanceof Report);
+    }
+
+    /**
+     * Test creating a report with columns.
+     *
+     * @throws EasyPostException when the request fails.
+     */
+    @Test
+    public void testCreateReportWithColumns() throws EasyPostException {
+        Map<String, Object> reportWithAdditionalColumnsParam = new HashMap<>();
+
+        List<String> columns = new ArrayList<>(Arrays.asList("usps_zone"));
+
+        reportWithAdditionalColumnsParam.put("start_date", Fixture.reportStartDate());
+        reportWithAdditionalColumnsParam.put("end_date", Fixture.reportEndDate());
+        reportWithAdditionalColumnsParam.put("type", "shipment");
+        reportWithAdditionalColumnsParam.put("columns", columns);
+
+        Report reportWithColumns = Report.create(reportWithAdditionalColumnsParam);
+
+        // Reports are queued, so we can't wait for completion. Verifying columns would require parsing CSV.
+        assertTrue(reportWithColumns instanceof Report);
+    }
+
+    /**
      * Test creating a Payment Log report.
      *
      * @throws EasyPostException when the request fails.
      */
     @Test
-    public void testCreateAndRetrievePaymentLogReport() throws EasyPostException {
+    public void testCreatePaymentLogReport() throws EasyPostException {
         Report paymentLogReport = Report.create(paymentLogReportParams);
 
-        assertNotNull(paymentLogReport);
         assertTrue(paymentLogReport instanceof Report);
         assertTrue(paymentLogReport.getId().startsWith("plrep_"));
     }
@@ -87,7 +132,6 @@ public class ReportTest {
     public void testCreateRefundReport() throws EasyPostException {
         Report refundReport = Report.create(refundParams);
 
-        assertNotNull(refundReport);
         assertTrue(refundReport instanceof Report);
         assertTrue(refundReport.getId().startsWith("refrep_"));
     }
@@ -101,7 +145,6 @@ public class ReportTest {
     public void testCreateShipmentReport() throws EasyPostException {
         Report shipmentReport = Report.create(shipmentParams);
 
-        assertNotNull(shipmentReport);
         assertTrue(shipmentReport instanceof Report);
         assertTrue(shipmentReport.getId().startsWith("shprep_"));
     }
@@ -115,7 +158,6 @@ public class ReportTest {
     public void testCreateShipmentInvoiceReport() throws EasyPostException {
         Report shipmentInvoiceReport = Report.create(shipmentInvoiceParams);
 
-        assertNotNull(shipmentInvoiceReport);
         assertTrue(shipmentInvoiceReport instanceof Report);
         assertTrue(shipmentInvoiceReport.getId().startsWith("shpinvrep_"));
     }
@@ -129,7 +171,6 @@ public class ReportTest {
     public void testCreateTrackerReport() throws EasyPostException {
         Report trackerReport = Report.create(trackerParams);
 
-        assertNotNull(trackerReport);
         assertTrue(trackerReport instanceof Report);
         assertTrue(trackerReport.getId().startsWith("trkrep_"));
     }


### PR DESCRIPTION
This PR adds support for specifying `columns` and `additional_columns` in the params for the report create method.

Adds two unit tests for this feature. E2E test and download the CSV report to check if the result is correct.

Additional columns and columns in the param, total three columns (from_name, from_company, usps_zone)
![Screen Shot 2022-03-21 at 2 13 20 PM](https://user-images.githubusercontent.com/22759143/159339021-b6225d21-1547-42ee-9e1d-3b5b94c6c9cf.png)

Only columns in the param, only one column (usps_zone)
![Screen Shot 2022-03-21 at 2 12 56 PM](https://user-images.githubusercontent.com/22759143/159339059-8f7c58ef-3cfa-4e98-b582-5b2fcaaf770e.png)

