### PR TITLE
convert return type for fundWallet and deletePaymentMethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Removes `getUpdate` and `setUpdate` from Tracker class
 - Removes all beta features and corrsponding unit tests
 - Remove `serviceCode` from `Rate` class since this value is internal use only
+- Converts return type from boolean to void in empty response body functions
+  - `fundWallet()` and `deletePaymentMethod()` in Billing class
+  - `createList()` in Tracker class
+  - `updateEmail()` in ReferralCustomer class
 
 ## v5.10.0 (2022-09-21)
 

--- a/src/main/java/com/easypost/model/Billing.java
+++ b/src/main/java/com/easypost/model/Billing.java
@@ -12,11 +12,10 @@ public final class Billing extends EasyPostResource {
      * Delete a payment method.
      *
      * @param priority Which type of payment method to delete.
-     * @return True if successful. Throws an exception if unsuccessful.
      * @throws EasyPostException when the request fails.
      */
-    public static boolean deletePaymentMethod(PaymentMethod.Priority priority) throws EasyPostException {
-        return deletePaymentMethod(priority, null);
+    public static void deletePaymentMethod(PaymentMethod.Priority priority) throws EasyPostException {
+        deletePaymentMethod(priority, null);
     }
 
     /**
@@ -24,29 +23,25 @@ public final class Billing extends EasyPostResource {
      *
      * @param priority Which type of payment method to delete.
      * @param apiKey   API key to use in request (overrides default API key).
-     * @return True if successful. Throws an exception if unsuccessful.
      * @throws EasyPostException when the request fails.
      */
-    public static boolean deletePaymentMethod(PaymentMethod.Priority priority, String apiKey) throws EasyPostException {
+    public static void deletePaymentMethod(PaymentMethod.Priority priority, String apiKey) throws EasyPostException {
         PaymentMethodObject paymentMethodObject = getPaymentMethodByPriority(priority, apiKey);
 
         // will attempt to serialize empty JSON to a PaymentMethod.class, that's fine
         request(EasyPostResource.RequestMethod.DELETE,
                 String.format("%s/%s/%s", EasyPost.API_BASE, paymentMethodObject.getEndpoint(),
                         paymentMethodObject.getId()), null, PaymentMethod.class, apiKey);
-
-        return true;
     }
 
     /**
      * Fund your wallet from the primary payment method.
      *
      * @param amount amount to fund.
-     * @return True if successful. Throws an exception if unsuccessful.
      * @throws EasyPostException when the request fails.
      */
-    public static boolean fundWallet(String amount) throws EasyPostException {
-        return fundWallet(amount, PaymentMethod.Priority.PRIMARY, null);
+    public static void fundWallet(String amount) throws EasyPostException {
+        fundWallet(amount, PaymentMethod.Priority.PRIMARY, null);
     }
 
     /**
@@ -54,11 +49,10 @@ public final class Billing extends EasyPostResource {
      *
      * @param amount   amount to fund.
      * @param priority which type of payment method to use to fund the wallet. Defaults to primary.
-     * @return True if successful. Throws an exception if unsuccessful.
      * @throws EasyPostException when the request fails.
      */
-    public static boolean fundWallet(String amount, PaymentMethod.Priority priority) throws EasyPostException {
-        return fundWallet(amount, priority, null);
+    public static void fundWallet(String amount, PaymentMethod.Priority priority) throws EasyPostException {
+        fundWallet(amount, priority, null);
     }
 
     /**
@@ -67,10 +61,9 @@ public final class Billing extends EasyPostResource {
      * @param amount   amount to fund.
      * @param priority which type of payment method to use to fund the wallet.
      * @param apiKey   API key to use in request (overrides default API key).
-     * @return True if successful. Throws an exception if unsuccessful.
      * @throws EasyPostException when the request fails.
      */
-    public static boolean fundWallet(String amount, PaymentMethod.Priority priority, String apiKey)
+    public static void fundWallet(String amount, PaymentMethod.Priority priority, String apiKey)
             throws EasyPostException {
         PaymentMethodObject paymentMethodObject = getPaymentMethodByPriority(priority, apiKey);
 
@@ -80,8 +73,6 @@ public final class Billing extends EasyPostResource {
         // will attempt to serialize empty JSON to a PaymentMethod.class, that's fine
         request(RequestMethod.POST, String.format("%s/%s/%s/%s", EasyPost.API_BASE, paymentMethodObject.getEndpoint(),
                 paymentMethodObject.getId(), "charges"), params, PaymentMethod.class, apiKey);
-
-        return true;
     }
 
     /**

--- a/src/main/java/com/easypost/model/ReferralCustomer.java
+++ b/src/main/java/com/easypost/model/ReferralCustomer.java
@@ -66,11 +66,10 @@ public class ReferralCustomer extends BaseUser {
      *
      * @param email  Email of the referral user to update.
      * @param userId ID of the referral user to update.
-     * @return true if success.
      * @throws EasyPostException when the request fails.
      */
-    public static boolean updateEmail(String email, String userId) throws EasyPostException {
-        return updateEmail(email, userId, null);
+    public static void updateEmail(String email, String userId) throws EasyPostException {
+        updateEmail(email, userId, null);
     }
 
     /**
@@ -79,10 +78,9 @@ public class ReferralCustomer extends BaseUser {
      * @param email  Email of the referral user to update.
      * @param userId ID of the referral user to update.
      * @param apiKey API key to use in request (overrides default API key).
-     * @return true if success.
      * @throws EasyPostException when the request fails.
      */
-    public static boolean updateEmail(String email, String userId, String apiKey) throws EasyPostException {
+    public static void updateEmail(String email, String userId, String apiKey) throws EasyPostException {
         Map<String, Object> wrappedParams = new HashMap<>();
         Map<String, Object> params = new HashMap<>();
         params.put("email", email);
@@ -90,8 +88,6 @@ public class ReferralCustomer extends BaseUser {
 
         request(RequestMethod.PUT, String.format("%s/%s/%s", EasyPost.API_BASE, "referral_customers", userId),
                 wrappedParams, ReferralCustomer.class, apiKey);
-
-        return true;
     }
 
     /**

--- a/src/main/java/com/easypost/model/Tracker.java
+++ b/src/main/java/com/easypost/model/Tracker.java
@@ -334,11 +334,10 @@ public final class Tracker extends EasyPostResource {
      * Create a list of Trackers.
      *
      * @param params Map of parameters used to create the Trackers.
-     * @return whether the creation was successful.
      * @throws EasyPostException when the request fails.
      */
-    public static boolean createList(final Map<String, Object> params) throws EasyPostException {
-        return createList(params, null);
+    public static void createList(final Map<String, Object> params) throws EasyPostException {
+        createList(params, null);
     }
 
     /**
@@ -346,17 +345,14 @@ public final class Tracker extends EasyPostResource {
      *
      * @param params Map of parameters used to create the Trackers.
      * @param apiKey API key to use in request (overrides default API key).
-     * @return whether the creation was successful.
      * @throws EasyPostException when the request fails.
      */
-    public static boolean createList(final Map<String, Object> params, final String apiKey) throws EasyPostException {
+    public static void createList(final Map<String, Object> params, final String apiKey) throws EasyPostException {
         String createListUrl = String.format("%s/create_list", classURL(Tracker.class));
 
         Map<String, Object> newParams = new HashMap<String, Object>();
         newParams.put("trackers", params);
 
         request(RequestMethod.POST, createListUrl, newParams, Object.class, apiKey);
-        // This endpoint does not return a response so we return true here
-        return true;
     }
 }

--- a/src/test/java/com/easypost/BillingTest.java
+++ b/src/test/java/com/easypost/BillingTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class BillingTest {
     private static TestUtils.VCR vcr;
@@ -33,9 +33,7 @@ public final class BillingTest {
     public void testDeletePaymentMethod() throws EasyPostException {
         vcr.setUpTest("delete_payment_method");
 
-        boolean success = Billing.deletePaymentMethod(PaymentMethod.Priority.PRIMARY);
-
-        assertTrue(success);
+        assertDoesNotThrow(() -> Billing.deletePaymentMethod(PaymentMethod.Priority.PRIMARY));
     }
 
     /**
@@ -48,9 +46,7 @@ public final class BillingTest {
     public void testFundWallet() throws EasyPostException {
         vcr.setUpTest("fund_wallet");
 
-        boolean success = Billing.fundWallet("2000", PaymentMethod.Priority.PRIMARY);
-
-        assertTrue(success);
+        assertDoesNotThrow(() -> Billing.fundWallet("2000", PaymentMethod.Priority.PRIMARY));
     }
 
     /**

--- a/src/test/java/com/easypost/CarrierAccountTest.java
+++ b/src/test/java/com/easypost/CarrierAccountTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -135,7 +136,7 @@ public final class CarrierAccountTest {
 
         CarrierAccount carrierAccount = createBasicCarrierAccount();
 
-        carrierAccount.delete();
+        assertDoesNotThrow(() -> carrierAccount.delete());
     }
 
     /**

--- a/src/test/java/com/easypost/ReferralTest.java
+++ b/src/test/java/com/easypost/ReferralTest.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -70,9 +71,8 @@ public final class ReferralTest {
         vcr.setUpTest("update");
 
         ReferralCustomer referralUser = createReferral();
-        boolean response = ReferralCustomer.updateEmail("email@example.com", referralUser.getId());
 
-        assertTrue(response);
+        assertDoesNotThrow(() -> ReferralCustomer.updateEmail("email@example.com", referralUser.getId()));
     }
 
     /**

--- a/src/test/java/com/easypost/TrackerTest.java
+++ b/src/test/java/com/easypost/TrackerTest.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -119,9 +120,6 @@ public final class TrackerTest {
             params.put(String.valueOf(i), tracker);
         }
 
-        boolean response = Tracker.createList(params);
-
-        // This endpoint returns nothing so we assert the function returns true
-        assertTrue(response);
+        assertDoesNotThrow(() -> Tracker.createList(params));
     }
 }

--- a/src/test/java/com/easypost/UserTest.java
+++ b/src/test/java/com/easypost/UserTest.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -155,7 +156,7 @@ public final class UserTest {
 
         User user = createUser();
 
-        user.delete();
+        assertDoesNotThrow(() -> user.delete());
     }
 
     /**

--- a/src/test/java/com/easypost/WebhookTest.java
+++ b/src/test/java/com/easypost/WebhookTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -142,7 +143,7 @@ public final class WebhookTest {
         Webhook webhook = createBasicWebhook();
         Webhook retrievedWebhook = Webhook.retrieve(webhook.getId());
 
-        retrievedWebhook.delete();
+        assertDoesNotThrow(() -> retrievedWebhook.delete()); 
 
         testWebhookId = null; // need to disable post-test deletion for test to work
     }


### PR DESCRIPTION
# Description

- Converts return type from boolean to void in empty response body functions
  - `fundWallet()` and `deletePaymentMethod()` in Billing class
  - `createList()` in Tracker class
  - `updateEmail()` in ReferralCustomer class
 
# Testing

Current unit tests pass

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
