### PR TITLE
remove additional code that add strict and verify_strict to url query.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run CheckStyle checks
-        uses: nikitasavinov/checkstyle-action@0.5.0
+        uses: nikitasavinov/checkstyle-action@0.5.1
         with:
           level: error
           fail_on_error: true

--- a/src/main/java/com/easypost/model/Address.java
+++ b/src/main/java/com/easypost/model/Address.java
@@ -4,7 +4,6 @@ import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public final class Address extends EasyPostResource {
@@ -47,32 +46,7 @@ public final class Address extends EasyPostResource {
      * @throws EasyPostException when the request fails.
      */
     public static Address create(final Map<String, Object> params, final String apiKey) throws EasyPostException {
-        String url = classURL(Address.class);
-
-        List<String> verifyList = (List<String>) params.remove("verify");
-        List<String> verifyStrictList = (List<String>) params.remove("verify_strict");
-
-        if ((verifyList != null && verifyList.size() >= 1) ||
-                (verifyStrictList != null && verifyStrictList.size() >= 1)) {
-            url += "?";
-
-            if (verifyList != null && verifyList.size() >= 1) {
-                for (String verification : verifyList) {
-                    url += "verify[]=" + verification + "&";
-                }
-            }
-
-            if (verifyStrictList != null && verifyStrictList.size() >= 1) {
-                for (String strictVerification : verifyStrictList) {
-                    url += "verify_strict[]=" + strictVerification + "&";
-                }
-            }
-        }
-
-        Map<String, Object> wrappedParams = new HashMap<String, Object>();
-        wrappedParams.put("address", params);
-
-        return request(RequestMethod.POST, url, wrappedParams, Address.class, apiKey);
+        return request(RequestMethod.POST, classURL(Address.class), params, Address.class, apiKey);
     }
 
     /**


### PR DESCRIPTION
# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)

# Description

This PR removes code that adds `strict` and `verify_strict` to the URL query when the API method is `POST`. The `wrappedParams` is also removed since it does not do anything. 

# Testing

Since Java CL is the only library that does not have VCR yet, E2E is locally tested.
![Screen Shot 2022-04-13 at 2 26 52 PM](https://user-images.githubusercontent.com/22759143/163246868-d5f52c8e-d684-493d-a04a-8fa36000f1eb.png)
