### PR TITLE
chore: unify Makefile and add release target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           distribution: "zulu"
           java-version: ${{ matrix.javaversion }}
       - name: Build and test with Maven
-        run: EASYPOST_TEST_API_KEY=${{ secrets.EASYPOST_TEST_API_KEY }} EASYPOST_PROD_API_KEY=${{ secrets.EASYPOST_PROD_API_KEY }} mvn --batch-mode install -Dgpg.skip=true -Dcheckstyle.skip=true
+        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 make test
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Run security check
+      - name: Run security analysis
         run: make scan
       - name: Upload Test results
         uses: actions/upload-artifact@master

--- a/Makefile
+++ b/Makefile
@@ -2,31 +2,19 @@
 help:
 	@cat Makefile | grep '^## ' --color=never | cut -c4- | sed -e "`printf 's/ - /\t- /;'`" | column -s "`printf '\t'`" -t
 
-## build-release - Build the project for release
-# @parameters:
-# pass= - The GPG password to sign the release
-build-release:
-	mvn clean install -Dgpg.passphrase=${pass}
-
-## build-dev - Build the project for development
-build-dev:
+## build - Builds the project for development
+build:
 	mvn clean install -DskipTests=true -Dgpg.skip=true -Dcheckstyle.skip=true -Dcheckstyle.skip=true -Ddependency-check.skip=true -Djavadoc.skip=true
 
-## publish - Publish a release of the project
-# @parameters:
-# pass= - The GPG password to sign the release
-publish:
-	mvn clean deploy -Dgpg.passphrase=${pass}
-
-## test - Test the project
-test:
-	mvn --batch-mode install -Dgpg.skip=true -Dcheckstyle.skip=true -Dcheckstyle.skip=true -Ddependency-check.skip=true -Djavadoc.skip=true
-
-## clean - Clean the project
+## clean - Cleans the project
 clean:
 	mvn clean
 
-# install-checkstyle - Install CheckStyle
+## coverage - Test the project and generate a coverage report
+coverage:
+	mvn --batch-mode install -Dgpg.skip=true -Dcheckstyle.skip=true -Dcheckstyle.skip=true -Ddependency-check.skip=true -Djavadoc.skip=true jacoco:report
+
+## install-checkstyle - Install CheckStyle
 install-checkstyle:
 	wget -O checkstyle.jar -q https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.3.1/checkstyle-10.3.1-all.jar
 
@@ -34,12 +22,29 @@ install-checkstyle:
 lint:
 	java -jar checkstyle.jar src -c easypost_java_style.xml -d
 
+## publish - Publish a release of the project
+# @parameters:
+# pass= - The GPG password to sign the release
+publish:
+	mvn clean deploy -Dgpg.passphrase=${pass}
+
+## publish-dry - Build the project as a dry run to publishing
+# @parameters:
+# pass= - The GPG password to sign the release
+publish-dry:
+	mvn clean install -Dgpg.passphrase=${pass}
+
+## release - Cuts a release for the project on GitHub (requires GitHub CLI)
+# tag = The associated tag title of the release
+release:
+	gh release create ${tag} target/*.jar target/*.asc target/*.pom
+
 ## scan - Scan the project for serious security issues
 scan:
-	mvn verify -DskipTests=true -Dgpg.skip=true -Dcheckstyle.skip=true -Djavadoc.skip=true -Ddependency-check.failBuildOnCVSS=7 -Ddependency-check.junitFailOnCVSS=7
-
-## scan-strict - Scan the project for any security issues (strict mode)
-scan-strict:
 	mvn verify -DskipTests=true -Dgpg.skip=true -Dcheckstyle.skip=true -Djavadoc.skip=true -Ddependency-check.failBuildOnCVSS=0 -Ddependency-check.junitFailOnCVSS=0
 
-.PHONY: help build-release build-dev publish test clean install-checkstyle lint scan scan-strict
+## test - Test the project
+test:
+	mvn --batch-mode install -Dgpg.skip=true -Dcheckstyle.skip=true -Dcheckstyle.skip=true -Ddependency-check.skip=true -Djavadoc.skip=true
+
+.PHONY: help build clean install-checkstyle lint publish publish-dry release scan scan-strict test

--- a/README.md
+++ b/README.md
@@ -91,13 +91,19 @@ Upgrading major versions of this project? Refer to the [Upgrade Guide](UPGRADE_G
 
 ```bash
 # Build project
-mvn clean install -Dgpg.skip
+make build
+
+# Lint project
+make lint
 
 # Run tests
-EASYPOST_TEST_API_KEY=123... EASYPOST_PROD_API_KEY=123... mvn clean test -B
+EASYPOST_TEST_API_KEY=123... EASYPOST_PROD_API_KEY=123... make test
 
 # Run tests with coverage
-EASYPOST_TEST_API_KEY=123... EASYPOST_PROD_API_KEY=123... mvn clean test -B jacoco:report
+EASYPOST_TEST_API_KEY=123... EASYPOST_PROD_API_KEY=123... make coverage
+
+# Run security analysis
+make scan
 ```
 
 ### Testing


### PR DESCRIPTION
# Description

Unifies the Makefile targets like we've done in other libs. Also adds a `release` target.
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- Tested the new targets locally to ensure they worked. Used the `release` target successfully in prod to release `v5.8.1` and all built assets.

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
