### PR TITLE
[Fix] Public accessibility of `EasyPostTimeInTransitData` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Releease
+
+- Fix `EasyPostTimeInTransitData` class and `easypostTimeInTransitData` property of `EstimatedDeliveryDate` class being publicly inaccessible
+
 ## v7.1.0 (2024-01-08)
 
 - Adds `allChildren` function in User service to get a paginated list of child users

--- a/src/main/java/com/easypost/model/EasyPostTimeInTransitData.java
+++ b/src/main/java/com/easypost/model/EasyPostTimeInTransitData.java
@@ -1,0 +1,10 @@
+package com.easypost.model;
+
+import lombok.Getter;
+
+@Getter
+public class EasyPostTimeInTransitData {
+    private TimeInTransit daysInTransit;
+    private String easypostEstimatedDeliveryDate;
+    private String plannedShipDate;
+}

--- a/src/main/java/com/easypost/model/EstimatedDeliveryDate.java
+++ b/src/main/java/com/easypost/model/EstimatedDeliveryDate.java
@@ -8,9 +8,3 @@ public class EstimatedDeliveryDate {
     private Rate rate;
 }
 
-@Getter
-class EasyPostTimeInTransitData {
-    private TimeInTransit daysInTransit;
-    private String easypostEstimatedDeliveryDate;
-    private String plannedShipDate;
-}

--- a/src/test/java/com/easypost/ShipmentTest.java
+++ b/src/test/java/com/easypost/ShipmentTest.java
@@ -713,6 +713,9 @@ public final class ShipmentTest {
                 .retrieveEstimatedDeliveryDate(shipment.getId(), Fixtures.plannedShipDate());
         for (EstimatedDeliveryDate estimatedDeliveryDate : estimatedDeliveryDates) {
             assertNotNull(estimatedDeliveryDate.getEasypostTimeInTransitData());
+            assertNotNull(estimatedDeliveryDate.getEasypostTimeInTransitData().getEasypostEstimatedDeliveryDate());
+            assertNotNull(estimatedDeliveryDate.getEasypostTimeInTransitData().getDaysInTransit());
+            assertNotNull(estimatedDeliveryDate.getEasypostTimeInTransitData().getDaysInTransit().getPercentile99());
         }
     }
 }


### PR DESCRIPTION
# Description

`EasyPostTimeInTransitData` was not explicitly marked as public, making it inaccessible to end-users.

Closes #304 

# Testing

- Unit test updated to confirm class/property of `EstimatedDeliveryDate` is accessible

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
