### PR TITLE
Fix EasyVCR-related issues for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         javaversion: [ "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19" ]
@@ -46,7 +46,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: "./coverage.lcov"
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Run CheckStyle checks
@@ -57,7 +57,7 @@ jobs:
           checkstyle_config: easypost_java_style.xml
           tool_name: "style_enforcer"
   security:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Load Maven dependencies and CVE database cache

--- a/src/main/java/com/easypost/service/ReferralCustomerService.java
+++ b/src/main/java/com/easypost/service/ReferralCustomerService.java
@@ -14,13 +14,10 @@ import com.easypost.model.ReferralCustomerCollection;
 import com.easypost.utils.Utilities;
 
 import java.io.BufferedReader;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/test/cassettes/referral/referral_add_credit_card.json
+++ b/src/test/cassettes/referral/referral_add_credit_card.json
@@ -1,6 +1,6 @@
 [
   {
-    "recordedAt": 1669142059,
+    "recordedAt": 1670453545,
     "request": {
       "body": "",
       "method": "GET",
@@ -28,7 +28,7 @@
           "0"
         ],
         "x-node": [
-          "bigweb12nuq"
+          "bigweb3nuq"
         ],
         "x-frame-options": [
           "SAMEORIGIN"
@@ -55,17 +55,18 @@
           "1; mode\u003dblock"
         ],
         "x-ep-request-uuid": [
-          "816b7d7e637d162be0ed0b67003d3f7b"
+          "99d32e0663911929ec9f76e0001e67ad"
         ],
         "x-proxied": [
-          "extlb1nuq 29913d444b",
-          "intlb1nuq 29913d444b"
+          "extlb3wdc 29913d444b",
+          "intlb1wdc 29913d444b",
+          "intlb2nuq 29913d444b"
         ],
         "referrer-policy": [
           "strict-origin-when-cross-origin"
         ],
         "x-runtime": [
-          "0.017105"
+          "0.016522"
         ],
         "etag": [
           "W/\"86cc970265a111486b443bf66ef85e91\""
@@ -74,7 +75,7 @@
           "application/json; charset\u003dutf-8"
         ],
         "x-version-label": [
-          "easypost-202211211953-c7d3fecdcf-master"
+          "easypost-202212072114-cbd87d5dd7-master"
         ],
         "cache-control": [
           "private, no-cache, no-store"
@@ -86,12 +87,91 @@
       },
       "uri": "https://api.easypost.com/v2/partners/stripe_public_key"
     },
-    "duration": 400
+    "duration": 510
   },
   {
-    "recordedAt": 1669142064,
+    "recordedAt": 1670453546,
     "request": {
-      "body": "{\n  \"credit_card\": {\n    \"stripe_object_id\": \"tok_0M71IWDqT4huGUvdZspMYMfr\",\n    \"priority\": \"primary\"\n  }\n}",
+      "body": "",
+      "method": "POST",
+      "headers": {
+        "Content-Type": [
+          "application/x-www-form-urlencoded"
+        ]
+      },
+      "uri": "https://api.stripe.com/v1/tokens?card%5Bcvc%5D\u003dREDACTED\u0026card%5Bexp_year%5D\u003d2028\u0026card%5Bnumber%5D\u003dREDACTED\u0026card%5Bexp_month%5D\u003d5"
+    },
+    "response": {
+      "body": "{\n  \"livemode\": true,\n  \"created\": 1.670453546E9,\n  \"client_ip\": \"REDACTED\",\n  \"id\": \"tok_0MCWTWDqT4huGUvdRss7rShI\",\n  \"used\": false,\n  \"type\": \"card\",\n  \"card\": {\n    \"address_zip_check\": null,\n    \"country\": \"US\",\n    \"last4\": \"6170\",\n    \"funding\": \"credit\",\n    \"address_country\": null,\n    \"address_state\": null,\n    \"exp_month\": 5.0,\n    \"exp_year\": 2028.0,\n    \"address_city\": null,\n    \"tokenization_method\": null,\n    \"cvc_check\": \"unchecked\",\n    \"address_line2\": null,\n    \"address_line1\": null,\n    \"name\": null,\n    \"id\": \"card_0MCWTWDqT4huGUvdxJDpWTkZ\",\n    \"address_line1_check\": null,\n    \"address_zip\": null,\n    \"dynamic_last4\": null,\n    \"brand\": \"Visa\",\n    \"object\": \"card\"\n  },\n  \"object\": \"token\"\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 200 OK"
+        ],
+        "Server": [
+          "nginx"
+        ],
+        "Access-Control-Allow-Origin": [
+          "*"
+        ],
+        "Access-Control-Allow-Methods": [
+          "GET, POST, HEAD, OPTIONS, DELETE"
+        ],
+        "Idempotency-Key": [
+          "ceb6ba5b-6211-4bb5-8407-0a4112a6fd20"
+        ],
+        "Connection": [
+          "keep-alive"
+        ],
+        "Original-Request": [
+          "req_cvg4JaGUqXU2Re"
+        ],
+        "Stripe-Version": [
+          "2020-08-27"
+        ],
+        "Stripe-Should-Retry": [
+          "false"
+        ],
+        "Date": [
+          "Wed, 07 Dec 2022 22:52:26 GMT"
+        ],
+        "Strict-Transport-Security": [
+          "max-age\u003d63072000; includeSubDomains; preload"
+        ],
+        "Access-Control-Expose-Headers": [
+          "Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required"
+        ],
+        "Cache-Control": [
+          "no-cache, no-store"
+        ],
+        "Access-Control-Allow-Credentials": [
+          "true"
+        ],
+        "Access-Control-Max-Age": [
+          "300"
+        ],
+        "Content-Length": [
+          "720"
+        ],
+        "Request-Id": [
+          "req_cvg4JaGUqXU2Re"
+        ],
+        "Content-Type": [
+          "application/json"
+        ]
+      },
+      "status": {
+        "code": 200,
+        "message": "OK"
+      },
+      "uri": "https://api.stripe.com/v1/tokens?card%5Bcvc%5D\u003dREDACTED\u0026card%5Bexp_year%5D\u003d2028\u0026card%5Bnumber%5D\u003dREDACTED\u0026card%5Bexp_month%5D\u003d5"
+    },
+    "duration": 644
+  },
+  {
+    "recordedAt": 1670453550,
+    "request": {
+      "body": "{\n  \"credit_card\": {\n    \"stripe_object_id\": \"tok_0MCWTWDqT4huGUvdRss7rShI\",\n    \"priority\": \"primary\"\n  }\n}",
       "method": "POST",
       "headers": {
         "Accept-Charset": [
@@ -107,7 +187,7 @@
       "uri": "https://api.easypost.com/v2/credit_cards"
     },
     "response": {
-      "body": "{\n  \"last4\": \"6170\",\n  \"disabled_at\": null,\n  \"name\": null,\n  \"exp_month\": 5.0,\n  \"id\": \"card_5eeca4edec3045c8ada6ccd52824d6c1\",\n  \"exp_year\": 2028.0,\n  \"brand\": \"Visa\",\n  \"object\": \"CreditCard\"\n}",
+      "body": "{\n  \"last4\": \"6170\",\n  \"disabled_at\": null,\n  \"name\": null,\n  \"exp_month\": 5.0,\n  \"id\": \"card_4ad89a83939644e382b3520f41d0e51c\",\n  \"exp_year\": 2028.0,\n  \"brand\": \"Visa\",\n  \"object\": \"CreditCard\"\n}",
       "httpVersion": null,
       "headers": {
         "null": [
@@ -120,7 +200,7 @@
           "0"
         ],
         "x-node": [
-          "bigweb6nuq"
+          "bigweb4nuq"
         ],
         "x-frame-options": [
           "SAMEORIGIN"
@@ -147,7 +227,7 @@
           "1; mode\u003dblock"
         ],
         "x-ep-request-uuid": [
-          "d96d15b1637d162ce0ed0b81003bbeb2"
+          "e26b982c6391192aec7a46e100202d39"
         ],
         "x-proxied": [
           "extlb2nuq 29913d444b",
@@ -157,16 +237,16 @@
           "strict-origin-when-cross-origin"
         ],
         "x-runtime": [
-          "3.862250"
+          "4.135978"
         ],
         "etag": [
-          "W/\"195f283080f5458e3b2402386b36ff63\""
+          "W/\"1fdc43c736f661170d96af73b24c6201\""
         ],
         "content-type": [
           "application/json; charset\u003dutf-8"
         ],
         "x-version-label": [
-          "easypost-202211211953-c7d3fecdcf-master"
+          "easypost-202212072114-cbd87d5dd7-master"
         ],
         "cache-control": [
           "private, no-cache, no-store"
@@ -178,6 +258,6 @@
       },
       "uri": "https://api.easypost.com/v2/credit_cards"
     },
-    "duration": 4116
+    "duration": 4364
   }
 ]

--- a/src/test/cassettes/shipment/create_with_ids.json
+++ b/src/test/cassettes/shipment/create_with_ids.json
@@ -1,0 +1,385 @@
+[
+  {
+    "recordedAt": 1670455025,
+    "request": {
+      "body": "{\n  \"address\": {\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"city\": \"San Francisco\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Jack Sparrow\",\n    \"street1\": \"388 Townsend St\",\n    \"street2\": \"Apt 20\",\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\"\n  }\n}",
+      "method": "POST",
+      "headers": {
+        "Accept-Charset": [
+          "UTF-8"
+        ],
+        "User-Agent": [
+          "REDACTED"
+        ],
+        "Content-Type": [
+          "application/json"
+        ]
+      },
+      "uri": "https://api.easypost.com/v2/addresses"
+    },
+    "response": {
+      "body": "{\n  \"zip\": \"94107\",\n  \"country\": \"US\",\n  \"city\": \"San Francisco\",\n  \"created_at\": \"2022-12-07T23:17:05+00:00\",\n  \"verifications\": {},\n  \"mode\": \"test\",\n  \"federal_tax_id\": null,\n  \"state_tax_id\": null,\n  \"carrier_facility\": null,\n  \"residential\": null,\n  \"updated_at\": \"2022-12-07T23:17:05+00:00\",\n  \"phone\": \"REDACTED\",\n  \"name\": \"Jack Sparrow\",\n  \"company\": null,\n  \"street1\": \"388 Townsend St\",\n  \"id\": \"adr_43821a08768511ed84c9ac1f6b0a0d1e\",\n  \"street2\": \"Apt 20\",\n  \"state\": \"CA\",\n  \"email\": \"test@example.com\",\n  \"object\": \"Address\"\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 201 Created"
+        ],
+        "content-length": [
+          "461"
+        ],
+        "expires": [
+          "0"
+        ],
+        "x-node": [
+          "bigweb5nuq"
+        ],
+        "x-frame-options": [
+          "SAMEORIGIN"
+        ],
+        "x-backend": [
+          "easypost"
+        ],
+        "x-permitted-cross-domain-policies": [
+          "none"
+        ],
+        "x-download-options": [
+          "noopen"
+        ],
+        "strict-transport-security": [
+          "max-age\u003d31536000; includeSubDomains; preload"
+        ],
+        "pragma": [
+          "no-cache"
+        ],
+        "x-content-type-options": [
+          "nosniff"
+        ],
+        "x-xss-protection": [
+          "1; mode\u003dblock"
+        ],
+        "x-ep-request-uuid": [
+          "99d32e0863911ef1ecc4d5800020f0a2"
+        ],
+        "x-proxied": [
+          "extlb3wdc 29913d444b",
+          "intlb1wdc 29913d444b",
+          "intlb2nuq 29913d444b"
+        ],
+        "referrer-policy": [
+          "strict-origin-when-cross-origin"
+        ],
+        "x-runtime": [
+          "0.035075"
+        ],
+        "etag": [
+          "W/\"380c59261a413c83974002af97b10f59\""
+        ],
+        "content-type": [
+          "application/json; charset\u003dutf-8"
+        ],
+        "location": [
+          "/api/v2/addresses/adr_43821a08768511ed84c9ac1f6b0a0d1e"
+        ],
+        "x-version-label": [
+          "easypost-202212072114-cbd87d5dd7-master"
+        ],
+        "cache-control": [
+          "private, no-cache, no-store"
+        ]
+      },
+      "status": {
+        "code": 201,
+        "message": "Created"
+      },
+      "uri": "https://api.easypost.com/v2/addresses"
+    },
+    "duration": 339
+  },
+  {
+    "recordedAt": 1670455026,
+    "request": {
+      "body": "{\n  \"address\": {\n    \"zip\": \"90277\",\n    \"country\": \"US\",\n    \"city\": \"Redondo Beach\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"EasyPost\",\n    \"street1\": \"179 N Harbor Dr\",\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\"\n  }\n}",
+      "method": "POST",
+      "headers": {
+        "Accept-Charset": [
+          "UTF-8"
+        ],
+        "User-Agent": [
+          "REDACTED"
+        ],
+        "Content-Type": [
+          "application/json"
+        ]
+      },
+      "uri": "https://api.easypost.com/v2/addresses"
+    },
+    "response": {
+      "body": "{\n  \"zip\": \"90277\",\n  \"country\": \"US\",\n  \"city\": \"Redondo Beach\",\n  \"created_at\": \"2022-12-07T23:17:06+00:00\",\n  \"verifications\": {},\n  \"mode\": \"test\",\n  \"federal_tax_id\": null,\n  \"state_tax_id\": null,\n  \"carrier_facility\": null,\n  \"residential\": null,\n  \"updated_at\": \"2022-12-07T23:17:06+00:00\",\n  \"phone\": \"REDACTED\",\n  \"name\": \"EasyPost\",\n  \"company\": null,\n  \"street1\": \"179 N Harbor Dr\",\n  \"id\": \"adr_4413e7d5768511ed84fcac1f6b0a0d1e\",\n  \"street2\": null,\n  \"state\": \"CA\",\n  \"email\": \"test@example.com\",\n  \"object\": \"Address\"\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 201 Created"
+        ],
+        "content-length": [
+          "453"
+        ],
+        "expires": [
+          "0"
+        ],
+        "x-node": [
+          "bigweb12nuq"
+        ],
+        "x-frame-options": [
+          "SAMEORIGIN"
+        ],
+        "x-backend": [
+          "easypost"
+        ],
+        "x-permitted-cross-domain-policies": [
+          "none"
+        ],
+        "x-download-options": [
+          "noopen"
+        ],
+        "strict-transport-security": [
+          "max-age\u003d31536000; includeSubDomains; preload"
+        ],
+        "pragma": [
+          "no-cache"
+        ],
+        "x-content-type-options": [
+          "nosniff"
+        ],
+        "x-xss-protection": [
+          "1; mode\u003dblock"
+        ],
+        "x-ep-request-uuid": [
+          "8d038d9563911ef2ecb4511f00206086"
+        ],
+        "x-proxied": [
+          "extlb4wdc 29913d444b",
+          "intlb1wdc 29913d444b",
+          "intlb2nuq 29913d444b"
+        ],
+        "referrer-policy": [
+          "strict-origin-when-cross-origin"
+        ],
+        "x-runtime": [
+          "0.032367"
+        ],
+        "etag": [
+          "W/\"cf401370df190020379aa4f953339969\""
+        ],
+        "content-type": [
+          "application/json; charset\u003dutf-8"
+        ],
+        "location": [
+          "/api/v2/addresses/adr_4413e7d5768511ed84fcac1f6b0a0d1e"
+        ],
+        "x-version-label": [
+          "easypost-202212072114-cbd87d5dd7-master"
+        ],
+        "cache-control": [
+          "private, no-cache, no-store"
+        ]
+      },
+      "status": {
+        "code": 201,
+        "message": "Created"
+      },
+      "uri": "https://api.easypost.com/v2/addresses"
+    },
+    "duration": 548
+  },
+  {
+    "recordedAt": 1670455027,
+    "request": {
+      "body": "{\n  \"parcel\": {\n    \"length\": 10.0,\n    \"width\": 8.0,\n    \"weight\": 15.4,\n    \"height\": 4.0\n  }\n}",
+      "method": "POST",
+      "headers": {
+        "Accept-Charset": [
+          "UTF-8"
+        ],
+        "User-Agent": [
+          "REDACTED"
+        ],
+        "Content-Type": [
+          "application/json"
+        ]
+      },
+      "uri": "https://api.easypost.com/v2/parcels"
+    },
+    "response": {
+      "body": "{\n  \"mode\": \"test\",\n  \"updated_at\": \"2022-12-07T23:17:07Z\",\n  \"predefined_package\": null,\n  \"length\": 10.0,\n  \"width\": 8.0,\n  \"created_at\": \"2022-12-07T23:17:07Z\",\n  \"weight\": 15.4,\n  \"id\": \"prcl_4ff1d0decd374cee8938c4edd3f5d6c1\",\n  \"object\": \"Parcel\",\n  \"height\": 4.0\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 201 Created"
+        ],
+        "content-length": [
+          "229"
+        ],
+        "expires": [
+          "0"
+        ],
+        "x-node": [
+          "bigweb6nuq"
+        ],
+        "x-frame-options": [
+          "SAMEORIGIN"
+        ],
+        "x-backend": [
+          "easypost"
+        ],
+        "x-permitted-cross-domain-policies": [
+          "none"
+        ],
+        "x-download-options": [
+          "noopen"
+        ],
+        "strict-transport-security": [
+          "max-age\u003d31536000; includeSubDomains; preload"
+        ],
+        "pragma": [
+          "no-cache"
+        ],
+        "x-content-type-options": [
+          "nosniff"
+        ],
+        "x-xss-protection": [
+          "1; mode\u003dblock"
+        ],
+        "x-ep-request-uuid": [
+          "8d038d9563911ef2ecc687ed002060cd"
+        ],
+        "x-proxied": [
+          "extlb4wdc 29913d444b",
+          "intlb2wdc 29913d444b",
+          "intlb1nuq 29913d444b"
+        ],
+        "referrer-policy": [
+          "strict-origin-when-cross-origin"
+        ],
+        "x-runtime": [
+          "0.026363"
+        ],
+        "etag": [
+          "W/\"8d5f2bfc1068f11d504ffd08e0368f12\""
+        ],
+        "content-type": [
+          "application/json; charset\u003dutf-8"
+        ],
+        "location": [
+          "/api/prcl_4ff1d0decd374cee8938c4edd3f5d6c1/parcels"
+        ],
+        "x-version-label": [
+          "easypost-202212072114-cbd87d5dd7-master"
+        ],
+        "cache-control": [
+          "private, no-cache, no-store"
+        ]
+      },
+      "status": {
+        "code": 201,
+        "message": "Created"
+      },
+      "uri": "https://api.easypost.com/v2/parcels"
+    },
+    "duration": 650
+  },
+  {
+    "recordedAt": 1670455028,
+    "request": {
+      "body": "{\n  \"carbon_offset\": false,\n  \"shipment\": {\n    \"parcel\": {\n      \"id\": \"prcl_4ff1d0decd374cee8938c4edd3f5d6c1\"\n    },\n    \"to_address\": {\n      \"id\": \"adr_4413e7d5768511ed84fcac1f6b0a0d1e\"\n    },\n    \"from_address\": {\n      \"id\": \"adr_43821a08768511ed84c9ac1f6b0a0d1e\"\n    }\n  }\n}",
+      "method": "POST",
+      "headers": {
+        "Accept-Charset": [
+          "UTF-8"
+        ],
+        "User-Agent": [
+          "REDACTED"
+        ],
+        "Content-Type": [
+          "application/json"
+        ]
+      },
+      "uri": "https://api.easypost.com/v2/shipments"
+    },
+    "response": {
+      "body": "{\n  \"insurance\": null,\n  \"fees\": [],\n  \"batch_id\": null,\n  \"batch_message\": null,\n  \"batch_status\": null,\n  \"created_at\": \"2022-12-07T23:17:07Z\",\n  \"mode\": \"test\",\n  \"reference\": null,\n  \"usps_zone\": 4.0,\n  \"is_return\": false,\n  \"updated_at\": \"2022-12-07T23:17:08Z\",\n  \"selected_rate\": null,\n  \"options\": {\n    \"date_advance\": 0.0,\n    \"currency\": \"USD\",\n    \"payment\": {\n      \"type\": \"SENDER\"\n    }\n  },\n  \"tracker\": null,\n  \"return_address\": {\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"city\": \"San Francisco\",\n    \"created_at\": \"2022-12-07T23:17:05+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-12-07T23:17:05+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Jack Sparrow\",\n    \"company\": null,\n    \"street1\": \"388 Townsend St\",\n    \"id\": \"adr_43821a08768511ed84c9ac1f6b0a0d1e\",\n    \"street2\": \"Apt 20\",\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\",\n    \"object\": \"Address\"\n  },\n  \"id\": \"shp_a3959e2859dd4c299b68f3bd1ed93818\",\n  \"from_address\": {\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"city\": \"San Francisco\",\n    \"created_at\": \"2022-12-07T23:17:05+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-12-07T23:17:05+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Jack Sparrow\",\n    \"company\": null,\n    \"street1\": \"388 Townsend St\",\n    \"id\": \"adr_43821a08768511ed84c9ac1f6b0a0d1e\",\n    \"street2\": \"Apt 20\",\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\",\n    \"object\": \"Address\"\n  },\n  \"customs_info\": null,\n  \"postage_label\": null,\n  \"parcel\": {\n    \"mode\": \"test\",\n    \"updated_at\": \"2022-12-07T23:17:07Z\",\n    \"predefined_package\": null,\n    \"length\": 10.0,\n    \"width\": 8.0,\n    \"created_at\": \"2022-12-07T23:17:07Z\",\n    \"weight\": 15.4,\n    \"id\": \"prcl_4ff1d0decd374cee8938c4edd3f5d6c1\",\n    \"object\": \"Parcel\",\n    \"height\": 4.0\n  },\n  \"refund_status\": null,\n  \"buyer_address\": {\n    \"zip\": \"90277\",\n    \"country\": \"US\",\n    \"city\": \"Redondo Beach\",\n    \"created_at\": \"2022-12-07T23:17:06+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-12-07T23:17:06+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"EasyPost\",\n    \"company\": null,\n    \"street1\": \"179 N Harbor Dr\",\n    \"id\": \"adr_4413e7d5768511ed84fcac1f6b0a0d1e\",\n    \"street2\": null,\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\",\n    \"object\": \"Address\"\n  },\n  \"rates\": [\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"5.82\",\n      \"created_at\": \"2022-12-07T23:17:08Z\",\n      \"delivery_days\": 3.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_a3959e2859dd4c299b68f3bd1ed93818\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"5.82\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-12-07T23:17:08Z\",\n      \"rate\": \"5.82\",\n      \"service\": \"First\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": 3.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_ab1a021e1c044df7b049b543ac2dbc52\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"8.15\",\n      \"created_at\": \"2022-12-07T23:17:08Z\",\n      \"delivery_days\": 2.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_a3959e2859dd4c299b68f3bd1ed93818\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"9.75\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-12-07T23:17:08Z\",\n      \"rate\": \"8.15\",\n      \"service\": \"Priority\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": 2.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_b74645ffff644382a05fac849a68573f\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"29.75\",\n      \"created_at\": \"2022-12-07T23:17:08Z\",\n      \"delivery_days\": null,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_a3959e2859dd4c299b68f3bd1ed93818\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"33.85\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-12-07T23:17:08Z\",\n      \"rate\": \"29.75\",\n      \"service\": \"Express\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": null,\n      \"currency\": \"USD\",\n      \"id\": \"rate_4410f10912834761ae6c84d89d109176\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"8.00\",\n      \"created_at\": \"2022-12-07T23:17:08Z\",\n      \"delivery_days\": 5.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_a3959e2859dd4c299b68f3bd1ed93818\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"8.00\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-12-07T23:17:08Z\",\n      \"rate\": \"8.00\",\n      \"service\": \"ParcelSelect\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": 5.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_f11c4891cc184db3a35b6f6f855a0147\",\n      \"object\": \"Rate\"\n    }\n  ],\n  \"scan_form\": null,\n  \"to_address\": {\n    \"zip\": \"90277\",\n    \"country\": \"US\",\n    \"city\": \"Redondo Beach\",\n    \"created_at\": \"2022-12-07T23:17:06+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-12-07T23:17:06+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"EasyPost\",\n    \"company\": null,\n    \"street1\": \"179 N Harbor Dr\",\n    \"id\": \"adr_4413e7d5768511ed84fcac1f6b0a0d1e\",\n    \"street2\": null,\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\",\n    \"object\": \"Address\"\n  },\n  \"tracking_code\": null,\n  \"messages\": [\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_2cdc6fb96d99484e8631d7c9620dec24\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_e6db2c19d54c4025b852d0ad81ee7f4e\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_3e92a82adac444a58f032ebcd8eb9028\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_687017c7f80044ab942b697a9607c439\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_8031f3014d2b49dba089e5c14da57413\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_f363eb4e1b194798b015a07598be6ed4\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_1c4eecb124f841d7a51e7e53cdda6cd8\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_6924408886ad49ac9a8468804f2b52b7\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    }\n  ],\n  \"order_id\": null,\n  \"forms\": [],\n  \"status\": \"unknown\",\n  \"object\": \"Shipment\"\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 201 Created"
+        ],
+        "content-length": [
+          "5960"
+        ],
+        "expires": [
+          "0"
+        ],
+        "x-node": [
+          "bigweb5nuq"
+        ],
+        "x-frame-options": [
+          "SAMEORIGIN"
+        ],
+        "x-backend": [
+          "easypost"
+        ],
+        "x-permitted-cross-domain-policies": [
+          "none"
+        ],
+        "x-download-options": [
+          "noopen"
+        ],
+        "strict-transport-security": [
+          "max-age\u003d31536000; includeSubDomains; preload"
+        ],
+        "pragma": [
+          "no-cache"
+        ],
+        "x-content-type-options": [
+          "nosniff"
+        ],
+        "x-xss-protection": [
+          "1; mode\u003dblock"
+        ],
+        "x-ep-request-uuid": [
+          "e26b982f63911ef3f3ca193a0022aee1"
+        ],
+        "x-proxied": [
+          "extlb2nuq 29913d444b",
+          "intlb2nuq 29913d444b"
+        ],
+        "referrer-policy": [
+          "strict-origin-when-cross-origin"
+        ],
+        "x-runtime": [
+          "1.042671"
+        ],
+        "etag": [
+          "W/\"0afc3b71735e2139cd9fd648ff79ca42\""
+        ],
+        "content-type": [
+          "application/json; charset\u003dutf-8"
+        ],
+        "location": [
+          "/api/v2/shipments/shp_a3959e2859dd4c299b68f3bd1ed93818"
+        ],
+        "x-version-label": [
+          "easypost-202212072114-cbd87d5dd7-master"
+        ],
+        "cache-control": [
+          "private, no-cache, no-store"
+        ]
+      },
+      "status": {
+        "code": 201,
+        "message": "Created"
+      },
+      "uri": "https://api.easypost.com/v2/shipments"
+    },
+    "duration": 1292
+  }
+]

