### PR TITLE
[chore] Fix coverage CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Install grcov
         if: github.ref == 'refs/heads/master'
-        run: cargo install grcov
+        run: cargo install grcov --version 0.8.13
       - name: Convert coverage report
         if: github.ref == 'refs/heads/master'
         run: grcov target/site/jacoco/jacoco.xml --source-dir ./ --ignore "target/*" > coverage.lcov


### PR DESCRIPTION
# Description

Our coverage step on CI (publishing coverage report when pushed to master) has been broken for a while due to an issue with one of the dependencies used in the flow.

I have personally confirmed that the latest version of the `grcov` tool used to convert reports (0.8.15) produces empty output files. The previous working version (0.8.13) still works.

This PR pins the version of `grcov` used to avoid this issue.

# Testing

 - Individually confirmed on local machine

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
