### PR TITLE
fix type for requestBody in Payload class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next release
+
+- Fixes the type for `requestBody` from Map to String for Payload class
+
 ## v6.4.0 (2023-04-04)
 
 - Adds `getNextPage` function to each service which retrieves the next page of a collection when the `has_more` key is present in the response (eg: `client.address.getNextPage(addressCollection)`)

--- a/src/main/java/com/easypost/model/Payload.java
+++ b/src/main/java/com/easypost/model/Payload.java
@@ -6,11 +6,11 @@ import lombok.Getter;
 
 @Getter
 public class Payload extends EasyPostResource {
-    private String requestUrl;
-    private Map<String, String> requestHeaders;
-    private Map<String, Object> requestBody;
-    private Map<String, String> responseHeaders;
-    private String responseBody;
     private int responseCode;
     private int totalTime;
+    private Map<String, String> requestHeaders;
+    private Map<String, String> responseHeaders;
+    private String requestBody;
+    private String requestUrl;
+    private String responseBody;
 }


### PR DESCRIPTION
# Description

We made a silly mistake on the type for `requestBody` in the `Payload` class. After doing some internal research, the type should be String instead of Map. This PR will close #246 

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
