### PR TITLE
add declaration attribute in customs info class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 * Add support for `columns` and `additional_columns` on Report creation
+* Add `declaraction` attribute in CustomsInfo class
 
 ## v5.2.0 (2022-02-25)
 

--- a/src/main/java/com/easypost/model/CustomsInfo.java
+++ b/src/main/java/com/easypost/model/CustomsInfo.java
@@ -18,6 +18,7 @@ public final class CustomsInfo extends EasyPostResource {
     private String restrictionComments;
     private List<CustomsItem> customsItems;
     private String eelPfc;
+    private String declaration;
 
     /**
      * Create a CustomsInfo from a map of parameters.
@@ -246,5 +247,23 @@ public final class CustomsInfo extends EasyPostResource {
      */
     public void setEelPfc(String eelPfc) {
         this.eelPfc = eelPfc;
+    }
+
+    /**
+     * Get this CustomsInfo's declaration.
+     *
+     * @return the declaration of this CustomsInfo.
+     */
+    public String getDeclaration() {
+        return declaration;
+    }
+
+    /**
+     * Set this CustomsInfo's declaration.
+     *
+     * @param declaration the declaration of this CustomsInfo.
+     */
+    public void setDeclaration(String declaration) {
+        this.declaration = declaration;
     }
 }


### PR DESCRIPTION
Customs Info class is currently missing the `declaration` attribute.

This PR adds the `declaration` attribute in the Customs Info class.