### PR TITLE
docs: remove Gradle install info until supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,6 @@ Add this to your project's POM:
 </dependency>
 ```
 
-### Gradle
-
-Add this to your project's build file:
-
-```groovy
-implementation "com.easypost:easypost-api-client:5.3.0"
-```
-
 **NOTE:** [Google Gson](http://code.google.com/p/google-gson/) is required.
 
 ## Usage


### PR DESCRIPTION
# Description

Removes the `Gradle` install instructions in the README until we support it.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
