### PR TITLE
move columns and additional_columns from url query to request body.

### DIFF
--- a/src/main/java/com/easypost/model/Report.java
+++ b/src/main/java/com/easypost/model/Report.java
@@ -8,7 +8,6 @@ import java.net.URLEncoder;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.List;
 import java.util.ArrayList;
 
 public final class Report extends EasyPostResource {
@@ -42,32 +41,21 @@ public final class Report extends EasyPostResource {
      */
     public static Report create(final Map<String, Object> params, final String apiKey) throws EasyPostException {
         String type = (String) params.get("type");
-        String url = reportURL(type) + "?";
-
-        if (params.containsKey("columns")) {
-            List<String> columns = (ArrayList<String>) params.get("columns");
-            for (int i = 0; i < columns.size(); i++) {
-                url += "columns[]=" + columns.get(i) + "&";
-            }
-            // Delete the columns from the param since it's added to the url query.
-            params.remove("columns");
-        }
-
-        if (params.containsKey("additional_columns")) {
-            List<String> additionalColumns = (ArrayList<String>) params.get("additional_columns");
-            for (int i = 0; i < additionalColumns.size(); i++) {
-                url += "additional_columns[]=" + additionalColumns.get(i) + "&";
-            }
-            // Delete the additional columns from the param since it's added to the url query.
-            params.remove("additional_columns");
-        }
 
         Map<String, Object> wrappedParams = new HashMap<String, Object>();
         wrappedParams.put("report", params);
         wrappedParams.put("start_date", params.get("start_date"));
         wrappedParams.put("end_date", params.get("end_date"));
 
-        return request(RequestMethod.POST, url, wrappedParams, Report.class, apiKey);
+        if (params.containsKey("columns")) {
+            wrappedParams.put("columns", params.get("columns"));
+        }
+
+        if (params.containsKey("additional_columns")) {
+            wrappedParams.put("additional_columns", params.get("additional_columns"));
+        }
+
+        return request(RequestMethod.POST, reportURL(type), wrappedParams, Report.class, apiKey);
     }
 
     /**


### PR DESCRIPTION
This PR moves the `columns` and `additional_columns` from URL query to request body because a long query URL can be rejected or silently truncated. 

E2E test:
![Screen Shot 2022-03-23 at 4 56 22 PM](https://user-images.githubusercontent.com/22759143/159794442-2f768d4d-8e83-4272-9eb5-a3105070ea02.png)
