### PR TITLE
Add generateForm function to Shipment class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Adds `generate_form()` in Shipment class
+
 ## v5.6.0 (2022-07-11)
 
 - Adds `Billing.retrievePaymentMethods()`, `Billing.fundWallet()`, and `Billing.deletePaymentMethod()` functions

--- a/src/main/java/com/easypost/model/Shipment.java
+++ b/src/main/java/com/easypost/model/Shipment.java
@@ -1158,4 +1158,49 @@ public final class Shipment extends EasyPostResource {
     public Rate lowestRate(final List<String> carriers) throws EasyPostException {
         return this.lowestRate(carriers, null);
     }
+
+    /**
+     * Generate a form for this shipment.
+     *
+     * @param formType the form type for this shipment.
+     * @throws EasyPostException when the request fails.
+     */
+    public void generateForm(final String formType) throws EasyPostException {
+        this.generateForm(formType, null);
+    }
+
+    /**
+     * Generate a form for this shipment.
+     *
+     * @param formType the form type for this shipment.
+     * @param formOptions the form options for this shipment.
+     * @throws EasyPostException when the request fails.
+     */
+    public void generateForm(final String formType, final Map<String, Object> formOptions) throws EasyPostException {
+        this.generateForm(formType, formOptions, null);
+    }
+
+    /**
+     * Generate a form for this shipment.
+     *
+     * @param formType the form type for this shipment.
+     * @param formOptions the form options for this shipment.
+     * @param apiKey API key to use in request (overrides default API key).
+     * 
+     * @throws EasyPostException when the request fails.
+     */
+    public void generateForm(final String formType, final Map<String, Object> formOptions, String apiKey)
+            throws EasyPostException {
+        HashMap<String, Object> params = new HashMap<>();
+        HashMap<String, Object> wrappedParams = new HashMap<>();
+
+        params.put("type", formType);
+        params.putAll(formOptions);
+        wrappedParams.put("form", params);
+
+        Shipment response = request(RequestMethod.POST, String.format("%s/forms",
+            instanceURL(Shipment.class, this.getId())), wrappedParams, Shipment.class, apiKey);
+
+        this.merge(this, response);
+    }
 }

