### PR TITLE
fix: coverage generation for coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: cargo install grcov
       - name: Convert coverage report
         if: github.ref == 'refs/heads/master'
-        run: grcov target/site/jacoco/jacoco.xml --output-type lcov > coverage.lcov
+        run: grcov target/site/jacoco/jacoco.xml --source-dir ./ --ignore "target/*" > coverage.lcov
       - name: Coveralls
         if: github.ref == 'refs/heads/master'
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
# Description

`grcov` previously didn't aggregate the path data correctly and was showing 0% coverage, this is fixed by passing a couple extra flags.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

I commented out the master branch check to see if it published to coveralls correctly which it did so this change definitely fixes the problem.

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
