### PR TITLE
[fix] Fire response hook before parsing API error to avoid early exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Fix bug where response hooks were not being called if an API request failed
+
 ## v7.4.0 (2024-07-24)
 
 - Add new `Claim` service for filing claims on EasyPost shipments and insurances

--- a/src/main/java/com/easypost/http/Requestor.java
+++ b/src/main/java/com/easypost/http/Requestor.java
@@ -606,14 +606,14 @@ public abstract class Requestor {
         }
         int rCode = response.getResponseCode();
         String rBody = response.getResponseBody();
-        if (rCode < HttpURLConnection.HTTP_OK || rCode >= HttpURLConnection.HTTP_MULT_CHOICE) {
-            handleAPIError(rBody, rCode);
-        }
 
         ResponseHookResponses responseHookResponses = new ResponseHookResponses(rCode, headers, method.toString(), url,
                 rBody, Instant.now().toString(), requestTimestamp.toString(), requestUuid.toString());
-
         client.getResponseHooks().executeEventHandler(responseHookResponses);
+
+        if (rCode < HttpURLConnection.HTTP_OK || rCode >= HttpURLConnection.HTTP_MULT_CHOICE) {
+            handleAPIError(rBody, rCode);
+        }
 
         return Constants.Http.GSON.fromJson(rBody, clazz);
     }

--- a/src/test/cassettes/hook/http_error.json
+++ b/src/test/cassettes/hook/http_error.json
@@ -1,0 +1,88 @@
+[
+  {
+    "recordedAt": 1721851236,
+    "request": {
+      "body": "",
+      "method": "GET",
+      "headers": {
+        "Accept-Charset": [
+          "UTF-8"
+        ],
+        "User-Agent": [
+          "REDACTED"
+        ]
+      },
+      "uri": "https://api.easypost.com/v2/parcels/par_123"
+    },
+    "response": {
+      "body": "{\n  \"error\": {\n    \"code\": \"NOT_FOUND\",\n    \"message\": \"The requested resource could not be found.\",\n    \"errors\": [\n      {\n        \"field\": \"par_123\",\n        \"message\": \"not found\"\n      }\n    ]\n  }\n}",
+      "httpVersion": null,
+      "headers": {
+        "null": [
+          "HTTP/1.1 404 Not Found"
+        ],
+        "content-length": [
+          "138"
+        ],
+        "expires": [
+          "0"
+        ],
+        "x-node": [
+          "bigweb42nuq"
+        ],
+        "x-frame-options": [
+          "SAMEORIGIN"
+        ],
+        "x-download-options": [
+          "noopen"
+        ],
+        "x-permitted-cross-domain-policies": [
+          "none"
+        ],
+        "x-backend": [
+          "easypost"
+        ],
+        "pragma": [
+          "no-cache"
+        ],
+        "strict-transport-security": [
+          "max-age\u003d31536000; includeSubDomains; preload"
+        ],
+        "x-xss-protection": [
+          "1; mode\u003dblock"
+        ],
+        "x-content-type-options": [
+          "nosniff"
+        ],
+        "x-ep-request-uuid": [
+          "f9cf1c1466a15d64f3f7e4f300198a71"
+        ],
+        "x-proxied": [
+          "intlb4nuq c0f5e722d1",
+          "extlb2nuq fa152d4755"
+        ],
+        "referrer-policy": [
+          "strict-origin-when-cross-origin"
+        ],
+        "x-runtime": [
+          "0.040646"
+        ],
+        "content-type": [
+          "application/json; charset\u003dutf-8"
+        ],
+        "x-version-label": [
+          "easypost-202407241855-6665de0674-master"
+        ],
+        "cache-control": [
+          "private, no-cache, no-store"
+        ]
+      },
+      "status": {
+        "code": 404,
+        "message": "Not Found"
+      },
+      "uri": "https://api.easypost.com/v2/parcels/par_123"
+    },
+    "duration": 585
+  }
+]

