### PR TITLE
override equals() and hashcode()

### DIFF
--- a/src/main/java/com/easypost/net/EasyPostResource.java
+++ b/src/main/java/com/easypost/net/EasyPostResource.java
@@ -44,7 +44,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-// import java.util.Random;
 import java.util.Scanner;
 
 public abstract class EasyPostResource {

--- a/src/main/java/com/easypost/net/EasyPostResource.java
+++ b/src/main/java/com/easypost/net/EasyPostResource.java
@@ -44,7 +44,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
+// import java.util.Random;
 import java.util.Scanner;
 
 public abstract class EasyPostResource {
@@ -878,13 +878,11 @@ public abstract class EasyPostResource {
     /**
      * Override the hashCode method because it is needed when overriding equals().
      *
-     * @return A random number.
+     * @return The hashcode of current object.
      */
     @Override
     public int hashCode() {
-      Random random = new Random();
-
-      return random.nextInt();
+      return GSON.toJson(this).hashCode();
     }
 
     /**
@@ -895,9 +893,8 @@ public abstract class EasyPostResource {
      */
     @Override
     public boolean equals(Object object) {
-      Gson gson = new Gson();
-      String currentObject = gson.toJson(this);
-      String newObject = gson.toJson(object);
+      String currentObject = GSON.toJson(this);
+      String newObject = GSON.toJson(object);
 
       return currentObject.equals(newObject);
     }

--- a/src/main/java/com/easypost/net/EasyPostResource.java
+++ b/src/main/java/com/easypost/net/EasyPostResource.java
@@ -44,6 +44,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Scanner;
 
 public abstract class EasyPostResource {
@@ -874,4 +875,30 @@ public abstract class EasyPostResource {
         }
     }
 
+    /**
+     * Override the hashCode method because it is needed when overriding equals().
+     *
+     * @return A random number.
+     */
+    @Override
+    public int hashCode() {
+      Random random = new Random();
+
+      return random.nextInt();
+    }
+
+    /**
+     * Override the equals method, convert objects to Json strings for comparsion.
+     *
+     * @param object Object of any class.
+     * @return If two objects have the same properties.
+     */
+    @Override
+    public boolean equals(Object object) {
+      Gson gson = new Gson();
+      String currentObject = gson.toJson(this);
+      String newObject = gson.toJson(object);
+
+      return currentObject.equals(newObject);
+    }
 }

--- a/src/test/java/com/easypost/AddressTest.java
+++ b/src/test/java/com/easypost/AddressTest.java
@@ -131,7 +131,7 @@ public final class AddressTest {
         Address retrievedAddress = Address.retrieve(address.getId());
 
         assertInstanceOf(Address.class, retrievedAddress);
-        assertEquals(address.getId(), retrievedAddress.getId());
+        assertTrue(address.equals(retrievedAddress));
 
     }
 

--- a/src/test/java/com/easypost/CarrierAccountTest.java
+++ b/src/test/java/com/easypost/CarrierAccountTest.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -85,7 +84,7 @@ public final class CarrierAccountTest {
 
         assertInstanceOf(CarrierAccount.class, retrieveCarrierAccount);
         assertTrue(retrieveCarrierAccount.getId().startsWith("ca_"));
-        assertThat(carrierAccount).usingRecursiveComparison().isEqualTo(retrieveCarrierAccount);
+        assertTrue(carrierAccount.equals(retrieveCarrierAccount));
     }
 
     /**

--- a/src/test/java/com/easypost/CustomsInfoTest.java
+++ b/src/test/java/com/easypost/CustomsInfoTest.java
@@ -5,7 +5,6 @@ import com.easypost.model.CustomsInfo;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -62,6 +61,6 @@ public final class CustomsInfoTest {
         CustomsInfo retrievedCustomsInfo = CustomsInfo.retrieve(customsInfo.getId());
 
         assertInstanceOf(CustomsInfo.class, retrievedCustomsInfo);
-        assertThat(customsInfo).usingRecursiveComparison().isEqualTo(retrievedCustomsInfo);
+        assertTrue(customsInfo.equals(retrievedCustomsInfo));
     }
 }

--- a/src/test/java/com/easypost/CustomsItemTest.java
+++ b/src/test/java/com/easypost/CustomsItemTest.java
@@ -5,7 +5,6 @@ import com.easypost.model.CustomsItem;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -62,6 +61,6 @@ public final class CustomsItemTest {
         CustomsItem retrieveCustomsItem = CustomsItem.retrieve(customsItem.getId());
 
         assertInstanceOf(CustomsItem.class, customsItem);
-        assertThat(customsItem).usingRecursiveComparison().isEqualTo(retrieveCustomsItem);
+        assertTrue(customsItem.equals(retrieveCustomsItem));
     }
 }

--- a/src/test/java/com/easypost/ParcelTest.java
+++ b/src/test/java/com/easypost/ParcelTest.java
@@ -5,7 +5,6 @@ import com.easypost.model.Parcel;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -62,6 +61,6 @@ public final class ParcelTest {
         Parcel retrievedParcel = Parcel.retrieve(parcel.getId());
 
         assertInstanceOf(Parcel.class, retrievedParcel);
-        assertThat(parcel).usingRecursiveComparison().isEqualTo(retrievedParcel);
+        assertTrue(parcel.equals(retrievedParcel));
     }
 }

--- a/src/test/java/com/easypost/PickupTest.java
+++ b/src/test/java/com/easypost/PickupTest.java
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -78,7 +77,7 @@ public final class PickupTest {
         Pickup retrievedPickup = Pickup.retrieve(pickup.getId());
 
         assertInstanceOf(Pickup.class, retrievedPickup);
-        assertThat(pickup).usingRecursiveComparison().isEqualTo(retrievedPickup);
+        assertTrue(pickup.equals(retrievedPickup));
     }
 
     /**

--- a/src/test/java/com/easypost/RateTest.java
+++ b/src/test/java/com/easypost/RateTest.java
@@ -6,8 +6,8 @@ import com.easypost.model.Shipment;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class RateTest {
     private static TestUtils.VCR vcr;
@@ -37,6 +37,6 @@ public final class RateTest {
         Rate retrievedRate = Rate.retrieve(rate.getId());
 
         assertInstanceOf(Rate.class, rate);
-        assertThat(rate).usingRecursiveComparison().isEqualTo(retrievedRate);
+        assertTrue(rate.equals(retrievedRate));
     }
 }

--- a/src/test/java/com/easypost/RefundTest.java
+++ b/src/test/java/com/easypost/RefundTest.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -103,6 +102,6 @@ public final class RefundTest {
         Refund retrievedRefund = Refund.retrieve(refund.getId());
 
         assertInstanceOf(Refund.class, retrievedRefund);
-        assertThat(refund).usingRecursiveComparison().isEqualTo(retrievedRefund);
+        assertTrue(refund.equals(retrievedRefund));
     }
 }

--- a/src/test/java/com/easypost/ScanFormTest.java
+++ b/src/test/java/com/easypost/ScanFormTest.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -77,7 +76,7 @@ public final class ScanFormTest {
         ScanForm retrievedScanForm = ScanForm.retrieve(scanForm.getId());
 
         assertInstanceOf(ScanForm.class, retrievedScanForm);
-        assertThat(scanForm).usingRecursiveComparison().isEqualTo(retrievedScanForm);
+        assertTrue(scanForm.equals(retrievedScanForm));
     }
 
     /**

--- a/src/test/java/com/easypost/ShipmentTest.java
+++ b/src/test/java/com/easypost/ShipmentTest.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -84,7 +83,7 @@ public final class ShipmentTest {
         Shipment retrievedShipment = Shipment.retrieve(shipment.getId());
 
         assertInstanceOf(Shipment.class, retrievedShipment);
-        assertThat(shipment).usingRecursiveComparison().isEqualTo(retrievedShipment);
+        assertTrue(shipment.equals(retrievedShipment));
     }
 
     /**

--- a/src/test/java/com/easypost/WebhookTest.java
+++ b/src/test/java/com/easypost/WebhookTest.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -96,7 +95,7 @@ public final class WebhookTest {
         Webhook retrievedWebhook = Webhook.retrieve(webhook.getId());
 
         assertInstanceOf(Webhook.class, retrievedWebhook);
-        assertThat(webhook).usingRecursiveComparison().isEqualTo(retrievedWebhook);
+        assertTrue(webhook.equals(retrievedWebhook));
     }
 
     /**


### PR DESCRIPTION
# Description

Override `equals()` that convert objects to JSON strings for comparison, which compares two objects' properties
Override `hashcode()` is needed: https://www.baeldung.com/java-equals-hashcode-contracts#hashcode
Update unit tests with override `equals()`

# Testing

Current unit tests pass

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
