### PR TITLE
Rename non-getter `getX` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 - Some `getX` functions have been deprecated and renamed to simply `X` to avoid confusion with proper getter/setter
   functions.
     - `getSmartrates()` -> `smartrates()`
-    - `getLowestSmartrate()` -> `lowestSmartrate()`
-    - `getSmartRateAccuracy()` -> `smartrateAccuracy()`
+    - `getLowestSmartRate()` -> `findLowestSmartrate()`
 
 ## v5.5.0 (2022-06-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Next Release
+
+- Some `getX` functions have been deprecated and renamed to simply `X` to avoid confusion with proper getter/setter
+  functions.
+    - `getSmartrates()` -> `smartrates()`
+    - `getLowestSmartrate()` -> `lowestSmartrate()`
+    - `getSmartRateAccuracy()` -> `smartrateAccuracy()`
+
 ## v5.5.0 (2022-06-21)
 
 - Adds `billingType` attribute to `Rate` and `CarrierAccount` classes.

--- a/src/main/java/com/easypost/model/Shipment.java
+++ b/src/main/java/com/easypost/model/Shipment.java
@@ -1039,7 +1039,7 @@ public final class Shipment extends EasyPostResource {
     public Smartrate lowestSmartRate(int deliveryDay, String deliveryAccuracy) throws EasyPostException {
         List<Smartrate> smartrates = this.getSmartrates();
 
-        Smartrate lowestSmartrate = getLowestSmartRate(smartrates, deliveryDay, deliveryAccuracy);
+        Smartrate lowestSmartrate = findLowestSmartrate(smartrates, deliveryDay, deliveryAccuracy);
 
         return lowestSmartrate;
     }

--- a/src/main/java/com/easypost/model/Shipment.java
+++ b/src/main/java/com/easypost/model/Shipment.java
@@ -754,9 +754,37 @@ public final class Shipment extends EasyPostResource {
      * @param params the options for the query.
      * @return List of Smartrate objects
      * @throws EasyPostException when the request fails.
+     * @deprecated Use {@link #smartrates(Map)} instead.
      */
+    @Deprecated
     public List<Smartrate> getSmartrates(final Map<String, Object> params) throws EasyPostException {
-        return this.getSmartrates(params, null);
+        return this.smartrates(params);
+    }
+
+    /**
+     * Get Smartrates for this Shipment.
+     *
+     * @param params the options for the query.
+     * @return List of Smartrate objects
+     * @throws EasyPostException when the request fails.
+     */
+    public List<Smartrate> smartrates(final Map<String, Object> params) throws EasyPostException {
+        return this.smartrates(params, null);
+    }
+
+    /**
+     * Get Smartrates for this Shipment.
+     *
+     * @param params the options for the query.
+     * @param apiKey API key to use in request (overrides default API key).
+     * @return List of Smartrate objects
+     * @throws EasyPostException when the request fails.
+     * @deprecated Use {@link #smartrates(Map, String)} instead.
+     */
+    @Deprecated
+    public List<Smartrate> getSmartrates(final Map<String, Object> params, final String apiKey)
+            throws EasyPostException {
+        return this.smartrates(params, apiKey);
     }
 
     /**
@@ -767,8 +795,7 @@ public final class Shipment extends EasyPostResource {
      * @return List of Smartrate objects
      * @throws EasyPostException when the request fails.
      */
-    public List<Smartrate> getSmartrates(final Map<String, Object> params, final String apiKey)
-            throws EasyPostException {
+    public List<Smartrate> smartrates(final Map<String, Object> params, final String apiKey) throws EasyPostException {
         SmartrateCollection smartrateCollection =
                 request(RequestMethod.GET, String.format("%s/smartrate", instanceURL(Shipment.class, this.getId())),
                         params, SmartrateCollection.class, apiKey);
@@ -781,9 +808,22 @@ public final class Shipment extends EasyPostResource {
      * @param apiKey API key to use in request (overrides default API key).
      * @return List of Smartrate objects
      * @throws EasyPostException when the request fails.
+     * @deprecated Use {@link #smartrates(String)} instead.
      */
+    @Deprecated
     public List<Smartrate> getSmartrates(final String apiKey) throws EasyPostException {
-        return this.getSmartrates(null, apiKey);
+        return this.smartrates(apiKey);
+    }
+
+    /**
+     * Get Smartrates for this Shipment.
+     *
+     * @param apiKey API key to use in request (overrides default API key).
+     * @return List of Smartrate objects
+     * @throws EasyPostException when the request fails.
+     */
+    public List<Smartrate> smartrates(final String apiKey) throws EasyPostException {
+        return this.smartrates(null, apiKey);
     }
 
     /**
@@ -1009,22 +1049,50 @@ public final class Shipment extends EasyPostResource {
      *
      * @return List of Smartrate objects
      * @throws EasyPostException when the request fails.
+     * @deprecated Use {@link #smartrates()} instead.
      */
+    @Deprecated
     public List<Smartrate> getSmartrates() throws EasyPostException {
-        return this.getSmartrates(null, null);
+        return this.smartrates();
     }
 
     /**
-     * Get the lowest smartrate from a list of smartrates.
+     * Get Smartrates for this Shipment.
      *
-     * @param smartrates       List of smartrates to filter from.
+     * @return List of Smartrate objects
+     * @throws EasyPostException when the request fails.
+     */
+    public List<Smartrate> smartrates() throws EasyPostException {
+        return this.smartrates(null, null);
+    }
+
+    /**
+     * Get the lowest Smartrate from a list of Smartrates.
+     *
+     * @param smartrates       List of Smartrates to filter from.
+     * @param deliveryDay      Delivery days restriction to use when filtering.
+     * @param deliveryAccuracy Delivery days accuracy restriction to use when filtering.
+     * @return lowest Smartrate object
+     * @throws EasyPostException when the request fails.
+     * @deprecated Use {@link #findLowestSmartrate(List, int, String)} instead.
+     */
+    @Deprecated
+    public static Smartrate getLowestSmartRate(final List<Smartrate> smartrates, int deliveryDay,
+                                               String deliveryAccuracy) throws EasyPostException {
+        return findLowestSmartrate(smartrates, deliveryDay, deliveryAccuracy);
+    }
+
+    /**
+     * Find the lowest Smartrate from a list of Smartrates.
+     *
+     * @param smartrates       List of Smartrates to filter from.
      * @param deliveryDay      Delivery days restriction to use when filtering.
      * @param deliveryAccuracy Delivery days accuracy restriction to use when filtering.
      * @return lowest Smartrate object
      * @throws EasyPostException when the request fails.
      */
-    public static Smartrate getLowestSmartRate(final List<Smartrate> smartrates, int deliveryDay,
-                                               String deliveryAccuracy) throws EasyPostException {
+    public static Smartrate findLowestSmartrate(final List<Smartrate> smartrates, int deliveryDay,
+                                                String deliveryAccuracy) throws EasyPostException {
         Smartrate lowestSmartrate = null;
 
         HashSet<String> validDeliveryAccuracies = new HashSet<String>(

--- a/src/test/java/com/easypost/ShipmentTest.java
+++ b/src/test/java/com/easypost/ShipmentTest.java
@@ -246,7 +246,7 @@ public final class ShipmentTest {
         assertNotNull(shipment.getRates());
         Rate rate = shipment.getRates().get(0);
 
-        List<Smartrate> smartRates = shipment.getSmartrates();
+        List<Smartrate> smartRates = shipment.smartrates();
         assertInstanceOf(List.class, smartRates);
         Smartrate smartRate = smartRates.get(0);
 
@@ -412,22 +412,22 @@ public final class ShipmentTest {
         vcr.setUpTest("lowest_smartrate_list");
 
         Shipment shipment = createBasicShipment();
-        List<Smartrate> smartrates = shipment.getSmartrates();
+        List<Smartrate> smartrates = shipment.smartrates();
 
         // Test lowest smartrate with valid filters
-        Smartrate lowestSmartRate = Shipment.getLowestSmartRate(smartrates, 1, "percentile_90");
+        Smartrate lowestSmartRate = Shipment.findLowestSmartrate(smartrates, 1, "percentile_90");
         assertEquals("First", lowestSmartRate.getService());
         assertEquals(5.49, lowestSmartRate.getRate(), 0.01);
         assertEquals("USPS", lowestSmartRate.getCarrier());
 
         // Test lowest smartrate with invalid filters (should error due to strict delivery days)
         assertThrows(EasyPostException.class, () -> {
-            Shipment.getLowestSmartRate(smartrates, 0, "percentile_90");
+            Shipment.findLowestSmartrate(smartrates, 0, "percentile_90");
         });
 
         // Test lowest smartrate with invalid filters (should error due to bad delivery accuracy)
         assertThrows(EasyPostException.class, () -> {
-            Shipment.getLowestSmartRate(smartrates, 1, "BAD ACCURACY");
+            Shipment.findLowestSmartrate(smartrates, 1, "BAD ACCURACY");
         });
     }
 }


### PR DESCRIPTION
# Description

To avoid confusion between proper getter/setter functions and other functions that merely start with the word `get`, all non-getter `getX` functions have been renamed to simply `X` (i.e. `getLowestSmartrate()` -> `lowestSmartrate()`).

This will avoid unnecessary exception throwing and catching during object merges, which utilizes getter/setter pairs and gets confused when there is no `setX` for a given `getX` function.

# Testing

All tests pass as expected.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
