### PR TITLE
Migrate to using enums for Smartrate delivery accuracy choices

### DIFF
--- a/src/main/java/com/easypost/model/Shipment.java
+++ b/src/main/java/com/easypost/model/Shipment.java
@@ -1086,27 +1086,11 @@ public final class Shipment extends EasyPostResource {
      * @param deliveryAccuracy Delivery days accuracy restriction to use when filtering.
      * @return lowest Smartrate object
      * @throws EasyPostException when the request fails.
-     * @deprecated Use {@link #findLowestSmartrate(List, int, String)} instead.
+     * @deprecated Use {@link #findLowestSmartrate(List, int, SmartrateAccuracy)} instead.
      */
     @Deprecated
     public static Smartrate getLowestSmartRate(final List<Smartrate> smartrates, int deliveryDay,
                                                String deliveryAccuracy) throws EasyPostException {
-        return findLowestSmartrate(smartrates, deliveryDay, deliveryAccuracy);
-    }
-
-    /**
-     * Find the lowest Smartrate from a list of Smartrates.
-     *
-     * @param smartrates       List of Smartrates to filter from.
-     * @param deliveryDay      Delivery days restriction to use when filtering.
-     * @param deliveryAccuracy Delivery days accuracy restriction to use when filtering.
-     * @return lowest Smartrate object
-     * @throws EasyPostException when the request fails.
-     * @deprecated Use {@link #findLowestSmartrate(List, int, SmartrateAccuracy)} instead.
-     */
-    @Deprecated
-    public static Smartrate findLowestSmartrate(final List<Smartrate> smartrates, int deliveryDay,
-                                                String deliveryAccuracy) throws EasyPostException {
         return findLowestSmartrate(smartrates, deliveryDay, SmartrateAccuracy.getByKeyName(deliveryAccuracy));
     }
 

--- a/src/main/java/com/easypost/model/Shipment.java
+++ b/src/main/java/com/easypost/model/Shipment.java
@@ -3,9 +3,7 @@ package com.easypost.model;
 import com.easypost.exception.EasyPostException;
 import com.easypost.net.EasyPostResource;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -1035,8 +1033,22 @@ public final class Shipment extends EasyPostResource {
      * @param deliveryAccuracy Delivery days accuracy restriction to use when filtering.
      * @return lowest Smartrate object
      * @throws EasyPostException when the request fails.
+     * @deprecated use {@link #lowestSmartRate(int, SmartrateAccuracy)} instead.
      */
+    @Deprecated
     public Smartrate lowestSmartRate(int deliveryDay, String deliveryAccuracy) throws EasyPostException {
+        return this.lowestSmartRate(deliveryDay, SmartrateAccuracy.getByKeyName(deliveryAccuracy));
+    }
+
+    /**
+     * Get the lowest smartrate for this Shipment.
+     *
+     * @param deliveryDay      Delivery days restriction to use when filtering.
+     * @param deliveryAccuracy Delivery days accuracy restriction to use when filtering.
+     * @return lowest Smartrate object
+     * @throws EasyPostException when the request fails.
+     */
+    public Smartrate lowestSmartRate(int deliveryDay, SmartrateAccuracy deliveryAccuracy) throws EasyPostException {
         List<Smartrate> smartrates = this.getSmartrates();
 
         Smartrate lowestSmartrate = findLowestSmartrate(smartrates, deliveryDay, deliveryAccuracy);
@@ -1090,21 +1102,29 @@ public final class Shipment extends EasyPostResource {
      * @param deliveryAccuracy Delivery days accuracy restriction to use when filtering.
      * @return lowest Smartrate object
      * @throws EasyPostException when the request fails.
+     * @deprecated Use {@link #findLowestSmartrate(List, int, SmartrateAccuracy)} instead.
      */
+    @Deprecated
     public static Smartrate findLowestSmartrate(final List<Smartrate> smartrates, int deliveryDay,
                                                 String deliveryAccuracy) throws EasyPostException {
+        return findLowestSmartrate(smartrates, deliveryDay, SmartrateAccuracy.getByKeyName(deliveryAccuracy));
+    }
+
+    /**
+     * Find the lowest Smartrate from a list of Smartrates.
+     *
+     * @param smartrates       List of Smartrates to filter from.
+     * @param deliveryDay      Delivery days restriction to use when filtering.
+     * @param deliveryAccuracy Delivery days accuracy restriction to use when filtering.
+     * @return lowest Smartrate object
+     * @throws EasyPostException when the request fails.
+     */
+    public static Smartrate findLowestSmartrate(final List<Smartrate> smartrates, int deliveryDay,
+                                                SmartrateAccuracy deliveryAccuracy) throws EasyPostException {
         Smartrate lowestSmartrate = null;
 
-        HashSet<String> validDeliveryAccuracies = new HashSet<String>(
-                Arrays.asList("percentile_50", "percentile_75", "percentile_85", "percentile_90", "percentile_95",
-                        "percentile_97", "percentile_99"));
-
-        if (!validDeliveryAccuracies.contains(deliveryAccuracy.toLowerCase())) {
-            throw new EasyPostException("Invalid delivery_accuracy value, must be one of: " + validDeliveryAccuracies);
-        }
-
         for (Smartrate rate : smartrates) {
-            int smartrateDeliveryDay = rate.getTimeInTransit().getSmartRateAccuracy(deliveryAccuracy);
+            int smartrateDeliveryDay = rate.getTimeInTransit().getBySmartrateAccuracy(deliveryAccuracy);
 
             if (smartrateDeliveryDay > deliveryDay) {
                 continue;

--- a/src/main/java/com/easypost/model/SmartrateAccuracy.java
+++ b/src/main/java/com/easypost/model/SmartrateAccuracy.java
@@ -1,0 +1,47 @@
+package com.easypost.model;
+
+public enum SmartrateAccuracy {
+    Percentile50("percentile_50"),
+    Percentile75("percentile_75"),
+    Percentile85("percentile_85"),
+    Percentile90("percentile_90"),
+    Percentile95("percentile_95"),
+    Percentile97("percentile_97"),
+    Percentile99("percentile_99");
+
+    private final String keyName;
+
+    /**
+     * Constructor.
+     *
+     * @param keyName the internal key name
+     */
+    SmartrateAccuracy(String keyName) {
+        this.keyName = keyName;
+    }
+
+    /**
+     * Get the internal key name for this enum value.
+     *
+     * @return the internal key name
+     */
+    public String getKeyName() {
+        return keyName;
+    }
+
+    /**
+     * Get the enum value for a given internal key name.
+     *
+     * @param keyName the internal key name
+     * @return the enum value
+     * @throws IllegalArgumentException if the key name is not found
+     */
+    public static SmartrateAccuracy getByKeyName(String keyName) throws IllegalArgumentException {
+        for (SmartrateAccuracy smartrateAccuracy : values()) {
+            if (smartrateAccuracy.getKeyName().equals(keyName)) {
+                return smartrateAccuracy;
+            }
+        }
+        throw new IllegalArgumentException("Invalid SmartrateAccuracy key name.");
+    }
+}

--- a/src/main/java/com/easypost/model/TimeInTransit.java
+++ b/src/main/java/com/easypost/model/TimeInTransit.java
@@ -152,7 +152,9 @@ public final class TimeInTransit {
      * @param percentile the percentile to find the corresponding accuracy for
      * @return the delivery accuracy of the specified percentile
      * @throws EasyPostException when the percentile is not valid
+     * @deprecated Use {@link #getBySmartrateAccuracy(SmartrateAccuracy)} instead.
      */
+    @Deprecated
     public int getSmartRateAccuracy(final String percentile) throws EasyPostException {
         switch (percentile) {
             case "percentile_50":
@@ -173,4 +175,33 @@ public final class TimeInTransit {
                 throw new EasyPostException("Invalid percentile value");
         }
     }
+
+    /**
+     * Get the delivery accuracy of a specific percentile of this TimeInTransit.
+     *
+     * @param accuracy the SmartrateAccuracy to find the corresponding accuracy for
+     * @return the delivery accuracy of the specified percentile
+     * @throws EasyPostException when the percentile is not valid
+     */
+    public int getBySmartrateAccuracy(SmartrateAccuracy accuracy) throws EasyPostException {
+        switch (accuracy) {
+            case Percentile50:
+                return this.percentile50;
+            case Percentile75:
+                return this.percentile75;
+            case Percentile85:
+                return this.percentile85;
+            case Percentile90:
+                return this.percentile90;
+            case Percentile95:
+                return this.percentile95;
+            case Percentile97:
+                return this.percentile97;
+            case Percentile99:
+                return this.percentile99;
+            default:
+                throw new EasyPostException("Invalid SmartrateAccuracy enum value.");
+        }
+    }
+
 }

--- a/src/test/java/com/easypost/ShipmentTest.java
+++ b/src/test/java/com/easypost/ShipmentTest.java
@@ -7,6 +7,7 @@ import com.easypost.model.Rate;
 import com.easypost.model.Shipment;
 import com.easypost.model.ShipmentCollection;
 import com.easypost.model.Smartrate;
+import com.easypost.model.SmartrateAccuracy;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -384,7 +385,7 @@ public final class ShipmentTest {
         vcr.setUpTest("lowest_smartrate");
 
         Shipment shipment = createBasicShipment();
-        Smartrate lowestSmartRateFilters = shipment.lowestSmartRate(1, "percentile_90");
+        Smartrate lowestSmartRateFilters = shipment.lowestSmartRate(1, SmartrateAccuracy.Percentile90);
 
         // Test lowest smartrate with valid filters
         assertEquals("First", lowestSmartRateFilters.getService());
@@ -393,12 +394,7 @@ public final class ShipmentTest {
 
         // Test lowest smartrate with invalid filters (should error due to strict delivery days)
         assertThrows(EasyPostException.class, () -> {
-            shipment.lowestSmartRate(0, "percentile_90");
-        });
-
-        // Test lowest smartrate with invalid filters (should error due to invalid delivery accuracy)
-        assertThrows(EasyPostException.class, () -> {
-            shipment.lowestSmartRate(1, "BAD ACCURACY");
+            shipment.lowestSmartRate(0, SmartrateAccuracy.Percentile90);
         });
     }
 
@@ -415,19 +411,14 @@ public final class ShipmentTest {
         List<Smartrate> smartrates = shipment.smartrates();
 
         // Test lowest smartrate with valid filters
-        Smartrate lowestSmartRate = Shipment.findLowestSmartrate(smartrates, 1, "percentile_90");
+        Smartrate lowestSmartRate = Shipment.findLowestSmartrate(smartrates, 1, SmartrateAccuracy.Percentile90);
         assertEquals("First", lowestSmartRate.getService());
         assertEquals(5.49, lowestSmartRate.getRate(), 0.01);
         assertEquals("USPS", lowestSmartRate.getCarrier());
 
         // Test lowest smartrate with invalid filters (should error due to strict delivery days)
         assertThrows(EasyPostException.class, () -> {
-            Shipment.findLowestSmartrate(smartrates, 0, "percentile_90");
-        });
-
-        // Test lowest smartrate with invalid filters (should error due to bad delivery accuracy)
-        assertThrows(EasyPostException.class, () -> {
-            Shipment.findLowestSmartrate(smartrates, 1, "BAD ACCURACY");
+            Shipment.findLowestSmartrate(smartrates, 0, SmartrateAccuracy.Percentile90);
         });
     }
 }


### PR DESCRIPTION
# Description

- New SmartrateAccuracy enum (similar to [C# library](https://github.com/EasyPost/easypost-csharp/blob/master/EasyPost/Smartrate.cs))
- New functions to use SmartrateAccuracy when dealing with smartrates
- Deprecate old smartrate functions using strings

# Testing

- Unit tests updated to use new functions
- No new unit tests
- No new cassettes needed
- No new recordings needed

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