--- a/src/main/java/com/easypost/model/Shipment.java
+++ b/src/main/java/com/easypost/model/Shipment.java
@@ -1166,7 +1166,18 @@ public final class Shipment extends EasyPostResource {
      * @throws EasyPostException when the request fails.
      */
     public void generateForm(final String formType) throws EasyPostException {
-        this.generateForm(formType, null);
+        this.generateForm(formType, null, null);
+    }
+
+    /**
+     * Generate a form for this shipment.
+     *
+     * @param formType the form type for this shipment.
+     * @param apiKey API key to use in request (overrides default API key).
+     * @throws EasyPostException when the request fails.
+     */
+    public void generateForm(final String formType, final String apiKey) throws EasyPostException {
+        this.generateForm(formType, null, apiKey);
     }
 
     /**
@@ -1186,7 +1197,6 @@ public final class Shipment extends EasyPostResource {
      * @param formType the form type for this shipment.
      * @param formOptions the form options for this shipment.
      * @param apiKey API key to use in request (overrides default API key).
-     * 
      * @throws EasyPostException when the request fails.
      */
     public void generateForm(final String formType, final Map<String, Object> formOptions, String apiKey)

--- a/src/test/cassettes/shipment/generate_form.json
+++ b/src/test/cassettes/shipment/generate_form.json
@@ -1,0 +1,286 @@
+[
+  {
+    "recordedAt": 1657574628,
+    "request": {
+      "body": "{\n  \"shipment\": {\n    \"parcel\": {\n      \"length\": \"10\",\n      \"width\": \"8\",\n      \"weight\": \"15.4\",\n      \"height\": \"4\"\n    },\n    \"carrier\": \"USPS\",\n    \"service\": \"First\",\n    \"to_address\": {\n      \"zip\": \"94107\",\n      \"city\": \"San Francisco\",\n      \"phone\": \"REDACTED\",\n      \"name\": \"Jack Sparrow\",\n      \"company\": \"EasyPost\",\n      \"street1\": \"388 Townsend St\",\n      \"street2\": \"Apt 20\",\n      \"state\": \"CA\"\n    },\n    \"carrier_accounts\": [\n      \"ca_f09befdb2e9c410e95c7622ea912c18c\"\n    ],\n    \"from_address\": {\n      \"zip\": \"94107\",\n      \"city\": \"San Francisco\",\n      \"phone\": \"REDACTED\",\n      \"name\": \"Jack Sparrow\",\n      \"company\": \"EasyPost\",\n      \"street1\": \"388 Townsend St\",\n      \"street2\": \"Apt 20\",\n      \"state\": \"CA\"\n    }\n  }\n}",
+      "method": "POST",
+      "headers": {
+        "Accept-Charset": [
+          "UTF-8"
+        ],
+        "User-Agent": [
+          "REDACTED"
+        ],
+        "Content-Type": [
+          "application/json"
+        ]
+      },
+      "uri": "https://api.easypost.com/v2/shipments"
+    },
+    "response": {
+      "body": "{\n  \"insurance\": \"50.00\",\n  \"fees\": [\n    {\n      \"amount\": \"0.00000\",\n      \"refunded\": false,\n      \"type\": \"LabelFee\",\n      \"charged\": true,\n      \"object\": \"Fee\"\n    },\n    {\n      \"amount\": \"5.49000\",\n      \"refunded\": false,\n      \"type\": \"PostageFee\",\n      \"charged\": true,\n      \"object\": \"Fee\"\n    },\n    {\n      \"amount\": \"0.25000\",\n      \"refunded\": false,\n      \"type\": \"InsuranceFee\",\n      \"charged\": true,\n      \"object\": \"Fee\"\n    }\n  ],\n  \"batch_id\": null,\n  \"batch_message\": null,\n  \"batch_status\": null,\n  \"created_at\": \"2022-07-11T21:23:46Z\",\n  \"mode\": \"test\",\n  \"reference\": null,\n  \"usps_zone\": 1.0,\n  \"is_return\": false,\n  \"updated_at\": \"2022-07-11T21:23:48Z\",\n  \"selected_rate\": {\n    \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n    \"list_rate\": \"5.49\",\n    \"created_at\": \"2022-07-11T21:23:47Z\",\n    \"delivery_days\": 2.0,\n    \"list_currency\": \"USD\",\n    \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n    \"mode\": \"test\",\n    \"carrier\": \"USPS\",\n    \"delivery_date\": null,\n    \"delivery_date_guaranteed\": false,\n    \"retail_rate\": \"5.49\",\n    \"retail_currency\": \"USD\",\n    \"updated_at\": \"2022-07-11T21:23:47Z\",\n    \"rate\": \"5.49\",\n    \"service\": \"First\",\n    \"billing_type\": \"easypost\",\n    \"est_delivery_days\": 2.0,\n    \"currency\": \"USD\",\n    \"id\": \"rate_cc6226a74d334360a8fbe5192327c991\",\n    \"object\": \"Rate\"\n  },\n  \"options\": {\n    \"date_advance\": 0.0,\n    \"currency\": \"USD\",\n    \"payment\": {\n      \"type\": \"SENDER\"\n    }\n  },\n  \"tracker\": {\n    \"fees\": [],\n    \"carrier_detail\": null,\n    \"created_at\": \"2022-07-11T21:23:48Z\",\n    \"weight\": null,\n    \"tracking_details\": [],\n    \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n    \"tracking_code\": \"9400100109361127629519\",\n    \"status_detail\": \"unknown\",\n    \"mode\": \"test\",\n    \"public_url\": \"https://track.easypost.com/djE6dHJrX2FkODkxNjY3Zjk3NzRiNzdiYWM0Zjg3NWUwNDY2ZTkw\",\n    \"est_delivery_date\": null,\n    \"carrier\": \"USPS\",\n    \"updated_at\": \"2022-07-11T21:23:48Z\",\n    \"signed_by\": null,\n    \"id\": \"trk_ad891667f9774b77bac4f875e0466e90\",\n    \"object\": \"Tracker\",\n    \"status\": \"unknown\"\n  },\n  \"return_address\": {\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"city\": \"San Francisco\",\n    \"created_at\": \"2022-07-11T21:23:46+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-07-11T21:23:46+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Jack Sparrow\",\n    \"company\": \"EasyPost\",\n    \"street1\": \"388 Townsend St\",\n    \"id\": \"adr_bfc51bde015f11edb25eac1f6bc7b362\",\n    \"street2\": \"Apt 20\",\n    \"state\": \"CA\",\n    \"email\": null,\n    \"object\": \"Address\"\n  },\n  \"id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n  \"from_address\": {\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"city\": \"San Francisco\",\n    \"created_at\": \"2022-07-11T21:23:46+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-07-11T21:23:46+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Jack Sparrow\",\n    \"company\": \"EasyPost\",\n    \"street1\": \"388 Townsend St\",\n    \"id\": \"adr_bfc51bde015f11edb25eac1f6bc7b362\",\n    \"street2\": \"Apt 20\",\n    \"state\": \"CA\",\n    \"email\": null,\n    \"object\": \"Address\"\n  },\n  \"customs_info\": null,\n  \"postage_label\": {\n    \"label_resolution\": 300.0,\n    \"date_advance\": 0.0,\n    \"label_size\": \"4x6\",\n    \"integrated_form\": \"none\",\n    \"label_pdf_url\": null,\n    \"created_at\": \"2022-07-11T21:23:47Z\",\n    \"label_type\": \"default\",\n    \"label_url\": \"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220711/193f9c546b484700b257ec7346bdedfd.png\",\n    \"label_file\": null,\n    \"label_epl2_url\": null,\n    \"label_file_type\": \"image/png\",\n    \"updated_at\": \"2022-07-11T21:23:47Z\",\n    \"id\": \"pl_82e3688ecd964c3f94aedf0e1547276a\",\n    \"label_zpl_url\": null,\n    \"label_date\": \"2022-07-11T21:23:47Z\",\n    \"object\": \"PostageLabel\"\n  },\n  \"parcel\": {\n    \"mode\": \"test\",\n    \"updated_at\": \"2022-07-11T21:23:46Z\",\n    \"predefined_package\": null,\n    \"length\": 10.0,\n    \"width\": 8.0,\n    \"created_at\": \"2022-07-11T21:23:46Z\",\n    \"weight\": 15.4,\n    \"id\": \"prcl_b0d84fde9b4b407487888fb8979e777c\",\n    \"object\": \"Parcel\",\n    \"height\": 4.0\n  },\n  \"refund_status\": null,\n  \"buyer_address\": {\n    \"zip\": \"94107-1670\",\n    \"country\": \"US\",\n    \"city\": \"SAN FRANCISCO\",\n    \"created_at\": \"2022-07-11T21:23:46+00:00\",\n    \"verifications\": {\n      \"delivery\": {\n        \"success\": true,\n        \"details\": {\n          \"latitude\": 37.77551,\n          \"time_zone\": \"America/Los_Angeles\",\n          \"longitude\": -122.39697\n        },\n        \"errors\": []\n      },\n      \"zip4\": {\n        \"success\": true,\n        \"details\": null,\n        \"errors\": []\n      }\n    },\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": true,\n    \"updated_at\": \"2022-07-11T21:23:47+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"JACK SPARROW\",\n    \"company\": \"EASYPOST\",\n    \"street1\": \"388 TOWNSEND ST APT 20\",\n    \"id\": \"adr_bfc307fd015f11edbaffac1f6b0a0d1e\",\n    \"street2\": null,\n    \"state\": \"CA\",\n    \"email\": null,\n    \"object\": \"Address\"\n  },\n  \"rates\": [\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"7.37\",\n      \"created_at\": \"2022-07-11T21:23:47Z\",\n      \"delivery_days\": 1.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"8.70\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-07-11T21:23:47Z\",\n      \"rate\": \"7.37\",\n      \"service\": \"Priority\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": 1.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_53e2df8547ad4f25a3ec3c53545b1315\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"5.49\",\n      \"created_at\": \"2022-07-11T21:23:47Z\",\n      \"delivery_days\": 2.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"5.49\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-07-11T21:23:47Z\",\n      \"rate\": \"5.49\",\n      \"service\": \"First\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": 2.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_cc6226a74d334360a8fbe5192327c991\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"7.22\",\n      \"created_at\": \"2022-07-11T21:23:47Z\",\n      \"delivery_days\": 2.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"7.22\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-07-11T21:23:47Z\",\n      \"rate\": \"7.22\",\n      \"service\": \"ParcelSelect\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": 2.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_adfcbba74a8d449cb1f2e280998c0b6c\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"23.75\",\n      \"created_at\": \"2022-07-11T21:23:47Z\",\n      \"delivery_days\": null,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"27.40\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-07-11T21:23:47Z\",\n      \"rate\": \"23.75\",\n      \"service\": \"Express\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": null,\n      \"currency\": \"USD\",\n      \"id\": \"rate_5c32d7111ff24a14ba21ba4ec05f7318\",\n      \"object\": \"Rate\"\n    }\n  ],\n  \"scan_form\": null,\n  \"to_address\": {\n    \"zip\": \"94107-1670\",\n    \"country\": \"US\",\n    \"city\": \"SAN FRANCISCO\",\n    \"created_at\": \"2022-07-11T21:23:46+00:00\",\n    \"verifications\": {\n      \"delivery\": {\n        \"success\": true,\n        \"details\": {\n          \"latitude\": 37.77551,\n          \"time_zone\": \"America/Los_Angeles\",\n          \"longitude\": -122.39697\n        },\n        \"errors\": []\n      },\n      \"zip4\": {\n        \"success\": true,\n        \"details\": null,\n        \"errors\": []\n      }\n    },\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": true,\n    \"updated_at\": \"2022-07-11T21:23:47+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"JACK SPARROW\",\n    \"company\": \"EASYPOST\",\n    \"street1\": \"388 TOWNSEND ST APT 20\",\n    \"id\": \"adr_bfc307fd015f11edbaffac1f6b0a0d1e\",\n    \"street2\": null,\n    \"state\": \"CA\",\n    \"email\": null,\n    \"object\": \"Address\"\n  },\n  \"tracking_code\": \"9400100109361127629519\",\n  \"messages\": [],\n  \"order_id\": null,\n  \"forms\": [],\n  \"status\": \"unknown\",\n  \"object\": \"Shipment\"\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 201 Created"
+        ],
+        "content-length": [
+          "7049"
+        ],
+        "expires": [
+          "0"
+        ],
+        "x-node": [
+          "bigweb6nuq"
+        ],
+        "x-frame-options": [
+          "SAMEORIGIN"
+        ],
+        "x-backend": [
+          "easypost"
+        ],
+        "x-permitted-cross-domain-policies": [
+          "none"
+        ],
+        "x-download-options": [
+          "noopen"
+        ],
+        "strict-transport-security": [
+          "max-age\u003d31536000; includeSubDomains; preload"
+        ],
+        "pragma": [
+          "no-cache"
+        ],
+        "x-content-type-options": [
+          "nosniff"
+        ],
+        "x-xss-protection": [
+          "1; mode\u003dblock"
+        ],
+        "x-ep-request-uuid": [
+          "47e9152d62cc94e2ff0308c700117df8"
+        ],
+        "x-proxied": [
+          "extlb1nuq 403f17ff97",
+          "intlb1nuq 403f17ff97"
+        ],
+        "referrer-policy": [
+          "strict-origin-when-cross-origin"
+        ],
+        "x-runtime": [
+          "1.282671"
+        ],
+        "etag": [
+          "W/\"5b7844a905415e5a9979e01ff2b04b18\""
+        ],
+        "content-type": [
+          "application/json; charset\u003dutf-8"
+        ],
+        "location": [
+          "/api/v2/shipments/shp_32dea50b4cee4787833444c1a0bd0324"
+        ],
+        "x-version-label": [
+          "easypost-202207112046-0249502a62-master"
+        ],
+        "cache-control": [
+          "no-cache, no-store"
+        ]
+      },
+      "status": {
+        "code": 201,
+        "message": "Created"
+      },
+      "errors": null,
+      "uri": "https://api.easypost.com/v2/shipments"
+    },
+    "duration": 1562
+  },
+  {
+    "recordedAt": 1657574629,
+    "request": {
+      "body": "{\n  \"form\": {\n    \"type\": \"return_packing_slip\",\n    \"barcode\": \"RMA12345678900\"\n  }\n}",
+      "method": "POST",
+      "headers": {
+        "Accept-Charset": [
+          "UTF-8"
+        ],
+        "User-Agent": [
+          "REDACTED"
+        ],
+        "Content-Type": [
+          "application/json"
+        ]
+      },
+      "uri": "https://api.easypost.com/v2/shipments/shp_32dea50b4cee4787833444c1a0bd0324/forms"
+    },
+    "response": {
+      "body": "{\n  \"insurance\": \"50.00\",\n  \"fees\": [\n    {\n      \"amount\": \"0.00000\",\n      \"refunded\": false,\n      \"type\": \"LabelFee\",\n      \"charged\": true,\n      \"object\": \"Fee\"\n    },\n    {\n      \"amount\": \"5.49000\",\n      \"refunded\": false,\n      \"type\": \"PostageFee\",\n      \"charged\": true,\n      \"object\": \"Fee\"\n    },\n    {\n      \"amount\": \"0.25000\",\n      \"refunded\": false,\n      \"type\": \"InsuranceFee\",\n      \"charged\": true,\n      \"object\": \"Fee\"\n    }\n  ],\n  \"batch_id\": null,\n  \"batch_message\": null,\n  \"batch_status\": null,\n  \"created_at\": \"2022-07-11T21:23:46Z\",\n  \"mode\": \"test\",\n  \"reference\": null,\n  \"usps_zone\": 1.0,\n  \"is_return\": false,\n  \"updated_at\": \"2022-07-11T21:23:48Z\",\n  \"selected_rate\": {\n    \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n    \"list_rate\": \"5.49\",\n    \"created_at\": \"2022-07-11T21:23:47Z\",\n    \"delivery_days\": 2.0,\n    \"list_currency\": \"USD\",\n    \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n    \"mode\": \"test\",\n    \"carrier\": \"USPS\",\n    \"delivery_date\": null,\n    \"delivery_date_guaranteed\": false,\n    \"retail_rate\": \"5.49\",\n    \"retail_currency\": \"USD\",\n    \"updated_at\": \"2022-07-11T21:23:47Z\",\n    \"rate\": \"5.49\",\n    \"service\": \"First\",\n    \"billing_type\": \"easypost\",\n    \"est_delivery_days\": 2.0,\n    \"currency\": \"USD\",\n    \"id\": \"rate_cc6226a74d334360a8fbe5192327c991\",\n    \"object\": \"Rate\"\n  },\n  \"options\": {\n    \"date_advance\": 0.0,\n    \"currency\": \"USD\",\n    \"payment\": {\n      \"type\": \"SENDER\"\n    }\n  },\n  \"tracker\": {\n    \"fees\": [],\n    \"carrier_detail\": {\n      \"est_delivery_date_local\": null,\n      \"origin_location\": \"HOUSTON TX, 77001\",\n      \"destination_tracking_location\": null,\n      \"guaranteed_delivery_date\": null,\n      \"est_delivery_time_local\": null,\n      \"service\": \"First-Class Package Service\",\n      \"container_type\": null,\n      \"initial_delivery_attempt\": null,\n      \"origin_tracking_location\": {\n        \"zip\": \"77063\",\n        \"country\": null,\n        \"city\": \"HOUSTON\",\n        \"state\": \"TX\",\n        \"object\": \"TrackingLocation\"\n      },\n      \"destination_location\": \"CHARLESTON SC, 29401\",\n      \"alternate_identifier\": null,\n      \"object\": \"CarrierDetail\"\n    },\n    \"created_at\": \"2022-07-11T21:23:48Z\",\n    \"weight\": null,\n    \"tracking_details\": [\n      {\n        \"tracking_location\": {\n          \"zip\": null,\n          \"country\": null,\n          \"city\": null,\n          \"state\": null,\n          \"object\": \"TrackingLocation\"\n        },\n        \"datetime\": \"2022-06-11T21:23:48Z\",\n        \"description\": null,\n        \"source\": \"USPS\",\n        \"message\": \"Pre-Shipment Info Sent to USPS\",\n        \"object\": \"TrackingDetail\",\n        \"status\": \"pre_transit\",\n        \"status_detail\": \"status_update\",\n        \"carrier_code\": null\n      },\n      {\n        \"tracking_location\": {\n          \"zip\": \"77063\",\n          \"country\": null,\n          \"city\": \"HOUSTON\",\n          \"state\": \"TX\",\n          \"object\": \"TrackingLocation\"\n        },\n        \"datetime\": \"2022-06-12T10:00:48Z\",\n        \"description\": null,\n        \"source\": \"USPS\",\n        \"message\": \"Shipping Label Created\",\n        \"object\": \"TrackingDetail\",\n        \"status\": \"pre_transit\",\n        \"status_detail\": \"status_update\",\n        \"carrier_code\": null\n      }\n    ],\n    \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n    \"tracking_code\": \"9400100109361127629519\",\n    \"status_detail\": \"status_update\",\n    \"mode\": \"test\",\n    \"public_url\": \"https://track.easypost.com/djE6dHJrX2FkODkxNjY3Zjk3NzRiNzdiYWM0Zjg3NWUwNDY2ZTkw\",\n    \"est_delivery_date\": \"2022-07-11T21:23:48Z\",\n    \"carrier\": \"USPS\",\n    \"updated_at\": \"2022-07-11T21:23:48Z\",\n    \"signed_by\": null,\n    \"id\": \"trk_ad891667f9774b77bac4f875e0466e90\",\n    \"object\": \"Tracker\",\n    \"status\": \"pre_transit\"\n  },\n  \"return_address\": {\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"city\": \"San Francisco\",\n    \"created_at\": \"2022-07-11T21:23:46+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-07-11T21:23:46+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Jack Sparrow\",\n    \"company\": \"EasyPost\",\n    \"street1\": \"388 Townsend St\",\n    \"id\": \"adr_bfc51bde015f11edb25eac1f6bc7b362\",\n    \"street2\": \"Apt 20\",\n    \"state\": \"CA\",\n    \"email\": null,\n    \"object\": \"Address\"\n  },\n  \"id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n  \"from_address\": {\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"city\": \"San Francisco\",\n    \"created_at\": \"2022-07-11T21:23:46+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-07-11T21:23:46+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Jack Sparrow\",\n    \"company\": \"EasyPost\",\n    \"street1\": \"388 Townsend St\",\n    \"id\": \"adr_bfc51bde015f11edb25eac1f6bc7b362\",\n    \"street2\": \"Apt 20\",\n    \"state\": \"CA\",\n    \"email\": null,\n    \"object\": \"Address\"\n  },\n  \"customs_info\": null,\n  \"postage_label\": {\n    \"label_resolution\": 300.0,\n    \"date_advance\": 0.0,\n    \"label_size\": \"4x6\",\n    \"integrated_form\": \"none\",\n    \"label_pdf_url\": null,\n    \"created_at\": \"2022-07-11T21:23:47Z\",\n    \"label_type\": \"default\",\n    \"label_url\": \"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220711/193f9c546b484700b257ec7346bdedfd.png\",\n    \"label_file\": null,\n    \"label_epl2_url\": null,\n    \"label_file_type\": \"image/png\",\n    \"updated_at\": \"2022-07-11T21:23:47Z\",\n    \"id\": \"pl_82e3688ecd964c3f94aedf0e1547276a\",\n    \"label_zpl_url\": null,\n    \"label_date\": \"2022-07-11T21:23:47Z\",\n    \"object\": \"PostageLabel\"\n  },\n  \"parcel\": {\n    \"mode\": \"test\",\n    \"updated_at\": \"2022-07-11T21:23:46Z\",\n    \"predefined_package\": null,\n    \"length\": 10.0,\n    \"width\": 8.0,\n    \"created_at\": \"2022-07-11T21:23:46Z\",\n    \"weight\": 15.4,\n    \"id\": \"prcl_b0d84fde9b4b407487888fb8979e777c\",\n    \"object\": \"Parcel\",\n    \"height\": 4.0\n  },\n  \"refund_status\": null,\n  \"buyer_address\": {\n    \"zip\": \"94107-1670\",\n    \"country\": \"US\",\n    \"city\": \"SAN FRANCISCO\",\n    \"created_at\": \"2022-07-11T21:23:46+00:00\",\n    \"verifications\": {\n      \"delivery\": {\n        \"success\": true,\n        \"details\": {\n          \"latitude\": 37.77551,\n          \"time_zone\": \"America/Los_Angeles\",\n          \"longitude\": -122.39697\n        },\n        \"errors\": []\n      },\n      \"zip4\": {\n        \"success\": true,\n        \"details\": null,\n        \"errors\": []\n      }\n    },\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": true,\n    \"updated_at\": \"2022-07-11T21:23:47+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"JACK SPARROW\",\n    \"company\": \"EASYPOST\",\n    \"street1\": \"388 TOWNSEND ST APT 20\",\n    \"id\": \"adr_bfc307fd015f11edbaffac1f6b0a0d1e\",\n    \"street2\": null,\n    \"state\": \"CA\",\n    \"email\": null,\n    \"object\": \"Address\"\n  },\n  \"rates\": [\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"7.37\",\n      \"created_at\": \"2022-07-11T21:23:47Z\",\n      \"delivery_days\": 1.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"8.70\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-07-11T21:23:47Z\",\n      \"rate\": \"7.37\",\n      \"service\": \"Priority\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": 1.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_53e2df8547ad4f25a3ec3c53545b1315\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"5.49\",\n      \"created_at\": \"2022-07-11T21:23:47Z\",\n      \"delivery_days\": 2.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"5.49\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-07-11T21:23:47Z\",\n      \"rate\": \"5.49\",\n      \"service\": \"First\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": 2.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_cc6226a74d334360a8fbe5192327c991\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"7.22\",\n      \"created_at\": \"2022-07-11T21:23:47Z\",\n      \"delivery_days\": 2.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"7.22\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-07-11T21:23:47Z\",\n      \"rate\": \"7.22\",\n      \"service\": \"ParcelSelect\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": 2.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_adfcbba74a8d449cb1f2e280998c0b6c\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"23.75\",\n      \"created_at\": \"2022-07-11T21:23:47Z\",\n      \"delivery_days\": null,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"27.40\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-07-11T21:23:47Z\",\n      \"rate\": \"23.75\",\n      \"service\": \"Express\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": null,\n      \"currency\": \"USD\",\n      \"id\": \"rate_5c32d7111ff24a14ba21ba4ec05f7318\",\n      \"object\": \"Rate\"\n    }\n  ],\n  \"scan_form\": null,\n  \"to_address\": {\n    \"zip\": \"94107-1670\",\n    \"country\": \"US\",\n    \"city\": \"SAN FRANCISCO\",\n    \"created_at\": \"2022-07-11T21:23:46+00:00\",\n    \"verifications\": {\n      \"delivery\": {\n        \"success\": true,\n        \"details\": {\n          \"latitude\": 37.77551,\n          \"time_zone\": \"America/Los_Angeles\",\n          \"longitude\": -122.39697\n        },\n        \"errors\": []\n      },\n      \"zip4\": {\n        \"success\": true,\n        \"details\": null,\n        \"errors\": []\n      }\n    },\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": true,\n    \"updated_at\": \"2022-07-11T21:23:47+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"JACK SPARROW\",\n    \"company\": \"EASYPOST\",\n    \"street1\": \"388 TOWNSEND ST APT 20\",\n    \"id\": \"adr_bfc307fd015f11edbaffac1f6b0a0d1e\",\n    \"street2\": null,\n    \"state\": \"CA\",\n    \"email\": null,\n    \"object\": \"Address\"\n  },\n  \"tracking_code\": \"9400100109361127629519\",\n  \"messages\": [],\n  \"order_id\": null,\n  \"forms\": [\n    {\n      \"mode\": \"test\",\n      \"submitted_electronically\": null,\n      \"updated_at\": \"2022-07-11T21:23:49Z\",\n      \"form_url\": \"https://easypost-files.s3-us-west-2.amazonaws.com/files/form/20220711/64dcadbb89b64c639675849c192b1cf3.pdf\",\n      \"created_at\": \"2022-07-11T21:23:48Z\",\n      \"id\": \"form_fb389d1dca0c438a89df6f113f9b50bd\",\n      \"form_type\": \"return_packing_slip\",\n      \"object\": \"Form\"\n    }\n  ],\n  \"status\": \"unknown\",\n  \"object\": \"Shipment\"\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 201 Created"
+        ],
+        "content-length": [
+          "8517"
+        ],
+        "expires": [
+          "0"
+        ],
+        "x-node": [
+          "bigweb3nuq"
+        ],
+        "x-frame-options": [
+          "SAMEORIGIN"
+        ],
+        "x-backend": [
+          "easypost"
+        ],
+        "x-permitted-cross-domain-policies": [
+          "none"
+        ],
+        "x-download-options": [
+          "noopen"
+        ],
+        "strict-transport-security": [
+          "max-age\u003d31536000; includeSubDomains; preload"
+        ],
+        "pragma": [
+          "no-cache"
+        ],
+        "x-content-type-options": [
+          "nosniff"
+        ],
+        "x-xss-protection": [
+          "1; mode\u003dblock"
+        ],
+        "x-ep-request-uuid": [
+          "9078d5c662cc94e4ff0308c90002135a"
+        ],
+        "x-proxied": [
+          "extlb3wdc 403f17ff97",
+          "intlb2wdc 403f17ff97",
+          "intlb2nuq 403f17ff97"
+        ],
+        "referrer-policy": [
+          "strict-origin-when-cross-origin"
+        ],
+        "x-runtime": [
+          "0.631122"
+        ],
+        "etag": [
+          "W/\"852cdbb3b86b5076b2e5dee3192a7503\""
+        ],
+        "content-type": [
+          "application/json; charset\u003dutf-8"
+        ],
+        "location": [
+          "/api/v2/shipments/shp_32dea50b4cee4787833444c1a0bd0324/forms/return_packing_slip"
+        ],
+        "x-version-label": [
+          "easypost-202207112046-0249502a62-master"
+        ],
+        "cache-control": [
+          "no-cache, no-store"
+        ]
+      },
+      "status": {
+        "code": 201,
+        "message": "Created"
+      },
+      "errors": null,
+      "uri": "https://api.easypost.com/v2/shipments/shp_32dea50b4cee4787833444c1a0bd0324/forms"
+    },
+    "duration": 830
+  },
+  {
+    "recordedAt": 1657574629,
+    "request": {
+      "body": "",
+      "method": "GET",
+      "headers": {
+        "Accept-Charset": [
+          "UTF-8"
+        ],
+        "User-Agent": [
+          "REDACTED"
+        ]
+      },
+      "uri": "https://api.easypost.com/v2/shipments/shp_32dea50b4cee4787833444c1a0bd0324/smartrate"
+    },
+    "response": {
+      "body": "{\n  \"result\": [\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": 7.37,\n      \"created_at\": \"2022-07-11T21:23:47Z\",\n      \"delivery_days\": 1.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_currency\": \"USD\",\n      \"retail_rate\": 8.7,\n      \"updated_at\": \"2022-07-11T21:23:47Z\",\n      \"rate\": 7.37,\n      \"time_in_transit\": {\n        \"percentile_90\": 2.0,\n        \"percentile_50\": 1.0,\n        \"percentile_85\": 2.0,\n        \"percentile_95\": 2.0,\n        \"percentile_75\": 1.0,\n        \"percentile_97\": 3.0,\n        \"percentile_99\": 5.0\n      },\n      \"service\": \"Priority\",\n      \"est_delivery_days\": 1.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_53e2df8547ad4f25a3ec3c53545b1315\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": 5.49,\n      \"created_at\": \"2022-07-11T21:23:47Z\",\n      \"delivery_days\": 2.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_currency\": \"USD\",\n      \"retail_rate\": 5.49,\n      \"updated_at\": \"2022-07-11T21:23:47Z\",\n      \"rate\": 5.49,\n      \"time_in_transit\": {\n        \"percentile_90\": 2.0,\n        \"percentile_50\": 1.0,\n        \"percentile_85\": 1.0,\n        \"percentile_95\": 2.0,\n        \"percentile_75\": 1.0,\n        \"percentile_97\": 3.0,\n        \"percentile_99\": 3.0\n      },\n      \"service\": \"First\",\n      \"est_delivery_days\": 2.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_cc6226a74d334360a8fbe5192327c991\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": 7.22,\n      \"created_at\": \"2022-07-11T21:23:47Z\",\n      \"delivery_days\": 2.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_currency\": \"USD\",\n      \"retail_rate\": 7.22,\n      \"updated_at\": \"2022-07-11T21:23:47Z\",\n      \"rate\": 7.22,\n      \"time_in_transit\": {\n        \"percentile_90\": 4.0,\n        \"percentile_50\": 2.0,\n        \"percentile_85\": 3.0,\n        \"percentile_95\": 5.0,\n        \"percentile_75\": 3.0,\n        \"percentile_97\": 6.0,\n        \"percentile_99\": 8.0\n      },\n      \"service\": \"ParcelSelect\",\n      \"est_delivery_days\": 2.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_adfcbba74a8d449cb1f2e280998c0b6c\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": 23.75,\n      \"created_at\": \"2022-07-11T21:23:47Z\",\n      \"delivery_days\": null,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_32dea50b4cee4787833444c1a0bd0324\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_currency\": \"USD\",\n      \"retail_rate\": 27.4,\n      \"updated_at\": \"2022-07-11T21:23:47Z\",\n      \"rate\": 23.75,\n      \"time_in_transit\": {\n        \"percentile_90\": 1.0,\n        \"percentile_50\": 1.0,\n        \"percentile_85\": 1.0,\n        \"percentile_95\": 2.0,\n        \"percentile_75\": 1.0,\n        \"percentile_97\": 2.0,\n        \"percentile_99\": 4.0\n      },\n      \"service\": \"Express\",\n      \"est_delivery_days\": null,\n      \"currency\": \"USD\",\n      \"id\": \"rate_5c32d7111ff24a14ba21ba4ec05f7318\",\n      \"object\": \"Rate\"\n    }\n  ]\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 200 OK"
+        ],
+        "content-length": [
+          "2619"
+        ],
+        "expires": [
+          "0"
+        ],
+        "x-node": [
+          "bigweb1nuq"
+        ],
+        "x-frame-options": [
+          "SAMEORIGIN"
+        ],
+        "x-backend": [
+          "easypost"
+        ],
+        "x-permitted-cross-domain-policies": [
+          "none"
+        ],
+        "x-download-options": [
+          "noopen"
+        ],
+        "strict-transport-security": [
+          "max-age\u003d31536000; includeSubDomains; preload"
+        ],
+        "pragma": [
+          "no-cache"
+        ],
+        "x-content-type-options": [
+          "nosniff"
+        ],
+        "x-xss-protection": [
+          "1; mode\u003dblock"
+        ],
+        "x-ep-request-uuid": [
+          "9078d5c262cc94e5ff0308ca0002138e"
+        ],
+        "x-proxied": [
+          "extlb3wdc 403f17ff97",
+          "intlb1wdc 403f17ff97",
+          "intlb2nuq 403f17ff97"
+        ],
+        "referrer-policy": [
+          "strict-origin-when-cross-origin"
+        ],
+        "x-runtime": [
+          "0.114751"
+        ],
+        "etag": [
+          "W/\"97bc910b93d83277474ae14238203e37\""
+        ],
+        "content-type": [
+          "application/json; charset\u003dutf-8"
+        ],
+        "x-version-label": [
+          "easypost-202207112046-0249502a62-master"
+        ],
+        "cache-control": [
+          "no-cache, no-store"
+        ]
+      },
+      "status": {
+        "code": 200,
+        "message": "OK"
+      },
+      "errors": null,
+      "uri": "https://api.easypost.com/v2/shipments/shp_32dea50b4cee4787833444c1a0bd0324/smartrate"
+    },
+    "duration": 299
+  }
+]

