### PR TITLE
[bug] Cannot determine payment method when funding/deleting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
 
-## Next release
+## Next Release
 
+- Fix payment method funding and deletion failures due to undetermined payment method type
 - Adds `refund` function in Insurance service for requesting a refund for a standalone insurance
 
 ## v7.1.1 (2024-03-21)

--- a/src/main/java/com/easypost/model/PaymentMethodObject.java
+++ b/src/main/java/com/easypost/model/PaymentMethodObject.java
@@ -59,9 +59,10 @@ public class PaymentMethodObject extends EasyPostResource {
         if (getId() == null) {
             return null;
         }
-        if (getId().startsWith("card_")) {
+        String objectType = getObject();
+        if (getId().startsWith("card_") || (objectType != null && objectType.equals("CreditCard"))) {
             type = PaymentMethodType.CREDIT_CARD;
-        } else if (getId().startsWith("bank_")) {
+        } else if (getId().startsWith("bank_") || (objectType != null && objectType.equals("BankAccount"))) {
             type = PaymentMethodType.BANK_ACCOUNT;
         }
         return type;

--- a/src/test/java/com/easypost/BillingTest.java
+++ b/src/test/java/com/easypost/BillingTest.java
@@ -32,7 +32,8 @@ public final class BillingTest {
             "y_payment_method\":{\"id\":\"bank_...\",\"disabled_at\":null,\"object\":null,\"name\":nu" +
             "ll,\"last4\":\"4444\",\"exp_month\":1,\"exp_year\":2025,\"brand\":\"Mastercard\"}}";
 
-    private PaymentMethod paymentMethodLegacyPrefixes = Constants.Http.GSON.fromJson(jsonResponseLegacyPrefixes, PaymentMethod.class);
+    private PaymentMethod paymentMethodLegacyPrefixes =
+            Constants.Http.GSON.fromJson(jsonResponseLegacyPrefixes, PaymentMethod.class);
 
     private static MockedStatic<Requestor> requestMock = Mockito.mockStatic(Requestor.class);
 


### PR DESCRIPTION
# Description

- Use payment method object type as fallback when determining type for fund, delete functions

# Testing

- Update, add unit test to confirm legacy (by ID prefix) and new (by object type) both work to determine payment method type

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
