### PR TITLE
Cache Maven dependencies, CVE database on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ jobs:
         javaversion: [ "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18" ]
     steps:
       - uses: actions/checkout@v3
+      - name: Load Maven dependencies cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-build${{ matrix.javaversion }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Install dependencies
         run: make install
       - name: Set up Java ${{ matrix.javaversion }}
@@ -37,6 +44,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Load Maven dependencies and CVE database cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository # The CVE database is included in the Maven repository folder
+          key: ${{ runner.os }}-maven-security-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Run security analysis
         run: make scan
       - name: Upload Test results


### PR DESCRIPTION
# Description

- CI build will pull Maven dependencies (including CVE database) from cache

# Testing

CVE database and Maven dependencies pulled successfully:
<img width="1334" alt="image" src="https://user-images.githubusercontent.com/17054780/187845162-fc74c3b0-bb4c-4157-9437-2dc8f0c511a8.png">

First run (when cache wasn't present), security scan step took ~3 minutes due to having to download the database.
Re-run (with cache now present), security scan step took ~20 seconds, did not need to re-download the database.
Even after a new commit (in case re-run uses cache by default), same result, security scan step did not need to re-download the database, suggesting that cache is working as expected.

Overall, with cache being used for Maven dependencies and CVE database for all `build` and `security` processes, the entire CI suite completed in record time, with all processes taking less than 1 minute each.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