--- a/src/test/java/com/easypost/Fixture.java
+++ b/src/test/java/com/easypost/Fixture.java
@@ -410,4 +410,25 @@ public abstract class Fixture {
     public static String webhookUrl() {
         return "http://example.com";
     }
+
+    /**
+     * RMA form options.
+     *
+     * @return RMA form options.
+     */
+    public static Map<String, Object> rmaFormOptions() {
+        final int units = 8;
+        Map<String, Object> params = new HashMap<String, Object>() {{
+            put("barcode", "RMA12345678900");
+            put("line_items", new HashMap<String, Object>() {{
+                put("units", units);
+                put("product", new HashMap<String, Object>() {{
+                    put("title", "Square Reader");
+                    put("barcode", "855658003251");
+                }});
+            }});
+        }};
+
+        return params;
+    }
 }

--- a/src/test/java/com/easypost/ShipmentTest.java
+++ b/src/test/java/com/easypost/ShipmentTest.java
@@ -2,6 +2,7 @@ package com.easypost;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.Address;
+import com.easypost.model.Form;
 import com.easypost.model.Parcel;
 import com.easypost.model.Rate;
 import com.easypost.model.Shipment;
@@ -420,5 +421,27 @@ public final class ShipmentTest {
         assertThrows(EasyPostException.class, () -> {
             Shipment.findLowestSmartrate(smartrates, 0, SmartrateAccuracy.Percentile90);
         });
+    }
+
+    /**
+     * Test generating a form from a shipment.
+     *
+     * @throws EasyPostException when the request fails.
+     */
+    @Test
+    public void testGenerateForm() throws EasyPostException {
+        vcr.setUpTest("generate_form");
+
+        Shipment shipment = createOneCallBuyShipment();
+        String formType = "return_packing_slip";
+
+        shipment.generateForm(formType, Fixture.rmaFormOptions());
+
+        assertTrue(shipment.getForms().size() > 0);
+
+        Form form = shipment.getForms().get(0);
+        
+        assertEquals(formType, form.getFormType());
+        assertTrue(form.getFormUrl() != null);
     }
 }


### PR DESCRIPTION
# Description

Add `generate_form` function in the Shipment class to allow the user to create a form from a shipment object.

# Testing

Added a new unit test and passed it

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
