### PR TITLE
[fix] Invalid `Fields` structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Fix `Fields` serialization bug causing carrier account operations to fail
+
 ## v7.2.0 (2024-04-10)
 
 - Adds `refund` function in Insurance service for requesting a refund for a standalone insurance

--- a/src/main/java/com/easypost/model/CarrierAccount.java
+++ b/src/main/java/com/easypost/model/CarrierAccount.java
@@ -8,6 +8,7 @@ public final class CarrierAccount extends EasyPostResource {
     private String type;
     private Fields fields;
     private boolean clone;
+    private String logo;
     private String readable;
     private String description;
     private String reference;

--- a/src/main/java/com/easypost/model/Field.java
+++ b/src/main/java/com/easypost/model/Field.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 
 @Getter
 public class Field extends EasyPostResource {
-    private String key;
     private String visibility;
     private String label;
     private String value;

--- a/src/main/java/com/easypost/model/Fields.java
+++ b/src/main/java/com/easypost/model/Fields.java
@@ -2,6 +2,12 @@ package com.easypost.model;
 
 import lombok.Getter;
 
+import java.util.Map;
+
 @Getter
 public class Fields extends EasyPostResource {
+    private Map<String, Field> credentials;
+    private Map<String, Field> testCredentials;
+    private boolean autoLink;
+    private boolean customWorkflow;
 }

--- a/src/test/java/com/easypost/BillingTest.java
+++ b/src/test/java/com/easypost/BillingTest.java
@@ -25,15 +25,6 @@ public final class BillingTest {
             "ll,\"last4\":\"4444\",\"exp_month\":1,\"exp_year\":2025,\"brand\":\"Mastercard\"}}";
     private PaymentMethod paymentMethod = Constants.Http.GSON.fromJson(jsonResponse, PaymentMethod.class);
 
-    private String jsonResponseLegacyPrefixes = "{\"id\":\"cust_...\",\"object\":\"PaymentMethods\",\"primary_" +
-            "payment_method\":{\"id\":\"card_...\",\"disabled_at\":null,\"object\":null,\"na" +
-            "me\":null,\"last4\":\"4242\",\"exp_month\":1,\"exp_year\":2025,\"brand\":\"Visa\"},\"secondar" +
-            "y_payment_method\":{\"id\":\"bank_...\",\"disabled_at\":null,\"object\":null,\"name\":nu" +
-            "ll,\"last4\":\"4444\",\"exp_month\":1,\"exp_year\":2025,\"brand\":\"Mastercard\"}}";
-
-    private PaymentMethod paymentMethodLegacyPrefixes =
-            Constants.Http.GSON.fromJson(jsonResponseLegacyPrefixes, PaymentMethod.class);
-
     private static MockedStatic<Requestor> requestMock = Mockito.mockStatic(Requestor.class);
 
     /**

--- a/src/test/java/com/easypost/CarrierAccountTest.java
+++ b/src/test/java/com/easypost/CarrierAccountTest.java
@@ -2,12 +2,18 @@ package com.easypost;
 
 import com.easypost.exception.API.InvalidRequestError;
 import com.easypost.exception.EasyPostException;
+import com.easypost.http.Requestor;
 import com.easypost.model.CarrierAccount;
 import com.easypost.model.CarrierType;
+import com.easypost.model.PaymentMethod;
+import com.easypost.model.Pickup;
+import com.easypost.model.Shipment;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.List;
@@ -22,6 +28,8 @@ public final class CarrierAccountTest {
     private static String testCarrierAccountId = null;
 
     private static TestUtils.VCR vcr;
+
+    private static MockedStatic<Requestor> requestMock = Mockito.mockStatic(Requestor.class);
 
     /**
      * Set up the testing environment for this file.
@@ -38,6 +46,7 @@ public final class CarrierAccountTest {
      */
     @AfterEach
     public void cleanup() {
+        requestMock.close();
         if (testCarrierAccountId != null) {
             try {
                 CarrierAccount carrierAccount = vcr.client.carrierAccount.retrieve(testCarrierAccountId);
@@ -178,5 +187,43 @@ public final class CarrierAccountTest {
 
         assertInstanceOf(List.class, types);
         assertTrue(types.stream().allMatch(type -> type != null));
+    }
+
+    /**
+     * Test that the CarrierAccount fields are correctly deserialized from the API response.
+     * None of the demo carrier accounts used in the above tests have credentials or test credentials fields, so we need to use some mock data.
+     */
+    @Test
+    public void testCarrierFieldsJsonDeserialization() {
+        String carrierAccountJson = "[{\"id\":\"ca_123\",\"object\":\"CarrierAccount\",\"fields\":{\"credentials\":{\"account_number\":{\"visibility\":\"visible\",\"label\":\"DHL Account Number\",\"value\":\"123456\"},\"country\":{\"visibility\":\"visible\",\"label\":\"Account Country Code (2 Letter)\",\"value\":\"US\"},\"site_id\":{\"visibility\":\"visible\",\"label\":\"Site ID (Optional)\",\"value\": null },\"password\":{\"visibility\":\"password\",\"label\":\"Password (Optional)\",\"value\":\"\"},\"is_reseller\":{\"visibility\":\"checkbox\",\"label\":\"Reseller Account? (check if yes)\",\"value\":null}}}}]";
+        CarrierAccount[] carrierAccounts = Constants.Http.GSON.fromJson(carrierAccountJson, CarrierAccount[].class);
+
+        CarrierAccount carrierAccount = carrierAccounts[0];
+        assertEquals("ca_123", carrierAccount.getId());
+        assertEquals("CarrierAccount", carrierAccount.getObject());
+        assertEquals("DHL Account Number", carrierAccount.getFields().getCredentials().get("account_number").getLabel());
+    }
+
+    /**
+     * Test that the CarrierAccount fields are correctly serialized to the API request.
+     */
+    @Test
+    public void testCarrierFieldsJsonSerialization() throws EasyPostException {
+        String carrierAccountJson = "[{\"id\":\"ca_123\",\"object\":\"CarrierAccount\",\"fields\":{\"credentials\":{\"account_number\":{\"visibility\":\"visible\",\"label\":\"DHL Account Number\",\"value\":\"123456\"},\"country\":{\"visibility\":\"visible\",\"label\":\"Account Country Code (2 Letter)\",\"value\":\"US\"},\"site_id\":{\"visibility\":\"visible\",\"label\":\"Site ID (Optional)\",\"value\": null },\"password\":{\"visibility\":\"password\",\"label\":\"Password (Optional)\",\"value\":\"\"},\"is_reseller\":{\"visibility\":\"checkbox\",\"label\":\"Reseller Account? (check if yes)\",\"value\":null}}}}]";
+        CarrierAccount[] carrierAccounts = Constants.Http.GSON.fromJson(carrierAccountJson, CarrierAccount[].class);
+        CarrierAccount carrierAccount = carrierAccounts[0];
+
+        // Prepare a parameter set for creating a pickup, using the carrier account object
+        Shipment shipment = vcr.client.shipment.create(Fixtures.oneCallBuyShipment());
+        Map<String, Object> pickupData = Fixtures.basicPickup();
+        pickupData.put("shipment", shipment);
+        pickupData.put("carrier_accounts", new CarrierAccount[]{carrierAccount});
+
+        // Avoid making a real request to the API, interested in pre-request serialization, not interested in response
+        requestMock.when(() -> Requestor.request(
+                Requestor.RequestMethod.POST, "pickups", pickupData, Shipment.class, vcr.client)).thenReturn(new Pickup());
+
+        // This will throw an exception if the carrier account fields could not be serialized properly
+        assertDoesNotThrow(() -> vcr.client.pickup.create(pickupData));
     }
 }

--- a/src/test/java/com/easypost/CarrierAccountTest.java
+++ b/src/test/java/com/easypost/CarrierAccountTest.java
@@ -5,7 +5,6 @@ import com.easypost.exception.EasyPostException;
 import com.easypost.http.Requestor;
 import com.easypost.model.CarrierAccount;
 import com.easypost.model.CarrierType;
-import com.easypost.model.PaymentMethod;
 import com.easypost.model.Pickup;
 import com.easypost.model.Shipment;
 import com.google.common.collect.ImmutableMap;
@@ -191,17 +190,25 @@ public final class CarrierAccountTest {
 
     /**
      * Test that the CarrierAccount fields are correctly deserialized from the API response.
-     * None of the demo carrier accounts used in the above tests have credentials or test credentials fields, so we need to use some mock data.
+     * None of the demo carrier accounts used in the above tests have credentials or test credentials fields,
+     * so we need to use some mock data.
      */
     @Test
     public void testCarrierFieldsJsonDeserialization() {
-        String carrierAccountJson = "[{\"id\":\"ca_123\",\"object\":\"CarrierAccount\",\"fields\":{\"credentials\":{\"account_number\":{\"visibility\":\"visible\",\"label\":\"DHL Account Number\",\"value\":\"123456\"},\"country\":{\"visibility\":\"visible\",\"label\":\"Account Country Code (2 Letter)\",\"value\":\"US\"},\"site_id\":{\"visibility\":\"visible\",\"label\":\"Site ID (Optional)\",\"value\": null },\"password\":{\"visibility\":\"password\",\"label\":\"Password (Optional)\",\"value\":\"\"},\"is_reseller\":{\"visibility\":\"checkbox\",\"label\":\"Reseller Account? (check if yes)\",\"value\":null}}}}]";
+        String carrierAccountJson = "[{\"id\":\"ca_123\",\"object\":\"CarrierAccount\"," +
+                "\"fields\":{\"credentials\":{\"account_number\":{\"visibility\":\"visible\"," +
+                "\"label\":\"DHL Account Number\",\"value\":\"123456\"},\"country\":{\"visibility\":\"visible\"," +
+                "\"label\":\"Account Country Code (2 Letter)\",\"value\":\"US\"},\"site_id\":{\"visibility\":" +
+                "\"visible\",\"label\":\"Site ID (Optional)\",\"value\": null },\"password\":{\"visibility\":" +
+                "\"password\",\"label\":\"Password (Optional)\",\"value\":\"\"},\"is_reseller\":{\"visibility\":" +
+                "\"checkbox\",\"label\":\"Reseller Account? (check if yes)\",\"value\":null}}}}]";
         CarrierAccount[] carrierAccounts = Constants.Http.GSON.fromJson(carrierAccountJson, CarrierAccount[].class);
 
         CarrierAccount carrierAccount = carrierAccounts[0];
         assertEquals("ca_123", carrierAccount.getId());
         assertEquals("CarrierAccount", carrierAccount.getObject());
-        assertEquals("DHL Account Number", carrierAccount.getFields().getCredentials().get("account_number").getLabel());
+        assertEquals("DHL Account Number",
+                carrierAccount.getFields().getCredentials().get("account_number").getLabel());
     }
 
     /**
@@ -209,7 +216,13 @@ public final class CarrierAccountTest {
      */
     @Test
     public void testCarrierFieldsJsonSerialization() throws EasyPostException {
-        String carrierAccountJson = "[{\"id\":\"ca_123\",\"object\":\"CarrierAccount\",\"fields\":{\"credentials\":{\"account_number\":{\"visibility\":\"visible\",\"label\":\"DHL Account Number\",\"value\":\"123456\"},\"country\":{\"visibility\":\"visible\",\"label\":\"Account Country Code (2 Letter)\",\"value\":\"US\"},\"site_id\":{\"visibility\":\"visible\",\"label\":\"Site ID (Optional)\",\"value\": null },\"password\":{\"visibility\":\"password\",\"label\":\"Password (Optional)\",\"value\":\"\"},\"is_reseller\":{\"visibility\":\"checkbox\",\"label\":\"Reseller Account? (check if yes)\",\"value\":null}}}}]";
+        String carrierAccountJson = "[{\"id\":\"ca_123\",\"object\":\"CarrierAccount\",\"fields\":{\"credentials\":" +
+                "{\"account_number\":{\"visibility\":\"visible\",\"label\":\"DHL Account Number\"," +
+                "\"value\":\"123456\"},\"country\":{\"visibility\":\"visible\",\"label\":" +
+                "\"Account Country Code (2 Letter)\",\"value\":\"US\"},\"site_id\":{\"visibility\":\"visible\"," +
+                "\"label\":\"Site ID (Optional)\",\"value\": null },\"password\":{\"visibility\":\"password\"," +
+                "\"label\":\"Password (Optional)\",\"value\":\"\"},\"is_reseller\":{\"visibility\":\"checkbox\"," +
+                "\"label\":\"Reseller Account? (check if yes)\",\"value\":null}}}}]";
         CarrierAccount[] carrierAccounts = Constants.Http.GSON.fromJson(carrierAccountJson, CarrierAccount[].class);
         CarrierAccount carrierAccount = carrierAccounts[0];
 
@@ -217,11 +230,12 @@ public final class CarrierAccountTest {
         Shipment shipment = vcr.client.shipment.create(Fixtures.oneCallBuyShipment());
         Map<String, Object> pickupData = Fixtures.basicPickup();
         pickupData.put("shipment", shipment);
-        pickupData.put("carrier_accounts", new CarrierAccount[]{carrierAccount});
+        pickupData.put("carrier_accounts", new CarrierAccount[] { carrierAccount });
 
         // Avoid making a real request to the API, interested in pre-request serialization, not interested in response
-        requestMock.when(() -> Requestor.request(
-                Requestor.RequestMethod.POST, "pickups", pickupData, Shipment.class, vcr.client)).thenReturn(new Pickup());
+        requestMock.when(() -> Requestor.request(Requestor.RequestMethod.POST, "pickups",
+                pickupData, Shipment.class,
+                vcr.client)).thenReturn(new Pickup());
 
         // This will throw an exception if the carrier account fields could not be serialized properly
         assertDoesNotThrow(() -> vcr.client.pickup.create(pickupData));


### PR DESCRIPTION
# Description

Port of [fix in .NET library](https://github.com/EasyPost/easypost-csharp/pull/558) to Java.

Fun fact: The `Fields` object in this library previously did not have any properties declared. This means there was never any deserialization issues, but also means that each `Field` was never reachable by end-users.

# Testing

- Add unit test to confirm deserialization works as expected
  - The carrier accounts used in our existing unit tests do not have fields returned by the API, so the serialization issue was not previously caught.
  - Beyond that, the properties of `Fields` were not declared, so they were never deserialized.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
