### PR TITLE
[chore] Ignore vulnerability in DependencyCheck and bumped the version

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -3,11 +3,16 @@
     <suppress>
         <!--
         Below vulnerabilities are from outdated Protocol Buffers which is the dependency of Error Prone.
-        This will not affect our code
+        This will not affect our code.
         -->
         <vulnerabilityName>CVE-2022-3171</vulnerabilityName>
         <vulnerabilityName>CVE-2022-3509</vulnerabilityName>
         <vulnerabilityName>CVE-2022-3510</vulnerabilityName>
         <vulnerabilityName>CVE-2023-2976</vulnerabilityName>
+        <!--
+        Vulnerability in the Dependency Check itself, used during testing.
+        Will not affect end-users.
+        Ref: https://github.com/jeremylong/DependencyCheck/issues/5943 -->
+        <vulnerabilityName>CVE-2023-4759</vulnerabilityName>
     </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -329,7 +329,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>8.2.1</version>
+                <version>8.4.0</version>
                 <configuration>
                     <suppressionFile>dependency-check-suppressions.xml</suppressionFile>
                     <failBuildOnCVSS>7</failBuildOnCVSS>


### PR DESCRIPTION
# Description

The DependencyCheck plugin we use to scan for vulnerabilities in our library is, itself, vulnerable. This is a red herring that unfortunately causes our CI to fail.

This PR will ignore this known vulnerability for the time being.

This does NOT pass vulnerable code down to our end-users, as this is purely an issue with one of the plugins we use to test the library.

# Testing

- `make scan` calls dependency check as expected
- Dependency scan passes as expected (no current vulnerabilities other than the aforementioned vulnerability inside the now-removed Maven plugin)

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