--- a/src/test/cassettes/shipment/create_with_ids.json
+++ b/src/test/cassettes/shipment/create_with_ids.json
@@ -1,6 +1,6 @@
 [
   {
-    "recordedAt": 1670455025,
+    "recordedAt": 1670532250,
     "request": {
       "body": "{\n  \"address\": {\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"city\": \"San Francisco\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Jack Sparrow\",\n    \"street1\": \"388 Townsend St\",\n    \"street2\": \"Apt 20\",\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\"\n  }\n}",
       "method": "POST",
@@ -18,7 +18,7 @@
       "uri": "https://api.easypost.com/v2/addresses"
     },
     "response": {
-      "body": "{\n  \"zip\": \"94107\",\n  \"country\": \"US\",\n  \"city\": \"San Francisco\",\n  \"created_at\": \"2022-12-07T23:17:05+00:00\",\n  \"verifications\": {},\n  \"mode\": \"test\",\n  \"federal_tax_id\": null,\n  \"state_tax_id\": null,\n  \"carrier_facility\": null,\n  \"residential\": null,\n  \"updated_at\": \"2022-12-07T23:17:05+00:00\",\n  \"phone\": \"REDACTED\",\n  \"name\": \"Jack Sparrow\",\n  \"company\": null,\n  \"street1\": \"388 Townsend St\",\n  \"id\": \"adr_43821a08768511ed84c9ac1f6b0a0d1e\",\n  \"street2\": \"Apt 20\",\n  \"state\": \"CA\",\n  \"email\": \"test@example.com\",\n  \"object\": \"Address\"\n}",
+      "body": "{\n  \"zip\": \"94107\",\n  \"country\": \"US\",\n  \"city\": \"San Francisco\",\n  \"created_at\": \"2022-12-08T20:44:10+00:00\",\n  \"verifications\": {},\n  \"mode\": \"test\",\n  \"federal_tax_id\": null,\n  \"state_tax_id\": null,\n  \"carrier_facility\": null,\n  \"residential\": null,\n  \"updated_at\": \"2022-12-08T20:44:10+00:00\",\n  \"phone\": \"REDACTED\",\n  \"name\": \"Jack Sparrow\",\n  \"company\": null,\n  \"street1\": \"388 Townsend St\",\n  \"id\": \"adr_113855d4773911ed9c27ac1f6bc72124\",\n  \"street2\": \"Apt 20\",\n  \"state\": \"CA\",\n  \"email\": \"test@example.com\",\n  \"object\": \"Address\"\n}",
       "httpVersion": null,
       "headers": {
         "null": [
@@ -31,7 +31,7 @@
           "0"
         ],
         "x-node": [
-          "bigweb5nuq"
+          "bigweb2nuq"
         ],
         "x-frame-options": [
           "SAMEORIGIN"
@@ -58,30 +58,30 @@
           "1; mode\u003dblock"
         ],
         "x-ep-request-uuid": [
-          "99d32e0863911ef1ecc4d5800020f0a2"
+          "8b57e25f63924c9afe7189cd000fb578"
         ],
         "x-proxied": [
-          "extlb3wdc 29913d444b",
+          "extlb4wdc 29913d444b",
           "intlb1wdc 29913d444b",
-          "intlb2nuq 29913d444b"
+          "intlb1nuq 29913d444b"
         ],
         "referrer-policy": [
           "strict-origin-when-cross-origin"
         ],
         "x-runtime": [
-          "0.035075"
+          "0.034476"
         ],
         "etag": [
-          "W/\"380c59261a413c83974002af97b10f59\""
+          "W/\"c7b7a601758a03f7d3213a791d98b888\""
         ],
         "content-type": [
           "application/json; charset\u003dutf-8"
         ],
         "location": [
-          "/api/v2/addresses/adr_43821a08768511ed84c9ac1f6b0a0d1e"
+          "/api/v2/addresses/adr_113855d4773911ed9c27ac1f6bc72124"
         ],
         "x-version-label": [
-          "easypost-202212072114-cbd87d5dd7-master"
+          "easypost-202212081958-674da0c6cf-master"
         ],
         "cache-control": [
           "private, no-cache, no-store"
@@ -93,12 +93,12 @@
       },
       "uri": "https://api.easypost.com/v2/addresses"
     },
-    "duration": 339
+    "duration": 401
   },
   {
-    "recordedAt": 1670455026,
+    "recordedAt": 1670532250,
     "request": {
-      "body": "{\n  \"address\": {\n    \"zip\": \"90277\",\n    \"country\": \"US\",\n    \"city\": \"Redondo Beach\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"EasyPost\",\n    \"street1\": \"179 N Harbor Dr\",\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\"\n  }\n}",
+      "body": "{\n  \"address\": {\n    \"zip\": \"90277\",\n    \"country\": \"US\",\n    \"city\": \"Redondo Beach\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Elizabeth Swan\",\n    \"street1\": \"179 N Harbor Dr\",\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\"\n  }\n}",
       "method": "POST",
       "headers": {
         "Accept-Charset": [
@@ -114,20 +114,20 @@
       "uri": "https://api.easypost.com/v2/addresses"
     },
     "response": {
-      "body": "{\n  \"zip\": \"90277\",\n  \"country\": \"US\",\n  \"city\": \"Redondo Beach\",\n  \"created_at\": \"2022-12-07T23:17:06+00:00\",\n  \"verifications\": {},\n  \"mode\": \"test\",\n  \"federal_tax_id\": null,\n  \"state_tax_id\": null,\n  \"carrier_facility\": null,\n  \"residential\": null,\n  \"updated_at\": \"2022-12-07T23:17:06+00:00\",\n  \"phone\": \"REDACTED\",\n  \"name\": \"EasyPost\",\n  \"company\": null,\n  \"street1\": \"179 N Harbor Dr\",\n  \"id\": \"adr_4413e7d5768511ed84fcac1f6b0a0d1e\",\n  \"street2\": null,\n  \"state\": \"CA\",\n  \"email\": \"test@example.com\",\n  \"object\": \"Address\"\n}",
+      "body": "{\n  \"zip\": \"90277\",\n  \"country\": \"US\",\n  \"city\": \"Redondo Beach\",\n  \"created_at\": \"2022-12-08T20:44:10+00:00\",\n  \"verifications\": {},\n  \"mode\": \"test\",\n  \"federal_tax_id\": null,\n  \"state_tax_id\": null,\n  \"carrier_facility\": null,\n  \"residential\": null,\n  \"updated_at\": \"2022-12-08T20:44:10+00:00\",\n  \"phone\": \"REDACTED\",\n  \"name\": \"Elizabeth Swan\",\n  \"company\": null,\n  \"street1\": \"179 N Harbor Dr\",\n  \"id\": \"adr_11916632773911ed8d47ac1f6bc7bdc6\",\n  \"street2\": null,\n  \"state\": \"CA\",\n  \"email\": \"test@example.com\",\n  \"object\": \"Address\"\n}",
       "httpVersion": null,
       "headers": {
         "null": [
           "HTTP/1.1 201 Created"
         ],
         "content-length": [
-          "453"
+          "459"
         ],
         "expires": [
           "0"
         ],
         "x-node": [
-          "bigweb12nuq"
+          "bigweb2nuq"
         ],
         "x-frame-options": [
           "SAMEORIGIN"
@@ -154,30 +154,29 @@
           "1; mode\u003dblock"
         ],
         "x-ep-request-uuid": [
-          "8d038d9563911ef2ecb4511f00206086"
+          "fbbd444663924c9afe7189cf0011d29e"
         ],
         "x-proxied": [
-          "extlb4wdc 29913d444b",
-          "intlb1wdc 29913d444b",
-          "intlb2nuq 29913d444b"
+          "extlb1nuq 29913d444b",
+          "intlb1nuq 29913d444b"
         ],
         "referrer-policy": [
           "strict-origin-when-cross-origin"
         ],
         "x-runtime": [
-          "0.032367"
+          "0.055236"
         ],
         "etag": [
-          "W/\"cf401370df190020379aa4f953339969\""
+          "W/\"045bd7e4282c3688d2602bd1c7e413cd\""
         ],
         "content-type": [
           "application/json; charset\u003dutf-8"
         ],
         "location": [
-          "/api/v2/addresses/adr_4413e7d5768511ed84fcac1f6b0a0d1e"
+          "/api/v2/addresses/adr_11916632773911ed8d47ac1f6bc7bdc6"
         ],
         "x-version-label": [
-          "easypost-202212072114-cbd87d5dd7-master"
+          "easypost-202212081958-674da0c6cf-master"
         ],
         "cache-control": [
           "private, no-cache, no-store"
@@ -189,10 +188,10 @@
       },
       "uri": "https://api.easypost.com/v2/addresses"
     },
-    "duration": 548
+    "duration": 210
   },
   {
-    "recordedAt": 1670455027,
+    "recordedAt": 1670532251,
     "request": {
       "body": "{\n  \"parcel\": {\n    \"length\": 10.0,\n    \"width\": 8.0,\n    \"weight\": 15.4,\n    \"height\": 4.0\n  }\n}",
       "method": "POST",
@@ -210,7 +209,7 @@
       "uri": "https://api.easypost.com/v2/parcels"
     },
     "response": {
-      "body": "{\n  \"mode\": \"test\",\n  \"updated_at\": \"2022-12-07T23:17:07Z\",\n  \"predefined_package\": null,\n  \"length\": 10.0,\n  \"width\": 8.0,\n  \"created_at\": \"2022-12-07T23:17:07Z\",\n  \"weight\": 15.4,\n  \"id\": \"prcl_4ff1d0decd374cee8938c4edd3f5d6c1\",\n  \"object\": \"Parcel\",\n  \"height\": 4.0\n}",
+      "body": "{\n  \"mode\": \"test\",\n  \"updated_at\": \"2022-12-08T20:44:11Z\",\n  \"predefined_package\": null,\n  \"length\": 10.0,\n  \"width\": 8.0,\n  \"created_at\": \"2022-12-08T20:44:11Z\",\n  \"weight\": 15.4,\n  \"id\": \"prcl_4fd654b687a94f449bb62c31ec8423cd\",\n  \"object\": \"Parcel\",\n  \"height\": 4.0\n}",
       "httpVersion": null,
       "headers": {
         "null": [
@@ -218,102 +217,6 @@
         ],
         "content-length": [
           "229"
-        ],
-        "expires": [
-          "0"
-        ],
-        "x-node": [
-          "bigweb6nuq"
-        ],
-        "x-frame-options": [
-          "SAMEORIGIN"
-        ],
-        "x-backend": [
-          "easypost"
-        ],
-        "x-permitted-cross-domain-policies": [
-          "none"
-        ],
-        "x-download-options": [
-          "noopen"
-        ],
-        "strict-transport-security": [
-          "max-age\u003d31536000; includeSubDomains; preload"
-        ],
-        "pragma": [
-          "no-cache"
-        ],
-        "x-content-type-options": [
-          "nosniff"
-        ],
-        "x-xss-protection": [
-          "1; mode\u003dblock"
-        ],
-        "x-ep-request-uuid": [
-          "8d038d9563911ef2ecc687ed002060cd"
-        ],
-        "x-proxied": [
-          "extlb4wdc 29913d444b",
-          "intlb2wdc 29913d444b",
-          "intlb1nuq 29913d444b"
-        ],
-        "referrer-policy": [
-          "strict-origin-when-cross-origin"
-        ],
-        "x-runtime": [
-          "0.026363"
-        ],
-        "etag": [
-          "W/\"8d5f2bfc1068f11d504ffd08e0368f12\""
-        ],
-        "content-type": [
-          "application/json; charset\u003dutf-8"
-        ],
-        "location": [
-          "/api/prcl_4ff1d0decd374cee8938c4edd3f5d6c1/parcels"
-        ],
-        "x-version-label": [
-          "easypost-202212072114-cbd87d5dd7-master"
-        ],
-        "cache-control": [
-          "private, no-cache, no-store"
-        ]
-      },
-      "status": {
-        "code": 201,
-        "message": "Created"
-      },
-      "uri": "https://api.easypost.com/v2/parcels"
-    },
-    "duration": 650
-  },
-  {
-    "recordedAt": 1670455028,
-    "request": {
-      "body": "{\n  \"carbon_offset\": false,\n  \"shipment\": {\n    \"parcel\": {\n      \"id\": \"prcl_4ff1d0decd374cee8938c4edd3f5d6c1\"\n    },\n    \"to_address\": {\n      \"id\": \"adr_4413e7d5768511ed84fcac1f6b0a0d1e\"\n    },\n    \"from_address\": {\n      \"id\": \"adr_43821a08768511ed84c9ac1f6b0a0d1e\"\n    }\n  }\n}",
-      "method": "POST",
-      "headers": {
-        "Accept-Charset": [
-          "UTF-8"
-        ],
-        "User-Agent": [
-          "REDACTED"
-        ],
-        "Content-Type": [
-          "application/json"
-        ]
-      },
-      "uri": "https://api.easypost.com/v2/shipments"
-    },
-    "response": {
-      "body": "{\n  \"insurance\": null,\n  \"fees\": [],\n  \"batch_id\": null,\n  \"batch_message\": null,\n  \"batch_status\": null,\n  \"created_at\": \"2022-12-07T23:17:07Z\",\n  \"mode\": \"test\",\n  \"reference\": null,\n  \"usps_zone\": 4.0,\n  \"is_return\": false,\n  \"updated_at\": \"2022-12-07T23:17:08Z\",\n  \"selected_rate\": null,\n  \"options\": {\n    \"date_advance\": 0.0,\n    \"currency\": \"USD\",\n    \"payment\": {\n      \"type\": \"SENDER\"\n    }\n  },\n  \"tracker\": null,\n  \"return_address\": {\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"city\": \"San Francisco\",\n    \"created_at\": \"2022-12-07T23:17:05+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-12-07T23:17:05+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Jack Sparrow\",\n    \"company\": null,\n    \"street1\": \"388 Townsend St\",\n    \"id\": \"adr_43821a08768511ed84c9ac1f6b0a0d1e\",\n    \"street2\": \"Apt 20\",\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\",\n    \"object\": \"Address\"\n  },\n  \"id\": \"shp_a3959e2859dd4c299b68f3bd1ed93818\",\n  \"from_address\": {\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"city\": \"San Francisco\",\n    \"created_at\": \"2022-12-07T23:17:05+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-12-07T23:17:05+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Jack Sparrow\",\n    \"company\": null,\n    \"street1\": \"388 Townsend St\",\n    \"id\": \"adr_43821a08768511ed84c9ac1f6b0a0d1e\",\n    \"street2\": \"Apt 20\",\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\",\n    \"object\": \"Address\"\n  },\n  \"customs_info\": null,\n  \"postage_label\": null,\n  \"parcel\": {\n    \"mode\": \"test\",\n    \"updated_at\": \"2022-12-07T23:17:07Z\",\n    \"predefined_package\": null,\n    \"length\": 10.0,\n    \"width\": 8.0,\n    \"created_at\": \"2022-12-07T23:17:07Z\",\n    \"weight\": 15.4,\n    \"id\": \"prcl_4ff1d0decd374cee8938c4edd3f5d6c1\",\n    \"object\": \"Parcel\",\n    \"height\": 4.0\n  },\n  \"refund_status\": null,\n  \"buyer_address\": {\n    \"zip\": \"90277\",\n    \"country\": \"US\",\n    \"city\": \"Redondo Beach\",\n    \"created_at\": \"2022-12-07T23:17:06+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-12-07T23:17:06+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"EasyPost\",\n    \"company\": null,\n    \"street1\": \"179 N Harbor Dr\",\n    \"id\": \"adr_4413e7d5768511ed84fcac1f6b0a0d1e\",\n    \"street2\": null,\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\",\n    \"object\": \"Address\"\n  },\n  \"rates\": [\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"5.82\",\n      \"created_at\": \"2022-12-07T23:17:08Z\",\n      \"delivery_days\": 3.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_a3959e2859dd4c299b68f3bd1ed93818\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"5.82\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-12-07T23:17:08Z\",\n      \"rate\": \"5.82\",\n      \"service\": \"First\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": 3.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_ab1a021e1c044df7b049b543ac2dbc52\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"8.15\",\n      \"created_at\": \"2022-12-07T23:17:08Z\",\n      \"delivery_days\": 2.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_a3959e2859dd4c299b68f3bd1ed93818\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"9.75\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-12-07T23:17:08Z\",\n      \"rate\": \"8.15\",\n      \"service\": \"Priority\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": 2.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_b74645ffff644382a05fac849a68573f\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"29.75\",\n      \"created_at\": \"2022-12-07T23:17:08Z\",\n      \"delivery_days\": null,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_a3959e2859dd4c299b68f3bd1ed93818\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"33.85\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-12-07T23:17:08Z\",\n      \"rate\": \"29.75\",\n      \"service\": \"Express\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": null,\n      \"currency\": \"USD\",\n      \"id\": \"rate_4410f10912834761ae6c84d89d109176\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"8.00\",\n      \"created_at\": \"2022-12-07T23:17:08Z\",\n      \"delivery_days\": 5.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_a3959e2859dd4c299b68f3bd1ed93818\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"8.00\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-12-07T23:17:08Z\",\n      \"rate\": \"8.00\",\n      \"service\": \"ParcelSelect\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": 5.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_f11c4891cc184db3a35b6f6f855a0147\",\n      \"object\": \"Rate\"\n    }\n  ],\n  \"scan_form\": null,\n  \"to_address\": {\n    \"zip\": \"90277\",\n    \"country\": \"US\",\n    \"city\": \"Redondo Beach\",\n    \"created_at\": \"2022-12-07T23:17:06+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-12-07T23:17:06+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"EasyPost\",\n    \"company\": null,\n    \"street1\": \"179 N Harbor Dr\",\n    \"id\": \"adr_4413e7d5768511ed84fcac1f6b0a0d1e\",\n    \"street2\": null,\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\",\n    \"object\": \"Address\"\n  },\n  \"tracking_code\": null,\n  \"messages\": [\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_2cdc6fb96d99484e8631d7c9620dec24\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_e6db2c19d54c4025b852d0ad81ee7f4e\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_3e92a82adac444a58f032ebcd8eb9028\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_687017c7f80044ab942b697a9607c439\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_8031f3014d2b49dba089e5c14da57413\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_f363eb4e1b194798b015a07598be6ed4\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_1c4eecb124f841d7a51e7e53cdda6cd8\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_6924408886ad49ac9a8468804f2b52b7\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    }\n  ],\n  \"order_id\": null,\n  \"forms\": [],\n  \"status\": \"unknown\",\n  \"object\": \"Shipment\"\n}",
-      "httpVersion": null,
-      "headers": {
-        "null": [
-          "HTTP/1.1 201 Created"
-        ],
-        "content-length": [
-          "5960"
         ],
         "expires": [
           "0"
@@ -346,29 +249,124 @@
           "1; mode\u003dblock"
         ],
         "x-ep-request-uuid": [
-          "e26b982f63911ef3f3ca193a0022aee1"
+          "fbbd444463924c9bfe7189d10011d2ea"
         ],
         "x-proxied": [
-          "extlb2nuq 29913d444b",
+          "extlb1nuq 29913d444b",
+          "intlb1nuq 29913d444b"
+        ],
+        "referrer-policy": [
+          "strict-origin-when-cross-origin"
+        ],
+        "x-runtime": [
+          "0.027685"
+        ],
+        "etag": [
+          "W/\"6cbd4a2b8928bf827f7efdfa947ab377\""
+        ],
+        "content-type": [
+          "application/json; charset\u003dutf-8"
+        ],
+        "location": [
+          "/api/prcl_4fd654b687a94f449bb62c31ec8423cd/parcels"
+        ],
+        "x-version-label": [
+          "easypost-202212081958-674da0c6cf-master"
+        ],
+        "cache-control": [
+          "private, no-cache, no-store"
+        ]
+      },
+      "status": {
+        "code": 201,
+        "message": "Created"
+      },
+      "uri": "https://api.easypost.com/v2/parcels"
+    },
+    "duration": 191
+  },
+  {
+    "recordedAt": 1670532252,
+    "request": {
+      "body": "{\n  \"carbon_offset\": false,\n  \"shipment\": {\n    \"parcel\": {\n      \"id\": \"prcl_4fd654b687a94f449bb62c31ec8423cd\"\n    },\n    \"to_address\": {\n      \"id\": \"adr_11916632773911ed8d47ac1f6bc7bdc6\"\n    },\n    \"from_address\": {\n      \"id\": \"adr_113855d4773911ed9c27ac1f6bc72124\"\n    }\n  }\n}",
+      "method": "POST",
+      "headers": {
+        "Accept-Charset": [
+          "UTF-8"
+        ],
+        "User-Agent": [
+          "REDACTED"
+        ],
+        "Content-Type": [
+          "application/json"
+        ]
+      },
+      "uri": "https://api.easypost.com/v2/shipments"
+    },
+    "response": {
+      "body": "{\n  \"insurance\": null,\n  \"fees\": [],\n  \"batch_id\": null,\n  \"batch_message\": null,\n  \"batch_status\": null,\n  \"created_at\": \"2022-12-08T20:44:11Z\",\n  \"mode\": \"test\",\n  \"reference\": null,\n  \"usps_zone\": 4.0,\n  \"is_return\": false,\n  \"updated_at\": \"2022-12-08T20:44:12Z\",\n  \"selected_rate\": null,\n  \"options\": {\n    \"date_advance\": 0.0,\n    \"currency\": \"USD\",\n    \"payment\": {\n      \"type\": \"SENDER\"\n    }\n  },\n  \"tracker\": null,\n  \"return_address\": {\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"city\": \"San Francisco\",\n    \"created_at\": \"2022-12-08T20:44:10+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-12-08T20:44:10+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Jack Sparrow\",\n    \"company\": null,\n    \"street1\": \"388 Townsend St\",\n    \"id\": \"adr_113855d4773911ed9c27ac1f6bc72124\",\n    \"street2\": \"Apt 20\",\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\",\n    \"object\": \"Address\"\n  },\n  \"id\": \"shp_d813e04339d94b8aa6867563c2766559\",\n  \"from_address\": {\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"city\": \"San Francisco\",\n    \"created_at\": \"2022-12-08T20:44:10+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-12-08T20:44:10+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Jack Sparrow\",\n    \"company\": null,\n    \"street1\": \"388 Townsend St\",\n    \"id\": \"adr_113855d4773911ed9c27ac1f6bc72124\",\n    \"street2\": \"Apt 20\",\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\",\n    \"object\": \"Address\"\n  },\n  \"customs_info\": null,\n  \"postage_label\": null,\n  \"parcel\": {\n    \"mode\": \"test\",\n    \"updated_at\": \"2022-12-08T20:44:11Z\",\n    \"predefined_package\": null,\n    \"length\": 10.0,\n    \"width\": 8.0,\n    \"created_at\": \"2022-12-08T20:44:11Z\",\n    \"weight\": 15.4,\n    \"id\": \"prcl_4fd654b687a94f449bb62c31ec8423cd\",\n    \"object\": \"Parcel\",\n    \"height\": 4.0\n  },\n  \"refund_status\": null,\n  \"buyer_address\": {\n    \"zip\": \"90277\",\n    \"country\": \"US\",\n    \"city\": \"Redondo Beach\",\n    \"created_at\": \"2022-12-08T20:44:10+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-12-08T20:44:10+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Elizabeth Swan\",\n    \"company\": null,\n    \"street1\": \"179 N Harbor Dr\",\n    \"id\": \"adr_11916632773911ed8d47ac1f6bc7bdc6\",\n    \"street2\": null,\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\",\n    \"object\": \"Address\"\n  },\n  \"rates\": [\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"8.15\",\n      \"created_at\": \"2022-12-08T20:44:12Z\",\n      \"delivery_days\": 2.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_d813e04339d94b8aa6867563c2766559\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"9.75\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-12-08T20:44:12Z\",\n      \"rate\": \"8.15\",\n      \"service\": \"Priority\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": 2.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_54e707b270574ac8879db3fabcc154db\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"29.75\",\n      \"created_at\": \"2022-12-08T20:44:12Z\",\n      \"delivery_days\": null,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_d813e04339d94b8aa6867563c2766559\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"33.85\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-12-08T20:44:12Z\",\n      \"rate\": \"29.75\",\n      \"service\": \"Express\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": null,\n      \"currency\": \"USD\",\n      \"id\": \"rate_8b89fd2d098e4c4c90f5e8467758a3f4\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"8.00\",\n      \"created_at\": \"2022-12-08T20:44:12Z\",\n      \"delivery_days\": 5.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_d813e04339d94b8aa6867563c2766559\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"8.00\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-12-08T20:44:12Z\",\n      \"rate\": \"8.00\",\n      \"service\": \"ParcelSelect\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": 5.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_8142865128134cd2b78b18fe020e8593\",\n      \"object\": \"Rate\"\n    },\n    {\n      \"carrier_account_id\": \"ca_f09befdb2e9c410e95c7622ea912c18c\",\n      \"list_rate\": \"5.82\",\n      \"created_at\": \"2022-12-08T20:44:12Z\",\n      \"delivery_days\": 3.0,\n      \"list_currency\": \"USD\",\n      \"shipment_id\": \"shp_d813e04339d94b8aa6867563c2766559\",\n      \"mode\": \"test\",\n      \"carrier\": \"USPS\",\n      \"delivery_date\": null,\n      \"delivery_date_guaranteed\": false,\n      \"retail_rate\": \"5.82\",\n      \"retail_currency\": \"USD\",\n      \"updated_at\": \"2022-12-08T20:44:12Z\",\n      \"rate\": \"5.82\",\n      \"service\": \"First\",\n      \"billing_type\": \"easypost\",\n      \"est_delivery_days\": 3.0,\n      \"currency\": \"USD\",\n      \"id\": \"rate_623d9e38b196463aa09f6049cc04d58d\",\n      \"object\": \"Rate\"\n    }\n  ],\n  \"scan_form\": null,\n  \"to_address\": {\n    \"zip\": \"90277\",\n    \"country\": \"US\",\n    \"city\": \"Redondo Beach\",\n    \"created_at\": \"2022-12-08T20:44:10+00:00\",\n    \"verifications\": {},\n    \"mode\": \"test\",\n    \"federal_tax_id\": null,\n    \"state_tax_id\": null,\n    \"carrier_facility\": null,\n    \"residential\": null,\n    \"updated_at\": \"2022-12-08T20:44:10+00:00\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Elizabeth Swan\",\n    \"company\": null,\n    \"street1\": \"179 N Harbor Dr\",\n    \"id\": \"adr_11916632773911ed8d47ac1f6bc7bdc6\",\n    \"street2\": null,\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\",\n    \"object\": \"Address\"\n  },\n  \"tracking_code\": null,\n  \"messages\": [\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_f363eb4e1b194798b015a07598be6ed4\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_8031f3014d2b49dba089e5c14da57413\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_3e92a82adac444a58f032ebcd8eb9028\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_6924408886ad49ac9a8468804f2b52b7\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_1c4eecb124f841d7a51e7e53cdda6cd8\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_e6db2c19d54c4025b852d0ad81ee7f4e\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_2cdc6fb96d99484e8631d7c9620dec24\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    },\n    {\n      \"carrier\": \"UPS\",\n      \"carrier_account_id\": \"ca_687017c7f80044ab942b697a9607c439\",\n      \"type\": \"rate_error\",\n      \"message\": \"Invalid Access License number\"\n    }\n  ],\n  \"order_id\": null,\n  \"forms\": [],\n  \"status\": \"unknown\",\n  \"object\": \"Shipment\"\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 201 Created"
+        ],
+        "content-length": [
+          "5972"
+        ],
+        "expires": [
+          "0"
+        ],
+        "x-node": [
+          "bigweb11nuq"
+        ],
+        "x-frame-options": [
+          "SAMEORIGIN"
+        ],
+        "x-backend": [
+          "easypost"
+        ],
+        "x-permitted-cross-domain-policies": [
+          "none"
+        ],
+        "x-download-options": [
+          "noopen"
+        ],
+        "strict-transport-security": [
+          "max-age\u003d31536000; includeSubDomains; preload"
+        ],
+        "pragma": [
+          "no-cache"
+        ],
+        "x-content-type-options": [
+          "nosniff"
+        ],
+        "x-xss-protection": [
+          "1; mode\u003dblock"
+        ],
+        "x-ep-request-uuid": [
+          "fbbd444563924c9bfe7189ea0011d325"
+        ],
+        "x-proxied": [
+          "extlb1nuq 29913d444b",
           "intlb2nuq 29913d444b"
         ],
         "referrer-policy": [
           "strict-origin-when-cross-origin"
         ],
         "x-runtime": [
-          "1.042671"
+          "0.736276"
         ],
         "etag": [
-          "W/\"0afc3b71735e2139cd9fd648ff79ca42\""
+          "W/\"8b7552338227e6523a0247a9740dbf53\""
         ],
         "content-type": [
           "application/json; charset\u003dutf-8"
         ],
         "location": [
-          "/api/v2/shipments/shp_a3959e2859dd4c299b68f3bd1ed93818"
+          "/api/v2/shipments/shp_d813e04339d94b8aa6867563c2766559"
         ],
         "x-version-label": [
-          "easypost-202212072114-cbd87d5dd7-master"
+          "easypost-202212081958-674da0c6cf-master"
         ],
         "cache-control": [
           "private, no-cache, no-store"
@@ -380,6 +378,6 @@
       },
       "uri": "https://api.easypost.com/v2/shipments"
     },
-    "duration": 1292
+    "duration": 908
   }
 ]

--- a/src/test/java/com/easypost/ReferralTest.java
+++ b/src/test/java/com/easypost/ReferralTest.java
@@ -110,7 +110,6 @@ public final class ReferralTest {
      * @throws EasyPostException when the request fails.
      */
     @Test
-    @Disabled // failing on replay likely because of urlencoding
     public void testReferralAddCreditCard() throws Exception {
         vcr.setUpTest("referral_add_credit_card");
 

--- a/src/test/java/com/easypost/ReferralTest.java
+++ b/src/test/java/com/easypost/ReferralTest.java
@@ -8,7 +8,6 @@ import com.easypost.model.ReferralCustomer;
 import com.easypost.model.ReferralCustomerCollection;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;

--- a/src/test/java/com/easypost/ShipmentTest.java
+++ b/src/test/java/com/easypost/ShipmentTest.java
@@ -13,7 +13,6 @@ import com.easypost.model.ShipmentCollection;
 import com.easypost.model.Smartrate;
 import com.easypost.model.SmartrateAccuracy;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/src/test/java/com/easypost/ShipmentTest.java
+++ b/src/test/java/com/easypost/ShipmentTest.java
@@ -344,14 +344,16 @@ public final class ShipmentTest {
      * @throws EasyPostException when the request fails.
      */
     @Test
-    @Disabled
-    // TODO: test is for some reason failing to pull a proper recording when playing
-    // back. Only test doing this
     public void testCreateWithIds() throws EasyPostException {
         vcr.setUpTest("create_with_ids");
 
-        Address fromAddress = vcr.client.address.create(Fixtures.caAddress1());
-        Address toAddress = vcr.client.address.create(Fixtures.caAddress1());
+        Map<String, Object> address1Data = Fixtures.caAddress1();
+        Map<String, Object> address2Data = Fixtures.caAddress2();
+        // VCR will overwrite the first address recording if the parameters are the exact same,
+        // which will cause us to lose the response from the first address creation and cause the replay to fail.
+        address2Data.put("name", "EasyPost");
+        Address fromAddress = vcr.client.address.create(address1Data);
+        Address toAddress = vcr.client.address.create(address2Data);
         Parcel parcel = vcr.client.parcel.create(Fixtures.basicParcel());
 
         Map<String, Object> shipmentData = Fixtures.basicShipment();

--- a/src/test/java/com/easypost/ShipmentTest.java
+++ b/src/test/java/com/easypost/ShipmentTest.java
@@ -346,13 +346,11 @@ public final class ShipmentTest {
     public void testCreateWithIds() throws EasyPostException {
         vcr.setUpTest("create_with_ids");
 
-        Map<String, Object> address1Data = Fixtures.caAddress1();
-        Map<String, Object> address2Data = Fixtures.caAddress2();
         // VCR will overwrite the first address recording if the parameters are the exact same,
         // which will cause us to lose the response from the first address creation and cause the replay to fail.
-        address2Data.put("name", "EasyPost");
-        Address fromAddress = vcr.client.address.create(address1Data);
-        Address toAddress = vcr.client.address.create(address2Data);
+        // So wee need to use two different addresses here.
+        Address fromAddress = vcr.client.address.create(Fixtures.caAddress1());
+        Address toAddress = vcr.client.address.create(Fixtures.caAddress2());
         Parcel parcel = vcr.client.parcel.create(Fixtures.basicParcel());
 
         Map<String, Object> shipmentData = Fixtures.basicShipment();


### PR DESCRIPTION
# Description

- Fix unit tests disabled due to EasyVCR issues:

Summary:
- Referral credit card - The API calls to Stripe use a temporary client that was not configured to use EasyVCR. API calls to Stripe were not being recorded/replayed, and instead live data was being used. The live API calls returned data that did not match expected data in later EasyPost API calls, causing it to fail.
  - The client used for Stripe calls has been configured to use EasyVCR on testing. Additional tweaks to the URL encoding for Stripe API calls fixed HTTP issues.
- Create shipment by IDs - Creating a shipment involves creating two addresses. Both API calls included the same exact request parameters. EasyVCR is configured to record a request if it does not already exist in the cassette (only considering request parameters, not response data). The first address API call was being lost during recording, causing a data mismatch on replay.
  - This unit test has been updated to have a different parameter for the second address creation API call, ensuring that both address creation calls are recorded due to different parameters, correcting the replay issues.

# Testing

- Re-enable disabled unit tests (no more disabled unit tests)

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
