### PR TITLE
clean up Java build warnings

### DIFF
--- a/src/main/java/com/easypost/service/ShipmentService.java
+++ b/src/main/java/com/easypost/service/ShipmentService.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import com.google.errorprone.annotations.InlineMe;
 
 public class ShipmentService {
     private final EasyPostClient client;
@@ -191,7 +192,9 @@ public class ShipmentService {
      * Deprecated: v5.5.0 - v7.0.0
      */
     @Deprecated
-    public List<SmartRate> getSmartrates(final String id, final Map<String, Object> params) throws EasyPostException {
+    @InlineMe(replacement = "this.smartrates(id, params)")
+    public final List<SmartRate> getSmartrates(final String id, final Map<String, Object> params)
+        throws EasyPostException {
         return this.smartrates(id, params);
     }
 
@@ -402,7 +405,11 @@ public class ShipmentService {
      * Deprecated: v5.5.0 - v7.0.0
      */
     @Deprecated
-    public SmartRate lowestSmartRate(final String id, int deliveryDay, String deliveryAccuracy)
+    @InlineMe(
+        replacement = "this.lowestSmartRate(id, deliveryDay, SmartrateAccuracy.getByKeyName(deliveryAccuracy))",
+        imports = "com.easypost.model.SmartrateAccuracy"
+    )
+    public final SmartRate lowestSmartRate(final String id, int deliveryDay, String deliveryAccuracy)
             throws EasyPostException {
         return this.lowestSmartRate(id, deliveryDay, SmartrateAccuracy.getByKeyName(deliveryAccuracy));
     }
@@ -436,8 +443,9 @@ public class ShipmentService {
      * Deprecated: v5.5.0 - v7.0.0
      */
     @Deprecated
-    public List<SmartRate> getSmartrates(final String id) throws EasyPostException {
-        return this.getSmartrates(id, null);
+    @InlineMe(replacement = "this.smartrates(id, null)")
+    public final List<SmartRate> getSmartrates(final String id) throws EasyPostException {
+        return this.smartrates(id, null);
     }
 
     /**
@@ -453,8 +461,12 @@ public class ShipmentService {
      * Deprecated: v5.5.0 - v7.0.0
      */
     @Deprecated
-    public SmartRate getLowestSmartRate(final List<SmartRate> smartRates, int deliveryDay, String deliveryAccuracy)
-            throws EasyPostException {
+    @InlineMe(replacement =
+        "this.findLowestSmartrate(smartRates, deliveryDay, SmartrateAccuracy.getByKeyName(deliveryAccuracy))",
+        imports = "com.easypost.model.SmartrateAccuracy"
+    )
+    public final SmartRate getLowestSmartRate(final List<SmartRate> smartRates,
+            int deliveryDay, String deliveryAccuracy) throws EasyPostException {
         return findLowestSmartrate(smartRates, deliveryDay, SmartrateAccuracy.getByKeyName(deliveryAccuracy));
     }
 

--- a/src/main/java/com/easypost/utils/Utilities.java
+++ b/src/main/java/com/easypost/utils/Utilities.java
@@ -9,6 +9,7 @@ import com.easypost.model.Rate;
 import com.easypost.model.SmartRate;
 import com.easypost.model.SmartrateAccuracy;
 import com.easypost.model.StatelessRate;
+import com.google.errorprone.annotations.InlineMe;
 
 import java.util.List;
 import java.util.Map;
@@ -151,6 +152,9 @@ public abstract class Utilities {
      * Deprecated: v5.5.0 - v7.0.0
      */
     @Deprecated
+    @InlineMe(replacement =
+        "Utilities.findLowestSmartrate(smartrates, deliveryDay, SmartrateAccuracy.getByKeyName(deliveryAccuracy))",
+        imports = {"com.easypost.model.SmartrateAccuracy", "com.easypost.utils.Utilities"})
     public static SmartRate getLowestSmartRate(final List<SmartRate> smartrates, int deliveryDay,
             String deliveryAccuracy) throws EasyPostException {
         return findLowestSmartrate(smartrates, deliveryDay, SmartrateAccuracy.getByKeyName(deliveryAccuracy));

--- a/src/test/java/com/easypost/Fixtures.java
+++ b/src/test/java/com/easypost/Fixtures.java
@@ -6,6 +6,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -283,7 +284,7 @@ public abstract class Fixtures {
             data = Files.readAllLines(Paths.get(fullFilePath), StandardCharsets.UTF_8)
                 .get(0).getBytes(Charset.defaultCharset());
         } catch (IOException error) {
-            error.printStackTrace();
+            throw new UncheckedIOException(error);
         }
 
         return data;


### PR DESCRIPTION
# Description

Clean up Java build warnings by:
* Adding `@InlineMe` to the deprecated function so that when users call the method tagged with `@InlineMe` will be migrated to the new method. This implementation is optional but it's worth adding it. 
* Removing the `printStackTrace()` and throw an exception instead

More resource: https://errorprone.info/docs/inlineme

# Testing

E2E ran **make clean publish-dry**

![Screenshot 2023-09-06 at 4 19 00 PM](https://github.com/EasyPost/easypost-java/assets/22759143/7ffbc691-6aee-479e-81db-6c2b0d6f53e1)

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
