### PR TITLE
chore: re-add Gradle install info and specify VERSION info when using Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Add this to your project's POM:
 </dependency>
 ```
 
+### Gradle
+
+Add this to your project's build file:
+
+```groovy
+implementation "com.easypost:easypost-api-client:5.10.0"
+```
+
 **NOTE:** [Google Gson](http://code.google.com/p/google-gson/) is required.
 
 ## Usage

--- a/src/main/java-templates/com/easypost/EasyPost.java
+++ b/src/main/java-templates/com/easypost/EasyPost.java
@@ -8,12 +8,13 @@ import com.easypost.easyvcr.VCR;
  * This file exists as a template for the Templating Maven Plugin (https://www.mojohaus.org/templating-maven-plugin/)
  * If you notice the VERSION = ${project.version} below, that's an example of a template variable.
  * <p>
- * In Maven (and Gradle), you can set variables inside the pom.xml file
+ * In Maven, you can set variables inside the pom.xml file
  * (https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#available-variables)
  * <p>
  * The Templating Maven Plugin, at compile time, will extract these variables and add them into the source code.
  * <p>
  * Specifically here, VERSION = ${project.version} will be replaced with, i.e. VERSION = 1.0.0 when compiling the code.
+ * NOTE: The VERSION will not populate if built with Gradle.
  * <p>
  * The placement of this file is important.
  * The Templating Maven Plugin will look for any template files in this specific `java-templates` directory.


### PR DESCRIPTION
# Description

Adds install info for Gradle back to the README. Also clarifies info about building with Gradle (specifically the VERSION variable will not be populated).
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

NA
<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
