### PR TITLE
Security analysis and Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,10 @@ jobs:
           fail_on_error: true
           checkstyle_config: easypost_java_style.xml
           tool_name: "style_enforcer"
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run security checks on dependencies
+        run: make scan  # this will take a while, has to download
+        # will make an HTML report inside the runner. In the future, need to extract report since this doesn't throw any errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,17 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run security check
-        uses: dependency-check/Dependency-Check_Action@main
-        id: DepCheck
-        with:
-          project: "EasyPost Java Client Library"
-          path: '.'
-          format: 'HTML'
-          args: >
-            --failOnCVSS 7
-            --enableRetired
+        run: make scan
       - name: Upload Test results
         uses: actions/upload-artifact@master
         with:
-          name: DepCheck report
+          name: DependencyCheck report
           path: ${{github.workspace}}/reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
         uses: actions/upload-artifact@master
         with:
           name: DependencyCheck report
-          path: ${{github.workspace}}/reports
+          path: ${{github.workspace}}/target/dependency-check-report.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request: ~
 
 jobs:
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        javaversion: ["8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18"]
+        javaversion: [ "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18" ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Java ${{ matrix.javaversion }}
@@ -35,6 +35,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Run security checks on dependencies
-        run: make scan  # this will take a while, has to download
-        # will make an HTML report inside the runner. In the future, need to extract report since this doesn't throw any errors
+      - name: Run security check
+        uses: dependency-check/Dependency-Check_Action@main
+        id: DepCheck
+        with:
+          project: "EasyPost Java Client Library"
+          path: '.'
+          format: 'HTML'
+          args: >
+            --failOnCVSS 7
+            --enableRetired
+      - name: Upload Test results
+        uses: actions/upload-artifact@master
+        with:
+          name: DepCheck report
+          path: ${{github.workspace}}/reports

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,12 @@ install-checkstyle:
 lint:
 	java -jar checkstyle.jar src -c easypost_java_style.xml -d
 
-## scan - Scan the project for security issues
+## scan - Scan the project for serious security issues
 scan:
-	mvn verify -DskipTests=true -Dgpg.skip=true -Dcheckstyle.skip=true -Djavadoc.skip=true
+	mvn verify -DskipTests=true -Dgpg.skip=true -Dcheckstyle.skip=true -Djavadoc.skip=true -Ddependency-check.failBuildOnCVSS=7 -Ddependency-check.junitFailOnCVSS=7
 
-.PHONY: help build-release build-dev publish test clean install-checkstyle lint scan
+## scan-strict - Scan the project for any security issues (strict mode)
+scan-strict:
+	mvn verify -DskipTests=true -Dgpg.skip=true -Dcheckstyle.skip=true -Djavadoc.skip=true -Ddependency-check.failBuildOnCVSS=0 -Ddependency-check.junitFailOnCVSS=0
+
+.PHONY: help build-release build-dev publish test clean install-checkstyle lint scan scan-strict

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+## help - Display help about make targets for this Makefile
+help:
+	@cat Makefile | grep '^## ' --color=never | cut -c4- | sed -e "`printf 's/ - /\t- /;'`" | column -s "`printf '\t'`" -t
+
+## build-release - Build the project for release
+# @parameters:
+# pass= - The GPG password to sign the release
+build-release:
+	mvn clean install -Dgpg.passphrase=${pass}
+
+## publish - Publish a release of the project
+# @parameters:
+# pass= - The GPG password to sign the release
+publish:
+	mvn clean deploy -Dgpg.passphrase=${pass}
+
+## test - Test the project
+test:
+	mvn --batch-mode install -Dgpg.skip=true -Dcheckstyle.skip=true -Dcheckstyle.skip=true -Ddependency-check.skip=true -Djavadoc.skip=true
+
+## clean - Clean the project
+clean:
+	mvn clean
+
+# install-checkstyle - Install CheckStyle
+install-checkstyle:
+	wget -O checkstyle.jar -q https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.3.1/checkstyle-10.3.1-all.jar
+
+## lint - Check if project follows CheckStyle rules (must run install-checkstyle first)
+lint:
+	java -jar checkstyle.jar src -c easypost_java_style.xml -d
+
+## scan - Scan the project for security issues
+scan:
+	mvn verify -DskipTests=true -Dgpg.skip=true -Dcheckstyle.skip=true -Djavadoc.skip=true
+
+.PHONY: help build-release publish test clean install-checkstyle lint scan

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ help:
 build-release:
 	mvn clean install -Dgpg.passphrase=${pass}
 
+## build-dev - Build the project for development
+build-dev:
+	mvn clean install -DskipTests=true -Dgpg.skip=true -Dcheckstyle.skip=true -Dcheckstyle.skip=true -Ddependency-check.skip=true -Djavadoc.skip=true
+
 ## publish - Publish a release of the project
 # @parameters:
 # pass= - The GPG password to sign the release
@@ -34,4 +38,4 @@ lint:
 scan:
 	mvn verify -DskipTests=true -Dgpg.skip=true -Dcheckstyle.skip=true -Djavadoc.skip=true
 
-.PHONY: help build-release publish test clean install-checkstyle lint scan
+.PHONY: help build-release build-dev publish test clean install-checkstyle lint scan

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,10 @@
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
                 <version>7.1.1</version>
+                <configuration>
+                    <failBuildOnCVSS>7</failBuildOnCVSS>
+                    <junitFailOnCVSS>7</junitFailOnCVSS>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>23.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.easypost</groupId>
             <artifactId>easyvcr</artifactId>
             <version>0.3.0</version>
@@ -249,6 +255,18 @@
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>7.1.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
# Description

- Add dependency-check as dependency
- Add Makefile for common commands (lint, security check, build, release, publish, etc)
- Add CI step (see notes)

# Testing

- All Makefile commands work as expected
- Dependency check runs from command line as expected
- All unit tests pass as expected, no changes or re-recording needed

# Notes
- The dependency check generates an HTML report after running, which is then uploaded as an artifact (example below). The CI step itself should fail on severe CVSs (plugin is configured to fail a build if there are any CVSs with a score 7+)
- There is also a [free GitHub integration](https://github.com/marketplace/muse-dev/plan/MLP_kgDNGN8) from Sonatype (who run the Maven repository) to scan for CVSs, that we might want to consider. This should be in addition to the CI tool, not as a replacement, to allow local CVS scanning still
- Example report: <img width="1348" alt="image" src="https://user-images.githubusercontent.com/17054780/177659474-297c49ad-1679-47fd-9e87-4d202f5eed9d.png">


# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
