### PR TITLE
fix: style make targets to pass during release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - name: Install style guide
-        run: make install-styleguide
+      - name: Install checkstyle and style guide
+        run: make install-checkstyle
       - name: Load Maven dependencies and CVE database cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,8 +44,8 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
 
-      - name: Publish to Apache Maven Central
-        run: mvn deploy
+      - name: Clean, build and publish to Apache Maven Central
+        run: make install-styleguide publish pass=${{ secrets.MAVEN_GPG_PASSPHRASE }}
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,12 @@ docs:
 	mvn install -DskipTests=true -Dgpg.skip=true -Dcheckstyle.skip=true -Ddependency-check.skip=true -Djacoco.skip=true
 	cp -R target/apidocs/ ./docs/
 
-## install-styleguide - Install style guides and CheckStyle utilities (Unix only)
-install-styleguide: | update-examples-submodule
+## install-checkstyle - Install the Checkstyle tool (Unix only)
+install-checkstyle: | install-styleguide
 	curl -LJs https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.3.1/checkstyle-10.3.1-all.jar -o checkstyle.jar
+
+## install-styleguide - Install style guides
+install-styleguide: | init-examples-submodule
 	sh examples/symlink_directory_files.sh examples/style_guides/java .
 
 ## init-examples-submodule - Initialize the examples submodule
@@ -34,7 +37,7 @@ init-examples-submodule:
 	git submodule update
 
 ## install - Install requirements
-install: | init-examples-submodule
+install: | install-checkstyle
 
 ## lint - Lints the project
 lint: checkstyle scan
@@ -70,4 +73,4 @@ update-examples-submodule:
 	git submodule init
 	git submodule update --remote
 
-.PHONY: help build clean coverage docs install-styleguide install lint publish publish-dry release scan scan-strict test update-examples-submodule
+.PHONY: help build clean coverage docs install-checkstyle install-styleguide install lint publish publish-dry release scan scan-strict test update-examples-submodule


### PR DESCRIPTION
# Description

The release failed because we weren't installing our styleguide so the process could check it. This fixes the makefile targets to allow us to use a styleguide specific one for releasing and clarifies and updates the dependencies for this on normal installs.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
