### PR TITLE
[chore] Remove VCR as production dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Test suite tweaked so EasyVCR is no longer a production dependency
+
 ## v6.6.0 (2023-05-02)
 
 - Adds `retrieveEstimatedDeliveryDate` function to the Shipment class

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
             <groupId>com.easypost</groupId>
             <artifactId>easyvcr</artifactId>
             <version>0.5.2</version>
-            <scope>compile</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java-templates/com/easypost/EasyPost.java
+++ b/src/main/java-templates/com/easypost/EasyPost.java
@@ -1,6 +1,7 @@
 package com.easypost;
 
-import com.easypost.easyvcr.VCR;
+import javax.net.ssl.HttpsURLConnection;
+import java.util.function.Function;
 
 /**
  * Hello weary traveler, welcome to the EasyPost Java client library.
@@ -37,5 +38,5 @@ public abstract class EasyPost {
      * <p>
      * NOTE: This is meant for unit testing purposes only. Do not use in production.
      */
-    public static VCR _vcr = null;
+    public static Function<String, HttpsURLConnection> _vcrUrlFunction = null;
 }

--- a/src/main/java/com/easypost/http/Requestor.java
+++ b/src/main/java/com/easypost/http/Requestor.java
@@ -129,12 +129,8 @@ public abstract class Requestor {
                      InstantiationException | IllegalAccessException | InvocationTargetException e) {
                 throw new IOException(e);
             }
-        } else if (EasyPost._vcr != null) {
-            try {
-                conn = EasyPost._vcr.getHttpUrlConnection(url).openConnectionSecure();
-            } catch (Exception vcrException) {
-                throw new IOException(vcrException);
-            }
+        } else if (EasyPost._vcrUrlFunction != null) {
+            conn = EasyPost._vcrUrlFunction.apply(url);
         } else {
             URL urlObj = new URL(null, url);
             conn = (javax.net.ssl.HttpsURLConnection) urlObj.openConnection();

--- a/src/main/java/com/easypost/service/ReferralCustomerService.java
+++ b/src/main/java/com/easypost/service/ReferralCustomerService.java
@@ -207,12 +207,8 @@ public class ReferralCustomerService {
         URL stripeUrl = new URL("https://api.stripe.com/v1/tokens?" + encodedURL);
 
         HttpURLConnection conn;
-        if (EasyPost._vcr != null) {
-            try {
-                conn = EasyPost._vcr.getHttpUrlConnection(stripeUrl).openConnectionSecure();
-            } catch (Exception vcrException) {
-                throw new IOException(vcrException);
-            }
+        if (EasyPost._vcrUrlFunction != null) {
+            conn = EasyPost._vcrUrlFunction.apply(stripeUrl.toString());
         } else {
             conn = (HttpURLConnection) stripeUrl.openConnection();
         }

--- a/src/test/java/com/easypost/TestUtils.java
+++ b/src/test/java/com/easypost/TestUtils.java
@@ -12,11 +12,13 @@ import com.easypost.exception.General.MissingParameterError;
 import com.easypost.service.EasyPostClient;
 import com.google.common.collect.ImmutableList;
 
+import javax.net.ssl.HttpsURLConnection;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.function.Function;
 
 public abstract class TestUtils {
     public enum ApiKey {
@@ -233,8 +235,16 @@ public abstract class TestUtils {
                 vcr.replay();
             }
 
+            Function<String, HttpsURLConnection> vcrUrlFunction = (url) -> {
+                try {
+                    return vcr.getHttpUrlConnection(url).openConnectionSecure();
+                } catch (Exception vcrException) {
+                    throw new RuntimeException(vcrException);
+                }
+            };
+
             // set VCR to be used during requests
-            EasyPost._vcr = vcr;
+            EasyPost._vcrUrlFunction = vcrUrlFunction;
         }
     }
 }


### PR DESCRIPTION
# Description

Rather than storing a global VCR (requiring EasyVCR to be a production dependency), we now store a global Function that accepts a string and returns an `HttpsUrlConnection`. This function is set by the test suite to use the configured VCR, but this means that `EasyVCR` does not leave the test suite.

Should close #265 

# Testing

- All unit tests pass, cassettes replayed as normal after rebuild (suggests that function is working as expected, no impact on flow).
- Can confirm that EasyVCR is no longer downloaded during build/install process (accidentally kept an import during testing and compiler correctly complains about a missing import)

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
