### PR TITLE
Replace extractions/setup-just with EasyPost/ep-actions setup/just action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           ['8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25']
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: actions/setup-java@v5
         with:
           distribution: 'zulu'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: actions/setup-java@v5
         with:
           distribution: 'zulu'


### PR DESCRIPTION
## What

Replaces the unverified third-party action `extractions/setup-just` with the internal composite action [`EasyPost/ep-actions/.github/actions/setup/just@main`](https://github.com/EasyPost/ep-actions/tree/main/.github/actions/setup/just).

## Why

`extractions/setup-just` is a third-party action from an unverified publisher and is **not** on the approved list in `EasyPost/ep-actions/ApprovedThirdPartyActions.yaml`. Using the internal composite action keeps CI on a vetted, EasyPost-owned action.

## Notes

- The ep-actions `setup/just` action installs Just on Linux runners; all affected jobs in this repo run on `ubuntu-latest`.
- The `just-version` input is supported by the ep-actions action where it was previously set.