### PR TITLE
remove assertj dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,6 @@
             <version>2.8.9</version>
         </dependency>
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>3.22.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.8.2</version>


### PR DESCRIPTION
# Description

Remove `assertj` dependency since it's no longer being used, this will also make a dependency less on the `Test Dependencies` in our [Java Maven page](https://mvnrepository.com/artifact/com.easypost/easypost-api-client/5.10.0). We have overridden the `equal()` for object comparison in this [PR](https://github.com/EasyPost/easypost-java/pull/191)
 
# Testing

Current unit tests pass.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
