### PR TITLE
Add Java 20 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        javaversion: [ "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19" ]
+        javaversion: [ "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20" ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK for compilation
         uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: "19" # Always use the latest JDK for building
+          java-version: "20" # Always use the latest JDK for building
       - name: Load Maven dependencies cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
# Description

It's everyone's favorite time of the year: March! Which means a new Java version: https://www.oracle.com/news/announcement/oracle-releases-java-20-2023-03-21/

# Testing

- Bump CI to test against 20, still using 8 as a min target

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