--- a/src/test/java/com/easypost/CarrierAccountTest.java
+++ b/src/test/java/com/easypost/CarrierAccountTest.java
@@ -124,10 +124,6 @@ public final class CarrierAccountTest {
     public void testCreateWithUPS() throws EasyPostException {
         vcr.setUpTest("create_with_ups");
 
-        Map<String, Object> data = new HashMap<>();
-        data.put("type", "UpsAccount");
-        data.put("account_number", "123456789");
-
         CarrierAccount upsAccount = createUpsCarrierAccount();
 
         assertInstanceOf(CarrierAccount.class, upsAccount);

--- a/src/test/java/com/easypost/HookTest.java
+++ b/src/test/java/com/easypost/HookTest.java
@@ -1,5 +1,6 @@
 package com.easypost;
 
+import com.easypost.exception.API.NotFoundError;
 import com.easypost.exception.EasyPostException;
 import com.easypost.hooks.RequestHookResponses;
 import com.easypost.hooks.ResponseHookResponses;
@@ -9,12 +10,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.function.Function;
 
 public class HookTest {
     private static TestUtils.VCR vcr;
+
+    private static boolean hookHit = false;
 
     /**
      * Set up the testing environment for this file.
@@ -63,6 +67,21 @@ public class HookTest {
         assertNotNull(data.getRequestBody());
         assertNotNull(data.getRequestTimestamp());
         assertNotNull(data.getRequestUuid());
+
+        return true;
+    }
+
+    public static Object testResponseHookOnHttpError(ResponseHookResponses data) {
+        assertEquals("https://api.easypost.com/v2/parcels/par_123", data.getPath());
+        assertEquals("GET", data.getMethod());
+        assertEquals(404, data.getHttpStatus());
+        assertNotNull(data.getHeaders());
+        assertNotNull(data.getResponseBody());
+        assertNotNull(data.getRequestTimestamp());
+        assertNotNull(data.getRequestTimestamp());
+        assertNotNull(data.getRequestUuid());
+
+        hookHit = true;
 
         return true;
     }
@@ -132,6 +151,29 @@ public class HookTest {
         vcr.client.unsubscribeFromResponseHook(failedResponseHook);
 
         vcr.client.parcel.create(Fixtures.basicParcel());
+    }
 
+    /**
+     * Test that response hooks are still fired even if the HTTP call fails.
+     *
+     * @throws EasyPostException when the request fails.
+     */
+    @Test
+    public void testResponseHookFiredOnHTTPError() throws EasyPostException {
+        vcr.setUpTest("http_error");
+
+        hookHit = false;
+
+        Function<ResponseHookResponses, Object> requestHook = HookTest::testResponseHookOnHttpError;
+
+        vcr.client.subscribeToResponseHook(requestHook);
+
+        try {
+            vcr.client.parcel.retrieve("par_123");
+        } catch (NotFoundError e) {
+            assertEquals(404, e.getStatusCode());
+        }
+
+        assertTrue(hookHit);
     }
 }

--- a/src/test/java/com/easypost/HookTest.java
+++ b/src/test/java/com/easypost/HookTest.java
@@ -71,6 +71,12 @@ public class HookTest {
         return true;
     }
 
+    /**
+     * Test subscribing a response hook when an HTTP error occurs.
+     *
+     * @param data The ResponseHookResponses object representing the hook data.
+     * @return The result of the test.
+     */
     public static Object testResponseHookOnHttpError(ResponseHookResponses data) {
         assertEquals("https://api.easypost.com/v2/parcels/par_123", data.getPath());
         assertEquals("GET", data.getMethod());


### PR DESCRIPTION
# Description

Fix an order-of-operations bug where API errors were being parsed (and potential exceptions thrown) before firing response hooks, meaning response hooks were not being triggered if an API call was unsuccessful.

Closes #321 

# Testing

- New unit test to confirm response hook gets fired even when an API error occurs.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
