### PR TITLE
[fix] ID field usage in string representation of EasyPost objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Next Release
 
-- Fix payment method funding and deletion failures due to undetermined payment method type
 - Adds `refund` function in Insurance service for requesting a refund for a standalone insurance
+- Fix payment method funding and deletion failures due to undetermined payment method type
+- Fix `toString` method for all EasyPost models
 
 ## v7.1.1 (2024-03-21)
 

--- a/src/main/java/com/easypost/model/EasyPostResource.java
+++ b/src/main/java/com/easypost/model/EasyPostResource.java
@@ -8,8 +8,6 @@
 
 package com.easypost.model;
 
-import java.lang.reflect.Field;
-
 import java.util.Date;
 
 import com.easypost.Constants;
@@ -30,27 +28,10 @@ public abstract class EasyPostResource {
      */
     @Override
     public String toString() {
-        return (String) this.getIdString();
-    }
-
-    /**
-     * Get the ID of the object.
-     *
-     * @return ID of the object.
-     */
-    private Object getIdString() {
-        try {
-            Field idField = this.getClass().getDeclaredField("id");
-            return idField.get(this);
-        } catch (SecurityException e) {
-            return "";
-        } catch (NoSuchFieldException e) {
-            return "";
-        } catch (IllegalArgumentException e) {
-            return "";
-        } catch (IllegalAccessException e) {
-            return "";
+        if (this.id == null) {
+            return String.format("<%s@%s>", this.getClass().getName(), System.identityHashCode(this));
         }
+        return String.format("<%s@%s id=%s>", this.getClass().getName(), System.identityHashCode(this), this.id);
     }
 
     /**
@@ -59,8 +40,9 @@ public abstract class EasyPostResource {
      * @return the JSON representation of the object.
      */
     public String prettyPrint() {
-        return String.format("<%s@%s id=%s> JSON: %s", this.getClass().getName(), System.identityHashCode(this),
-                this.getIdString(), Constants.Http.PRETTY_PRINT_GSON.toJson(this));
+        String identifier = this.toString();
+        String json = Constants.Http.PRETTY_PRINT_GSON.toJson(this);
+        return String.format("%s JSON: %s", identifier, json);
     }
 
     /**

--- a/src/test/cassettes/easypost_resource/pretty_print.json
+++ b/src/test/cassettes/easypost_resource/pretty_print.json
@@ -1,0 +1,94 @@
+[
+  {
+    "recordedAt": 1712770648,
+    "request": {
+      "body": "{\n  \"address\": {\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"city\": \"San Francisco\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Jack Sparrow\",\n    \"street1\": \"388 Townsend St\",\n    \"street2\": \"Apt 20\",\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\"\n  }\n}",
+      "method": "POST",
+      "headers": {
+        "Accept-Charset": [
+          "UTF-8"
+        ],
+        "User-Agent": [
+          "REDACTED"
+        ],
+        "Content-Type": [
+          "application/json"
+        ]
+      },
+      "uri": "https://api.easypost.com/v2/addresses"
+    },
+    "response": {
+      "body": "{\n  \"zip\": \"94107\",\n  \"country\": \"US\",\n  \"city\": \"San Francisco\",\n  \"created_at\": \"2024-04-10T17:37:28+00:00\",\n  \"verifications\": {},\n  \"mode\": \"test\",\n  \"federal_tax_id\": null,\n  \"state_tax_id\": null,\n  \"carrier_facility\": null,\n  \"residential\": null,\n  \"updated_at\": \"2024-04-10T17:37:28+00:00\",\n  \"phone\": \"REDACTED\",\n  \"name\": \"Jack Sparrow\",\n  \"company\": null,\n  \"street1\": \"388 Townsend St\",\n  \"id\": \"adr_006266a2f76111eea3d8ac1f6bc53342\",\n  \"street2\": \"Apt 20\",\n  \"state\": \"CA\",\n  \"email\": \"test@example.com\",\n  \"object\": \"Address\"\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 201 Created"
+        ],
+        "content-length": [
+          "461"
+        ],
+        "expires": [
+          "0"
+        ],
+        "x-node": [
+          "bigweb38nuq"
+        ],
+        "x-frame-options": [
+          "SAMEORIGIN"
+        ],
+        "x-download-options": [
+          "noopen"
+        ],
+        "x-permitted-cross-domain-policies": [
+          "none"
+        ],
+        "x-backend": [
+          "easypost"
+        ],
+        "pragma": [
+          "no-cache"
+        ],
+        "strict-transport-security": [
+          "max-age\u003d31536000; includeSubDomains; preload"
+        ],
+        "x-xss-protection": [
+          "1; mode\u003dblock"
+        ],
+        "x-content-type-options": [
+          "nosniff"
+        ],
+        "x-ep-request-uuid": [
+          "77b91a9f6616ce58e7996a030043e2b3"
+        ],
+        "x-proxied": [
+          "intlb4nuq 39c21b8207",
+          "extlb2nuq 60566a9ec2"
+        ],
+        "referrer-policy": [
+          "strict-origin-when-cross-origin"
+        ],
+        "x-runtime": [
+          "0.036852"
+        ],
+        "location": [
+          "/api/v2/addresses/adr_006266a2f76111eea3d8ac1f6bc53342"
+        ],
+        "content-type": [
+          "application/json; charset\u003dutf-8"
+        ],
+        "x-version-label": [
+          "easypost-202404101512-5c010fff78-master"
+        ],
+        "cache-control": [
+          "private, no-cache, no-store"
+        ]
+      },
+      "status": {
+        "code": 201,
+        "message": "Created"
+      },
+      "uri": "https://api.easypost.com/v2/addresses"
+    },
+    "duration": 229
+  }
+]

--- a/src/test/cassettes/easypost_resource/to_string.json
+++ b/src/test/cassettes/easypost_resource/to_string.json
@@ -1,0 +1,94 @@
+[
+  {
+    "recordedAt": 1712770647,
+    "request": {
+      "body": "{\n  \"address\": {\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"city\": \"San Francisco\",\n    \"phone\": \"REDACTED\",\n    \"name\": \"Jack Sparrow\",\n    \"street1\": \"388 Townsend St\",\n    \"street2\": \"Apt 20\",\n    \"state\": \"CA\",\n    \"email\": \"test@example.com\"\n  }\n}",
+      "method": "POST",
+      "headers": {
+        "Accept-Charset": [
+          "UTF-8"
+        ],
+        "User-Agent": [
+          "REDACTED"
+        ],
+        "Content-Type": [
+          "application/json"
+        ]
+      },
+      "uri": "https://api.easypost.com/v2/addresses"
+    },
+    "response": {
+      "body": "{\n  \"zip\": \"94107\",\n  \"country\": \"US\",\n  \"city\": \"San Francisco\",\n  \"created_at\": \"2024-04-10T17:37:28+00:00\",\n  \"verifications\": {},\n  \"mode\": \"test\",\n  \"federal_tax_id\": null,\n  \"state_tax_id\": null,\n  \"carrier_facility\": null,\n  \"residential\": null,\n  \"updated_at\": \"2024-04-10T17:37:28+00:00\",\n  \"phone\": \"REDACTED\",\n  \"name\": \"Jack Sparrow\",\n  \"company\": null,\n  \"street1\": \"388 Townsend St\",\n  \"id\": \"adr_0012aea9f76111ee8db6ac1f6bc539ae\",\n  \"street2\": \"Apt 20\",\n  \"state\": \"CA\",\n  \"email\": \"test@example.com\",\n  \"object\": \"Address\"\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 201 Created"
+        ],
+        "content-length": [
+          "461"
+        ],
+        "expires": [
+          "0"
+        ],
+        "x-node": [
+          "bigweb39nuq"
+        ],
+        "x-frame-options": [
+          "SAMEORIGIN"
+        ],
+        "x-download-options": [
+          "noopen"
+        ],
+        "x-permitted-cross-domain-policies": [
+          "none"
+        ],
+        "x-backend": [
+          "easypost"
+        ],
+        "pragma": [
+          "no-cache"
+        ],
+        "strict-transport-security": [
+          "max-age\u003d31536000; includeSubDomains; preload"
+        ],
+        "x-xss-protection": [
+          "1; mode\u003dblock"
+        ],
+        "x-content-type-options": [
+          "nosniff"
+        ],
+        "x-ep-request-uuid": [
+          "77b91aa26616ce57e7996a010043e236"
+        ],
+        "x-proxied": [
+          "intlb4nuq 39c21b8207",
+          "extlb2nuq 60566a9ec2"
+        ],
+        "referrer-policy": [
+          "strict-origin-when-cross-origin"
+        ],
+        "x-runtime": [
+          "0.037294"
+        ],
+        "location": [
+          "/api/v2/addresses/adr_0012aea9f76111ee8db6ac1f6bc539ae"
+        ],
+        "content-type": [
+          "application/json; charset\u003dutf-8"
+        ],
+        "x-version-label": [
+          "easypost-202404101512-5c010fff78-master"
+        ],
+        "cache-control": [
+          "private, no-cache, no-store"
+        ]
+      },
+      "status": {
+        "code": 201,
+        "message": "Created"
+      },
+      "uri": "https://api.easypost.com/v2/addresses"
+    },
+    "duration": 243
+  }
+]

--- a/src/test/java/com/easypost/EasyPostResourceTest.java
+++ b/src/test/java/com/easypost/EasyPostResourceTest.java
@@ -2,16 +2,9 @@ package com.easypost;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.Address;
-import com.easypost.model.CustomsItem;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class EasyPostResourceTest {

--- a/src/test/java/com/easypost/EasyPostResourceTest.java
+++ b/src/test/java/com/easypost/EasyPostResourceTest.java
@@ -1,0 +1,69 @@
+package com.easypost;
+
+import com.easypost.exception.EasyPostException;
+import com.easypost.model.Address;
+import com.easypost.model.CustomsItem;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public final class EasyPostResourceTest {
+    private static TestUtils.VCR vcr;
+
+    /**
+     * Set up the testing environment for this file.
+     *
+     * @throws EasyPostException when the request fails.
+     */
+    @BeforeAll
+    public static void setup() throws EasyPostException {
+        vcr = new TestUtils.VCR("easypost_resource", TestUtils.ApiKey.TEST);
+    }
+
+    /**
+     * Test string representation of an EasyPostResource.
+     *
+     * @throws EasyPostException when the request fails.
+     */
+    @Test
+    public void testToString() throws EasyPostException {
+        vcr.setUpTest("to_string");
+
+        Address address = vcr.client.address.create(Fixtures.caAddress1());
+
+        String stringRepresentation = address.toString();
+        String stringRepresentationRegex = "^<com\\.easypost\\.model\\.Address@\\d{10} id=adr_[a-f0-9]{32}>$";
+
+        boolean stringRepresentationMatches = stringRepresentation.matches(stringRepresentationRegex);
+
+        assertTrue(stringRepresentationMatches);
+    }
+
+    /**
+     * Test pretty print of an EasyPostResource.
+     *
+     * @throws EasyPostException when the request fails.
+     */
+    @Test
+    public void testPrettyPrint() throws EasyPostException {
+        vcr.setUpTest("pretty_print");
+
+        Address address = vcr.client.address.create(Fixtures.caAddress1());
+
+        String prettyPrint = address.prettyPrint();
+        String prettyPrintRegex = "> JSON: {";
+
+        // Partial regex matching is terrible in Java. Works in debug mode, not in run mode, possibly due to timing
+
+        boolean prettyPrintMatches = prettyPrint.contains(prettyPrintRegex);
+
+        assertTrue(prettyPrintMatches);
+    }
+}

--- a/src/test/java/com/easypost/EasyPostResourceTest.java
+++ b/src/test/java/com/easypost/EasyPostResourceTest.java
@@ -2,8 +2,12 @@ package com.easypost;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.Address;
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -32,11 +36,27 @@ public final class EasyPostResourceTest {
         Address address = vcr.client.address.create(Fixtures.caAddress1());
 
         String stringRepresentation = address.toString();
-        String stringRepresentationRegex = "^<com\\.easypost\\.model\\.Address@\\d{10} id=adr_[a-f0-9]{32}>$";
+        List<String> substringsToContain = new ArrayList<String>(ImmutableList.of(
+                "<",
+                address.getClass().getName(),
+                "@",
+                "" + System.identityHashCode(address), // cast to string
+                " id=",
+                address.getId(),
+                ">"
+        ));
 
-        boolean stringRepresentationMatches = stringRepresentation.matches(stringRepresentationRegex);
+        // Regex matching doesn't work in run mode, only in debug mode (timing issue?)
+        boolean matches = false;
 
-        assertTrue(stringRepresentationMatches);
+        for (String substring : substringsToContain) {
+            matches = stringRepresentation.contains(substring);
+            if (!matches) {
+                break;
+            }
+        }
+
+        assertTrue(matches);
     }
 
     /**
@@ -51,12 +71,29 @@ public final class EasyPostResourceTest {
         Address address = vcr.client.address.create(Fixtures.caAddress1());
 
         String prettyPrint = address.prettyPrint();
-        String prettyPrintRegex = "> JSON: {";
 
-        // Partial regex matching is terrible in Java. Works in debug mode, not in run mode, possibly due to timing
+        List<String> substringsToContain = new ArrayList<String>(ImmutableList.of(
+            "<",
+            address.getClass().getName(),
+            "@",
+            "" + System.identityHashCode(address), // cast to string
+            " id=",
+            address.getId(),
+            ">",
+            " JSON: {",
+            "}"
+        ));
 
-        boolean prettyPrintMatches = prettyPrint.contains(prettyPrintRegex);
+        // Regex matching doesn't work in run mode, only in debug mode (timing issue?)
+        boolean matches = false;
 
-        assertTrue(prettyPrintMatches);
+        for (String substring : substringsToContain) {
+            matches = prettyPrint.contains(substring);
+            if (!matches) {
+                break;
+            }
+        }
+
+        assertTrue(matches);
     }
 }


### PR DESCRIPTION
# Description

Previous method of reflection to retrieve the `id` of an `EasyPostResource` often failed, resulting in fallback to empty string. As a result, the string representation of any `EasyPostResource` was often an empty string.

New method improves `toString` calculation, including accounting for present/non-present `id` field (ephemeral objects).

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
