### PR TITLE
Account for special parameters for `all()` and `getNextPage()` for shipments and trackers

### DIFF
--- a/src/main/java/com/easypost/model/Shipment.java
+++ b/src/main/java/com/easypost/model/Shipment.java
@@ -9,7 +9,7 @@ import com.easypost.utils.Utilities;
 import lombok.Getter;
 
 @Getter
-public final class Shipment extends EasyPostResource {
+public class Shipment extends EasyPostResource {
     private String reference;
     private Boolean isReturn;
     private Address toAddress;

--- a/src/main/java/com/easypost/model/ShipmentCollection.java
+++ b/src/main/java/com/easypost/model/ShipmentCollection.java
@@ -18,7 +18,7 @@ public class ShipmentCollection extends PaginatedCollection<Shipment> {
     private Boolean includeChildren;
 
     @Override
-    protected Map<String, Object> buildNextPageParameters(List<Shipment> shipments, Integer pageSize)
+    protected final Map<String, Object> buildNextPageParameters(List<Shipment> shipments, Integer pageSize)
             throws EndOfPaginationError {
         String lastId = shipments.get(shipments.size() - 1).getId();
 

--- a/src/main/java/com/easypost/model/ShipmentCollection.java
+++ b/src/main/java/com/easypost/model/ShipmentCollection.java
@@ -5,10 +5,17 @@ import java.util.Map;
 
 import com.easypost.exception.General.EndOfPaginationError;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
-public final class ShipmentCollection extends PaginatedCollection<Shipment> {
+public class ShipmentCollection extends PaginatedCollection<Shipment> {
     private List<Shipment> shipments;
+
+    @Setter
+    private Boolean purchased;
+
+    @Setter
+    private Boolean includeChildren;
 
     @Override
     protected Map<String, Object> buildNextPageParameters(List<Shipment> shipments, Integer pageSize)
@@ -20,6 +27,14 @@ public final class ShipmentCollection extends PaginatedCollection<Shipment> {
 
         if (pageSize != null) {
             parameters.put("page_size", pageSize);
+        }
+
+        // We only want to include these parameters if they are set (versus defaulting to false; anti-pattern)
+        if (purchased != null) {
+            parameters.put("purchased", purchased);
+        }
+        if (includeChildren != null) {
+            parameters.put("include_children", includeChildren);
         }
 
         return parameters;

--- a/src/main/java/com/easypost/model/Tracker.java
+++ b/src/main/java/com/easypost/model/Tracker.java
@@ -6,7 +6,7 @@ import java.util.List;
 import lombok.Getter;
 
 @Getter
-public final class Tracker extends EasyPostResource {
+public class Tracker extends EasyPostResource {
     private String trackingCode;
     private String status;
     private String shipmentId;

--- a/src/main/java/com/easypost/model/TrackerCollection.java
+++ b/src/main/java/com/easypost/model/TrackerCollection.java
@@ -5,10 +5,17 @@ import java.util.Map;
 
 import com.easypost.exception.General.EndOfPaginationError;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
-public final class TrackerCollection extends PaginatedCollection<Tracker> {
+public class TrackerCollection extends PaginatedCollection<Tracker> {
     private List<Tracker> trackers;
+
+    @Setter
+    private String trackingCode;
+
+    @Setter
+    private String carrier;
 
     @Override
     protected Map<String, Object> buildNextPageParameters(List<Tracker> trackers, Integer pageSize)
@@ -20,6 +27,14 @@ public final class TrackerCollection extends PaginatedCollection<Tracker> {
 
         if (pageSize != null) {
             parameters.put("page_size", pageSize);
+        }
+
+        // We only want to include these parameters if they are set (versus defaulting to false; anti-pattern)
+        if (trackingCode != null) {
+            parameters.put("tracking_code", trackingCode);
+        }
+        if (carrier != null) {
+            parameters.put("carrier", carrier);
         }
 
         return parameters;

--- a/src/main/java/com/easypost/model/TrackerCollection.java
+++ b/src/main/java/com/easypost/model/TrackerCollection.java
@@ -18,7 +18,7 @@ public class TrackerCollection extends PaginatedCollection<Tracker> {
     private String carrier;
 
     @Override
-    protected Map<String, Object> buildNextPageParameters(List<Tracker> trackers, Integer pageSize)
+    protected final Map<String, Object> buildNextPageParameters(List<Tracker> trackers, Integer pageSize)
             throws EndOfPaginationError {
         String lastId = trackers.get(trackers.size() - 1).getId();
 

--- a/src/main/java/com/easypost/service/ShipmentService.java
+++ b/src/main/java/com/easypost/service/ShipmentService.java
@@ -12,6 +12,7 @@ import com.easypost.model.Shipment;
 import com.easypost.model.SmartRate;
 import com.easypost.model.SmartrateAccuracy;
 import com.easypost.model.SmartrateCollection;
+import com.easypost.utils.InternalUtilities;
 import lombok.SneakyThrows;
 
 import java.util.HashMap;
@@ -84,7 +85,13 @@ public class ShipmentService {
     public ShipmentCollection all(final Map<String, Object> params) throws EasyPostException {
         String endpoint = "shipments";
 
-        return Requestor.request(RequestMethod.GET, endpoint, params, ShipmentCollection.class, client);
+        ShipmentCollection shipmentCollection =
+                Requestor.request(RequestMethod.GET, endpoint, params, ShipmentCollection.class, client);
+        // we store the params in the collection so that we can use them to get the next page
+        shipmentCollection.setPurchased(InternalUtilities.getOrDefault(params, "purchased", null));
+        shipmentCollection.setIncludeChildren(InternalUtilities.getOrDefault(params, "include_children", null));
+
+        return shipmentCollection;
     }
 
     /**

--- a/src/main/java/com/easypost/service/TrackerService.java
+++ b/src/main/java/com/easypost/service/TrackerService.java
@@ -6,6 +6,7 @@ import com.easypost.http.Requestor;
 import com.easypost.http.Requestor.RequestMethod;
 import com.easypost.model.TrackerCollection;
 import com.easypost.model.Tracker;
+import com.easypost.utils.InternalUtilities;
 import lombok.SneakyThrows;
 
 import java.util.HashMap;
@@ -63,7 +64,13 @@ public class TrackerService {
     public TrackerCollection all(final Map<String, Object> params) throws EasyPostException {
         String endpoint = "trackers";
 
-        return Requestor.request(RequestMethod.GET, endpoint, params, TrackerCollection.class, client);
+        TrackerCollection trackerCollection =
+                Requestor.request(RequestMethod.GET, endpoint, params, TrackerCollection.class, client);
+        // we store the params in the collection so that we can use them to get the next page
+        trackerCollection.setTrackingCode(InternalUtilities.getOrDefault(params, "tracking_code", null));
+        trackerCollection.setCarrier(InternalUtilities.getOrDefault(params, "carrier", null));
+
+        return trackerCollection;
     }
 
     /**

--- a/src/main/java/com/easypost/utils/InternalUtilities.java
+++ b/src/main/java/com/easypost/utils/InternalUtilities.java
@@ -1,6 +1,7 @@
 package com.easypost.utils;
 
 import com.easypost.exception.API.EncodingError;
+import com.easypost.model.PaginatedCollection;
 
 import java.net.URLEncoder;
 
@@ -36,5 +37,18 @@ public abstract class InternalUtilities {
         }
 
         return result.toString();
+    }
+
+    /**
+     * Extract a value from a Map, or return a default value if the key is not present.
+     * @param map Map to extract from
+     * @param key Key to extract
+     * @param defaultValue Default value to return if the key is not present
+     * @return Value from the map, or the default value if the key is not present
+     * @param <TElement> Type of the value to extract
+     */
+    public static <TElement> TElement getOrDefault(Map<String, Object> map, String key, TElement defaultValue) {
+        // The built-in Map<String, Object>.getOrDefault() method extracts a value of type Object, so this handles the cast.
+        return (TElement) map.getOrDefault(key, defaultValue);
     }
 }

--- a/src/main/java/com/easypost/utils/InternalUtilities.java
+++ b/src/main/java/com/easypost/utils/InternalUtilities.java
@@ -1,7 +1,6 @@
 package com.easypost.utils;
 
 import com.easypost.exception.API.EncodingError;
-import com.easypost.model.PaginatedCollection;
 
 import java.net.URLEncoder;
 
@@ -48,7 +47,8 @@ public abstract class InternalUtilities {
      * @param <TElement> Type of the value to extract
      */
     public static <TElement> TElement getOrDefault(Map<String, Object> map, String key, TElement defaultValue) {
-        // The built-in Map<String, Object>.getOrDefault() method extracts a value of type Object, so this handles the cast.
+        // The built-in Map<String, Object>.getOrDefault() method extracts a value of type Object,
+        // so this handles the cast.
         return (TElement) map.getOrDefault(key, defaultValue);
     }
 }

--- a/src/test/cassettes/shipment/all_parameter_hand_off.json
+++ b/src/test/cassettes/shipment/all_parameter_hand_off.json
@@ -1,0 +1,91 @@
+[
+  {
+    "recordedAt": 1680116312,
+    "request": {
+      "body": "",
+      "method": "GET",
+      "headers": {
+        "Accept-Charset": [
+          "UTF-8"
+        ],
+        "User-Agent": [
+          "REDACTED"
+        ]
+      },
+      "uri": "https://api.easypost.com/v2/shipments?%70%75%72%63%68%61%73%65%64\u003d%66%61%6C%73%65\u0026%70%61%67%65%5F%73%69%7A%65\u003d%35\u0026%69%6E%63%6C%75%64%65%5F%63%68%69%6C%64%72%65%6E\u003d%74%72%75%65"
+    },
+    "response": {
+      "body": "{\n  \"has_more\": false,\n  \"shipments\": []\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 200 OK"
+        ],
+        "content-length": [
+          "33"
+        ],
+        "expires": [
+          "0"
+        ],
+        "x-node": [
+          "bigweb3nuq"
+        ],
+        "x-frame-options": [
+          "SAMEORIGIN"
+        ],
+        "x-download-options": [
+          "noopen"
+        ],
+        "x-permitted-cross-domain-policies": [
+          "none"
+        ],
+        "x-backend": [
+          "easypost"
+        ],
+        "pragma": [
+          "no-cache"
+        ],
+        "strict-transport-security": [
+          "max-age\u003d31536000; includeSubDomains; preload"
+        ],
+        "x-xss-protection": [
+          "1; mode\u003dblock"
+        ],
+        "x-content-type-options": [
+          "nosniff"
+        ],
+        "x-ep-request-uuid": [
+          "730d5da864248a58e64f26c100037756"
+        ],
+        "x-proxied": [
+          "intlb1nuq a29e4ad05c",
+          "extlb1nuq a29e4ad05c"
+        ],
+        "referrer-policy": [
+          "strict-origin-when-cross-origin"
+        ],
+        "x-runtime": [
+          "0.032766"
+        ],
+        "content-type": [
+          "application/json; charset\u003dutf-8"
+        ],
+        "etag": [
+          "W/\"2f41284d43f60e5545923a32fd36976a\""
+        ],
+        "x-version-label": [
+          "easypost-202303291803-b399a149ad-master"
+        ],
+        "cache-control": [
+          "private, no-cache, no-store"
+        ]
+      },
+      "status": {
+        "code": 200,
+        "message": "OK"
+      },
+      "uri": "https://api.easypost.com/v2/shipments?%70%75%72%63%68%61%73%65%64\u003d%66%61%6C%73%65\u0026%70%61%67%65%5F%73%69%7A%65\u003d%35\u0026%69%6E%63%6C%75%64%65%5F%63%68%69%6C%64%72%65%6E\u003d%74%72%75%65"
+    },
+    "duration": 160
+  }
+]

--- a/src/test/cassettes/shipment/get_next_page_parameter_hand_off.json
+++ b/src/test/cassettes/shipment/get_next_page_parameter_hand_off.json
@@ -1,0 +1,95 @@
+[
+  {
+    "recordedAt": 1680115434,
+    "request": {
+      "body": "",
+      "method": "GET",
+      "headers": {
+        "Accept-Charset": [
+          "UTF-8"
+        ],
+        "User-Agent": [
+          "REDACTED"
+        ]
+      },
+      "uri": "https://api.easypost.com/v2/shipments?%70%75%72%63%68%61%73%65%64\u003d%66%61%6C%73%65\u0026%70%61%67%65%5F%73%69%7A%65\u003d%35\u0026%69%6E%63%6C%75%64%65%5F%63%68%69%6C%64%72%65%6E\u003d%74%72%75%65"
+    },
+    "response": {
+      "body": "{\n  \"has_more\": false,\n  \"shipments\": []\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 200 OK"
+        ],
+        "content-length": [
+          "33"
+        ],
+        "expires": [
+          "0"
+        ],
+        "x-node": [
+          "bigweb7nuq"
+        ],
+        "x-frame-options": [
+          "SAMEORIGIN"
+        ],
+        "x-download-options": [
+          "noopen"
+        ],
+        "x-permitted-cross-domain-policies": [
+          "none"
+        ],
+        "x-backend": [
+          "easypost"
+        ],
+        "pragma": [
+          "no-cache"
+        ],
+        "strict-transport-security": [
+          "max-age\u003d31536000; includeSubDomains; preload"
+        ],
+        "x-canary": [
+          "direct"
+        ],
+        "x-xss-protection": [
+          "1; mode\u003dblock"
+        ],
+        "x-content-type-options": [
+          "nosniff"
+        ],
+        "x-ep-request-uuid": [
+          "c617988c642486eae687377400022d7f"
+        ],
+        "x-proxied": [
+          "intlb2nuq a29e4ad05c",
+          "intlb1wdc a29e4ad05c",
+          "extlb4wdc a29e4ad05c"
+        ],
+        "referrer-policy": [
+          "strict-origin-when-cross-origin"
+        ],
+        "x-runtime": [
+          "0.028001"
+        ],
+        "content-type": [
+          "application/json; charset\u003dutf-8"
+        ],
+        "etag": [
+          "W/\"2f41284d43f60e5545923a32fd36976a\""
+        ],
+        "x-version-label": [
+          "easypost-202303291803-b399a149ad-master"
+        ],
+        "cache-control": [
+          "private, no-cache, no-store"
+        ]
+      },
+      "status": {
+        "code": 200,
+        "message": "OK"
+      },
+      "uri": "https://api.easypost.com/v2/shipments?%70%75%72%63%68%61%73%65%64\u003d%66%61%6C%73%65\u0026%70%61%67%65%5F%73%69%7A%65\u003d%35\u0026%69%6E%63%6C%75%64%65%5F%63%68%69%6C%64%72%65%6E\u003d%74%72%75%65"
+    },
+    "duration": 727
+  }
+]

--- a/src/test/cassettes/tracker/all_parameter_hand_off.json
+++ b/src/test/cassettes/tracker/all_parameter_hand_off.json
@@ -1,0 +1,91 @@
+[
+  {
+    "recordedAt": 1680116323,
+    "request": {
+      "body": "",
+      "method": "GET",
+      "headers": {
+        "Accept-Charset": [
+          "UTF-8"
+        ],
+        "User-Agent": [
+          "REDACTED"
+        ]
+      },
+      "uri": "https://api.easypost.com/v2/trackers?%70%61%67%65%5F%73%69%7A%65\u003d%35\u0026%74%72%61%63%6B%69%6E%67%5F%63%6F%64%65\u003d%73%6F%6D%65%74%68%69%6E%67\u0026%63%61%72%72%69%65%72\u003d%73%6F%6D%65%74%68%69%6E%67+%65%6C%73%65"
+    },
+    "response": {
+      "body": "{\n  \"trackers\": [],\n  \"has_more\": false\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 200 OK"
+        ],
+        "content-length": [
+          "32"
+        ],
+        "expires": [
+          "0"
+        ],
+        "x-node": [
+          "bigweb2nuq"
+        ],
+        "x-frame-options": [
+          "SAMEORIGIN"
+        ],
+        "x-download-options": [
+          "noopen"
+        ],
+        "x-permitted-cross-domain-policies": [
+          "none"
+        ],
+        "x-backend": [
+          "easypost"
+        ],
+        "pragma": [
+          "no-cache"
+        ],
+        "strict-transport-security": [
+          "max-age\u003d31536000; includeSubDomains; preload"
+        ],
+        "x-xss-protection": [
+          "1; mode\u003dblock"
+        ],
+        "x-content-type-options": [
+          "nosniff"
+        ],
+        "x-ep-request-uuid": [
+          "730d5dab64248a63e687aa4700037a99"
+        ],
+        "x-proxied": [
+          "intlb1nuq a29e4ad05c",
+          "extlb1nuq a29e4ad05c"
+        ],
+        "referrer-policy": [
+          "strict-origin-when-cross-origin"
+        ],
+        "x-runtime": [
+          "0.032262"
+        ],
+        "content-type": [
+          "application/json; charset\u003dutf-8"
+        ],
+        "etag": [
+          "W/\"279365d332866943a8f7d4b39c51f40e\""
+        ],
+        "x-version-label": [
+          "easypost-202303291803-b399a149ad-master"
+        ],
+        "cache-control": [
+          "private, no-cache, no-store"
+        ]
+      },
+      "status": {
+        "code": 200,
+        "message": "OK"
+      },
+      "uri": "https://api.easypost.com/v2/trackers?%70%61%67%65%5F%73%69%7A%65\u003d%35\u0026%74%72%61%63%6B%69%6E%67%5F%63%6F%64%65\u003d%73%6F%6D%65%74%68%69%6E%67\u0026%63%61%72%72%69%65%72\u003d%73%6F%6D%65%74%68%69%6E%67+%65%6C%73%65"
+    },
+    "duration": 147
+  }
+]

--- a/src/test/cassettes/tracker/get_next_page_parameter_hand_off.json
+++ b/src/test/cassettes/tracker/get_next_page_parameter_hand_off.json
@@ -1,0 +1,91 @@
+[
+  {
+    "recordedAt": 1680116324,
+    "request": {
+      "body": "",
+      "method": "GET",
+      "headers": {
+        "Accept-Charset": [
+          "UTF-8"
+        ],
+        "User-Agent": [
+          "REDACTED"
+        ]
+      },
+      "uri": "https://api.easypost.com/v2/trackers?%70%61%67%65%5F%73%69%7A%65\u003d%35\u0026%74%72%61%63%6B%69%6E%67%5F%63%6F%64%65\u003d%73%6F%6D%65%74%68%69%6E%67\u0026%63%61%72%72%69%65%72\u003d%73%6F%6D%65%74%68%69%6E%67+%65%6C%73%65"
+    },
+    "response": {
+      "body": "{\n  \"trackers\": [],\n  \"has_more\": false\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 200 OK"
+        ],
+        "content-length": [
+          "32"
+        ],
+        "expires": [
+          "0"
+        ],
+        "x-node": [
+          "bigweb1nuq"
+        ],
+        "x-frame-options": [
+          "SAMEORIGIN"
+        ],
+        "x-download-options": [
+          "noopen"
+        ],
+        "x-permitted-cross-domain-policies": [
+          "none"
+        ],
+        "x-backend": [
+          "easypost"
+        ],
+        "pragma": [
+          "no-cache"
+        ],
+        "strict-transport-security": [
+          "max-age\u003d31536000; includeSubDomains; preload"
+        ],
+        "x-xss-protection": [
+          "1; mode\u003dblock"
+        ],
+        "x-content-type-options": [
+          "nosniff"
+        ],
+        "x-ep-request-uuid": [
+          "730d5da464248a64e6894aac00037add"
+        ],
+        "x-proxied": [
+          "intlb2nuq a29e4ad05c",
+          "extlb1nuq a29e4ad05c"
+        ],
+        "referrer-policy": [
+          "strict-origin-when-cross-origin"
+        ],
+        "x-runtime": [
+          "0.040451"
+        ],
+        "content-type": [
+          "application/json; charset\u003dutf-8"
+        ],
+        "etag": [
+          "W/\"279365d332866943a8f7d4b39c51f40e\""
+        ],
+        "x-version-label": [
+          "easypost-202303291803-b399a149ad-master"
+        ],
+        "cache-control": [
+          "private, no-cache, no-store"
+        ]
+      },
+      "status": {
+        "code": 200,
+        "message": "OK"
+      },
+      "uri": "https://api.easypost.com/v2/trackers?%70%61%67%65%5F%73%69%7A%65\u003d%35\u0026%74%72%61%63%6B%69%6E%67%5F%63%6F%64%65\u003d%73%6F%6D%65%74%68%69%6E%67\u0026%63%61%72%72%69%65%72\u003d%73%6F%6D%65%74%68%69%6E%67+%65%6C%73%65"
+    },
+    "duration": 171
+  }
+]

--- a/src/test/java/com/easypost/ShipmentTest.java
+++ b/src/test/java/com/easypost/ShipmentTest.java
@@ -15,14 +15,12 @@ import com.easypost.model.SmartRate;
 import com.easypost.model.SmartrateAccuracy;
 import com.easypost.utils.Utilities;
 import com.google.common.collect.ImmutableList;
-import com.google.errorprone.annotations.Immutable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -199,27 +197,31 @@ public final class ShipmentTest {
 
         // Can't access protected method directly, need to make a temporary extended class, yay
         // Downside, ShipmentCollection and Shipment are no longer final because they need to be extended
-        class ExtendedShipmentCollection extends ShipmentCollection {
+        final class ExtendedShipmentCollection extends ShipmentCollection {
 
-            public ExtendedShipmentCollection(ShipmentCollection shipmentCollection) {
+            ExtendedShipmentCollection(ShipmentCollection shipmentCollection) {
                 setPurchased(shipmentCollection.getPurchased());
                 setIncludeChildren(shipmentCollection.getIncludeChildren());
             }
+
             @Override
             public List<Shipment> getShipments() {
 
-                class ExtendedShipment extends Shipment {
+                final class ExtendedShipment extends Shipment {
                     @Override
                     public String getId() {
                         return "shp_123";
                     }
                 }
+
                 return new ArrayList<Shipment>(ImmutableList.of(new ExtendedShipment()));
             }
+
             public Map<String, Object> getNextPageParams() throws EndOfPaginationError {
                 return super.buildNextPageParameters(getShipments(), null);
             }
         }
+
         ExtendedShipmentCollection extendedShipmentCollection = new ExtendedShipmentCollection(shipmentCollection);
         Map<String, Object> nextPageParams = extendedShipmentCollection.getNextPageParams();
 

--- a/src/test/java/com/easypost/TrackerTest.java
+++ b/src/test/java/com/easypost/TrackerTest.java
@@ -2,11 +2,15 @@ package com.easypost;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.exception.General.EndOfPaginationError;
+import com.easypost.model.Shipment;
+import com.easypost.model.ShipmentCollection;
 import com.easypost.model.Tracker;
 import com.easypost.model.TrackerCollection;
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -101,6 +105,30 @@ public final class TrackerTest {
     }
 
     /**
+     * Test the parameter handoff when retrieving all trackers.
+     *
+     * @throws EasyPostException when the request fails.
+     */
+    @Test
+    public void testAllParameterHandOff() throws EasyPostException {
+        vcr.setUpTest("all_parameter_hand_off");
+
+        String trackingCode = "something";
+        String carrier = "something else";
+
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("page_size", Fixtures.pageSize());
+
+        params.put("tracking_code", trackingCode);
+        params.put("carrier", carrier);
+
+        TrackerCollection trackerCollection = vcr.client.tracker.all(params);
+
+        assertEquals(trackingCode, trackerCollection.getTrackingCode());
+        assertEquals(carrier, trackerCollection.getCarrier());
+    }
+
+    /**
      * Test retrieving the next page.
      *
      * @throws EasyPostException when the request fails.
@@ -127,6 +155,56 @@ public final class TrackerTest {
         } catch (Exception e) { // Any other exception is a failure
             fail();
         }
+    }
+
+    /**
+     * Test the parameter handoff when constructing the next page parameter map.
+     *
+     * @throws EasyPostException when the request fails.
+     */
+    @Test
+    public void testGetNextPageParameterHandOff() throws EasyPostException {
+        vcr.setUpTest("get_next_page_parameter_hand_off");
+
+        String trackingCode = "something";
+        String carrier = "something else";
+
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("page_size", Fixtures.pageSize());
+
+        params.put("tracking_code", trackingCode);
+        params.put("carrier", carrier);
+
+        TrackerCollection trackerCollection = vcr.client.tracker.all(params);
+
+        // Can't access protected method directly, need to make a temporary extended class, yay
+        // Downside, TrackerCollection and Tracker are no longer final because they need to be extended
+        class ExtendedTrackerCollection extends TrackerCollection {
+
+            public ExtendedTrackerCollection(TrackerCollection trackerCollection) {
+                setTrackingCode(trackerCollection.getTrackingCode());
+                setCarrier(trackerCollection.getCarrier());
+            }
+            @Override
+            public List<Tracker> getTrackers() {
+
+                class ExtendedTracker extends Tracker {
+                    @Override
+                    public String getId() {
+                        return "trk_123";
+                    }
+                }
+                return new ArrayList<Tracker>(ImmutableList.of(new ExtendedTracker()));
+            }
+            public Map<String, Object> getNextPageParams() throws EndOfPaginationError {
+                return super.buildNextPageParameters(getTrackers(), null);
+            }
+        }
+        ExtendedTrackerCollection extendedShipmentCollection = new ExtendedTrackerCollection(trackerCollection);
+        Map<String, Object> nextPageParams = extendedShipmentCollection.getNextPageParams();
+
+        assertEquals(trackingCode, nextPageParams.get("tracking_code"));
+        assertEquals(carrier, nextPageParams.get("carrier"));
     }
 
     /**

--- a/src/test/java/com/easypost/TrackerTest.java
+++ b/src/test/java/com/easypost/TrackerTest.java
@@ -2,8 +2,6 @@ package com.easypost;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.exception.General.EndOfPaginationError;
-import com.easypost.model.Shipment;
-import com.easypost.model.ShipmentCollection;
 import com.easypost.model.Tracker;
 import com.easypost.model.TrackerCollection;
 import com.google.common.collect.ImmutableList;
@@ -179,27 +177,31 @@ public final class TrackerTest {
 
         // Can't access protected method directly, need to make a temporary extended class, yay
         // Downside, TrackerCollection and Tracker are no longer final because they need to be extended
-        class ExtendedTrackerCollection extends TrackerCollection {
+        final class ExtendedTrackerCollection extends TrackerCollection {
 
-            public ExtendedTrackerCollection(TrackerCollection trackerCollection) {
+            ExtendedTrackerCollection(TrackerCollection trackerCollection) {
                 setTrackingCode(trackerCollection.getTrackingCode());
                 setCarrier(trackerCollection.getCarrier());
             }
+
             @Override
             public List<Tracker> getTrackers() {
 
-                class ExtendedTracker extends Tracker {
+                final class ExtendedTracker extends Tracker {
                     @Override
                     public String getId() {
                         return "trk_123";
                     }
                 }
+
                 return new ArrayList<Tracker>(ImmutableList.of(new ExtendedTracker()));
             }
+
             public Map<String, Object> getNextPageParams() throws EndOfPaginationError {
                 return super.buildNextPageParameters(getTrackers(), null);
             }
         }
+
         ExtendedTrackerCollection extendedShipmentCollection = new ExtendedTrackerCollection(trackerCollection);
         Map<String, Object> nextPageParams = extendedShipmentCollection.getNextPageParams();
 


### PR DESCRIPTION
# Description

Java port of https://github.com/EasyPost/easypost-csharp/pull/424

# Testing

- Adds unit tests to ensure that parameters are being captured from parameter dictionary and stored in the XCollection objects
- Adds unit tests to ensure that parameters are being extracted from XCollection objects and reused in getNextPage parameter construction
  - Apologies for the hacky extended classes needed to test a protected function from a different namespace

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
