### PR TITLE
[fix] Address verification details lost during deserialization

### DIFF
--- a/src/main/java/com/easypost/Constants.java
+++ b/src/main/java/com/easypost/Constants.java
@@ -1,6 +1,8 @@
 package com.easypost;
 
 import com.easypost.http.HashMapSerializer;
+import com.easypost.model.AddressVerification;
+import com.easypost.model.AddressVerificationDeserializer;
 import com.easypost.model.Error;
 import com.easypost.model.ErrorDeserializer;
 import com.easypost.model.SmartrateCollection;
@@ -72,6 +74,7 @@ public abstract class Constants {
                 .registerTypeAdapter(HashMap.class, new HashMapSerializer())
                 .registerTypeAdapter(SmartrateCollection.class, new SmartrateCollectionDeserializer())
                 .registerTypeAdapter(Error.class, new ErrorDeserializer())
+                .registerTypeAdapter(AddressVerification.class, new AddressVerificationDeserializer())
                 .registerTypeAdapter(StatelessRate[].class, new StatelessRateDeserializer()).create();
         public static final Gson PRETTY_PRINT_GSON = new GsonBuilder().setPrettyPrinting().serializeNulls()
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();

--- a/src/main/java/com/easypost/model/AddressVerification.java
+++ b/src/main/java/com/easypost/model/AddressVerification.java
@@ -8,4 +8,31 @@ public final class AddressVerification {
     private Boolean success;
     private List<Error> errors;
     private AddressDetail details;
+
+    /**
+     * Set the success of this address verification object.
+     *
+     * @param success The success message.
+     */
+    void setSuccess(final boolean success) {
+        this.success = success;
+    }
+
+    /**
+     * Set the errors of this address verification object.
+     *
+     * @param errors The errors.
+     */
+    void setErrors(final List<Error> errors) {
+        this.errors = errors;
+    }
+
+    /**
+     * Set the details of this address verification object.
+     *
+     * @param details The details.
+     */
+    void setDetails(final AddressDetail details) {
+        this.details = details;
+    }
 }

--- a/src/main/java/com/easypost/model/AddressVerificationDeserializer.java
+++ b/src/main/java/com/easypost/model/AddressVerificationDeserializer.java
@@ -1,0 +1,75 @@
+package com.easypost.model;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+
+public final class AddressVerificationDeserializer implements JsonDeserializer<AddressVerification> {
+    /**
+     * Deserialize an AddressVerification from a JSON object.
+     *
+     * @param json    JSON object to deserialize.
+     * @param typeOfT Type of the object to deserialize.
+     * @param context Deserialization context.
+     * @return Deserialized AddressVerification object.
+     * @throws JsonParseException if the JSON object is not a valid SmartrateCollection.
+     */
+    @Override
+    public AddressVerification deserialize(final JsonElement json, final Type typeOfT,
+    final JsonDeserializationContext context) throws JsonParseException {
+        JsonObject jo = json.getAsJsonObject();
+
+        AddressVerification addressVerification = new AddressVerification();
+
+        boolean success = jo.get("success").getAsBoolean();
+        addressVerification.setSuccess(success);
+
+        AddressDetail details = context.deserialize(jo.get("details"), AddressDetail.class);
+        addressVerification.setDetails(details);
+
+        JsonElement errorsAsJson = jo.get("errors");
+        Gson gson = new Gson();
+
+        if (errorsAsJson != null) {
+            JsonArray errorsAsArray = errorsAsJson.getAsJsonArray();
+            ArrayList<Error> errors = new ArrayList<>();
+            for (JsonElement errorAsJson : errorsAsArray) {
+                JsonObject errorAsJsonObject = errorAsJson.getAsJsonObject();
+
+                Error error = new Error();
+
+                JsonElement code = errorAsJsonObject.get("code");
+                if (code != null) {
+                    error.setCode(code.getAsString());
+                }
+
+                JsonElement message = errorAsJsonObject.get("message");
+                if (message != null) {
+                    error.setMessage(message.getAsString());
+                }
+
+                JsonElement field = errorAsJsonObject.get("field");
+                if (field != null) {
+                    error.setField(field.getAsString());
+                }
+
+                JsonElement suggestion = errorAsJsonObject.get("suggestion");
+                if (suggestion != null && !suggestion.isJsonNull()) {
+                    error.setSuggestion(suggestion.getAsString());
+                }
+
+                errors.add(error);
+            }
+            addressVerification.setErrors(errors);
+        }
+
+        return addressVerification;
+    }
+}

--- a/src/main/java/com/easypost/model/Error.java
+++ b/src/main/java/com/easypost/model/Error.java
@@ -29,4 +29,31 @@ public final class Error {
     void setCode(final String code) {
         this.code = code;
     }
+
+    /**
+     * Set the errors of this error object.
+     *
+     * @param errors The errors.
+     */
+    void setErrors(final List<Error> errors) {
+        this.errors = errors;
+    }
+
+    /**
+     * Set the suggestion of this error object.
+     *
+     * @param suggestion The suggestion.
+     */
+    void setSuggestion(final String suggestion) {
+        this.suggestion = suggestion;
+    }
+
+    /**
+     * Set the field of this error object.
+     *
+     * @param field The field.
+     */
+    void setField(final String field) {
+        this.field = field;
+    }
 }

--- a/src/test/java/com/easypost/AddressTest.java
+++ b/src/test/java/com/easypost/AddressTest.java
@@ -5,6 +5,7 @@ import com.easypost.exception.EasyPostException;
 import com.easypost.exception.General.EndOfPaginationError;
 import com.easypost.model.Address;
 import com.easypost.model.AddressCollection;
+import com.easypost.model.Error;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -14,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -81,8 +83,14 @@ public final class AddressTest {
         assertEquals("417 MONTGOMERY ST FL 5", address.getStreet1());
 
         assertNotNull(address.getVerifications());
-        assertNotNull(address.getVerifications().getZip4().getErrors()); // Should have a error due to second line
-        assertNotNull(address.getVerifications().getDelivery().getErrors());
+
+        assertFalse(address.getVerifications().getDelivery().getErrors().isEmpty()); // should have at least one error
+        Error error = address.getVerifications().getDelivery().getErrors().get(0);
+        assertEquals("E.SECONDARY_INFORMATION.INVALID", error.getCode());
+
+        assertFalse(address.getVerifications().getZip4().getErrors().isEmpty()); // should have at least one error
+        error = address.getVerifications().getZip4().getErrors().get(0);
+        assertEquals("E.SECONDARY_INFORMATION.INVALID", error.getCode());
     }
 
     /**

--- a/src/test/java/com/easypost/AddressTest.java
+++ b/src/test/java/com/easypost/AddressTest.java
@@ -79,6 +79,10 @@ public final class AddressTest {
         assertInstanceOf(Address.class, address);
         assertTrue(address.getId().startsWith("adr_"));
         assertEquals("417 MONTGOMERY ST FL 5", address.getStreet1());
+
+        assertNotNull(address.getVerifications());
+        assertNotNull(address.getVerifications().getZip4().getErrors()); // Should have a error due to second line
+        assertNotNull(address.getVerifications().getDelivery().getErrors());
     }
 
     /**
@@ -222,7 +226,7 @@ public final class AddressTest {
 
         Address verifiedAddress = vcr.client.address.verify(address.getId());
 
-        assertInstanceOf(Address.class, address);
+        assertInstanceOf(Address.class, verifiedAddress);
         assertTrue(verifiedAddress.getId().startsWith("adr_"));
         assertEquals("388 TOWNSEND ST APT 20", verifiedAddress.getStreet1());
     }


### PR DESCRIPTION
# Description

Our current setup reuses the `Error` class to represent address verification errors. However, the `Error` class has a custom deserializer that is being called during typical JSON deserialization in our library. Hard-coded logic inside that deserializer was effectively causing deserialization of the hints for address verification to fail.

This PR introduces another custom deserializer, specifically for the `AddressVerification` class that handles deserializing address verification JSON without the `Error` deserializer getting in the way.

Closes #288 

# Testing

- Improved existing unit test to verify that deserialization worked properly (that address verification details were not lost during deserialization)

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
